### PR TITLE
Phase 2: Admin PIN / login UI (dashboard Security panel)

### DIFF
--- a/src/Helpers/index_html.h
+++ b/src/Helpers/index_html.h
@@ -479,7 +479,8 @@ R"rawhtml(
 }
 
 #wifi-connect-form input[type="text"],
-#wifi-connect-form input[type="password"] {
+#wifi-connect-form input[type="password"],
+#admin-section input[type="password"] {
   width: 100%;
   background: var(--black);
   border: 1px solid var(--dk-cyan);
@@ -490,7 +491,8 @@ R"rawhtml(
   margin-bottom: 8px;
   outline: none;
 }
-#wifi-connect-form input:focus {
+#wifi-connect-form input:focus,
+#admin-section input:focus {
   border-color: var(--cyan);
   box-shadow: 0 0 6px rgba(85,255,255,0.3);
 }
@@ -722,6 +724,23 @@ R"rawhtml(
       <div style="margin-top:6px;">
         <button class="btn-retro" onclick="connectWifi()">⚡ Connect</button>
         <button class="btn-retro btn-danger" onclick="cancelWifiConnect()">Cancel</button>
+      </div>
+    </div>
+    <div id="admin-section" style="margin-top:12px; border-top:1px dashed var(--dk-yellow); padding-top:8px;">
+      <div style="font-size:14px; color:var(--dk-yellow); margin-bottom:4px;">&#128274; Admin Access:</div>
+      <div id="admin-status" style="font-size:13px; color:var(--gray); margin-bottom:6px;">Checking&#8230;</div>
+      <div id="admin-setpin-form" style="display:none;">
+        <label style="color:var(--cyan); display:block; margin-bottom:4px; font-size:14px;">No PIN set &mdash; control actions are unprotected. Set an admin PIN (min 4 chars):</label>
+        <input type="password" id="admin-newpin" placeholder="New PIN&#8230;" autocomplete="new-password">
+        <div style="margin-top:6px;"><button class="btn-retro" onclick="adminSetPin()">&#128274; Set PIN</button></div>
+      </div>
+      <div id="admin-login-form" style="display:none;">
+        <label style="color:var(--cyan); display:block; margin-bottom:4px; font-size:14px;">Enter admin PIN to unlock control actions:</label>
+        <input type="password" id="admin-pin" placeholder="Admin PIN&#8230;" autocomplete="current-password">
+        <div style="margin-top:6px;"><button class="btn-retro" onclick="adminLogin()">&#9889; Log In</button></div>
+      </div>
+      <div id="admin-logout-form" style="display:none;">
+        <button class="btn-retro" onclick="adminLogout()">&#9099; Log Out</button>
       </div>
     </div>
     <div style="margin-top:12px; border-top:1px dashed var(--dk-cyan); padding-top:8px;">
@@ -1166,7 +1185,7 @@ function showHelp() { document.getElementById('help-modal').style.display = 'blo
 function closeHelp() { document.getElementById('help-modal').style.display = 'none'; }
 
 // ─── WIFI MODAL ───
-function showWifi() { document.getElementById('wifi-modal').style.display = 'block'; }
+function showWifi() { document.getElementById('wifi-modal').style.display = 'block'; refreshAdminStatus(); }
 function closeWifi() { document.getElementById('wifi-modal').style.display = 'none'; }
 
 function scanWifi() {
@@ -1306,6 +1325,72 @@ function factoryReset() {
   }).catch(e => termPrint(' RESET ERROR: ' + e.message, 'var(--red)'));
 }
 
+// ─── ADMIN ACCESS (PIN + session) ───
+// The control endpoints (kill / wifi / factory-reset) enforce auth server-side
+// once a PIN is set; this panel lets an operator set the PIN and log in/out.
+function refreshAdminStatus() {
+  const stat = document.getElementById('admin-status');
+  if (!stat) return;
+  const setF = document.getElementById('admin-setpin-form');
+  const logF = document.getElementById('admin-login-form');
+  const outF = document.getElementById('admin-logout-form');
+  fetch('/api/admin/status').then(r => r.json()).then(d => {
+    setF.style.display = 'none'; logF.style.display = 'none'; outF.style.display = 'none';
+    if (!d.provisioned) {
+      stat.textContent = '⚠ Unprotected — no admin PIN set.';
+      stat.style.color = 'var(--dk-red)';
+      setF.style.display = 'block';
+    } else if (d.authenticated) {
+      stat.textContent = '✓ Authenticated — control actions unlocked.';
+      stat.style.color = 'var(--green)';
+      outF.style.display = 'block';
+    } else {
+      stat.textContent = '🔒 Locked — log in to use control actions.';
+      stat.style.color = 'var(--yellow)';
+      logF.style.display = 'block';
+    }
+  }).catch(e => {
+    stat.textContent = 'Status unavailable: ' + e.message;
+    stat.style.color = 'var(--red)';
+  });
+}
+
+function adminSetPin() {
+  const pin = document.getElementById('admin-newpin').value;
+  if (pin.length < 4) { termPrint(' ADMIN: PIN must be at least 4 characters.', 'var(--red)'); return; }
+  fetch('/api/admin/set-pin', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'pin=' + encodeURIComponent(pin)
+  }).then(r => {
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    document.getElementById('admin-newpin').value = '';
+    termPrint(' ADMIN: PIN set — control actions are now protected.', 'var(--green)');
+    refreshAdminStatus();
+  }).catch(e => termPrint(' ADMIN ERROR: ' + e.message, 'var(--red)'));
+}
+
+function adminLogin() {
+  const pin = document.getElementById('admin-pin').value;
+  fetch('/api/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'pin=' + encodeURIComponent(pin)
+  }).then(r => {
+    if (r.status === 429) throw new Error('locked out — too many attempts, wait and retry');
+    if (!r.ok) throw new Error('invalid PIN');
+    document.getElementById('admin-pin').value = '';
+    termPrint(' ADMIN: Logged in.', 'var(--green)');
+    refreshAdminStatus();
+  }).catch(e => termPrint(' ADMIN: Login failed — ' + e.message, 'var(--red)'));
+}
+
+function adminLogout() {
+  fetch('/api/admin/logout', { method: 'POST' })
+    .then(() => { termPrint(' ADMIN: Logged out.', 'var(--cyan)'); refreshAdminStatus(); })
+    .catch(e => termPrint(' ADMIN ERROR: ' + e.message, 'var(--red)'));
+}
+
 // ─── 3D WIREFRAME ROTATING TESSERACT ───
 (function() {
   const canvas = document.getElementById('retro-canvas');
@@ -1437,6 +1522,7 @@ function factoryReset() {
 // ─── INIT ───
 bootSequence();
 fetchStatus();
+refreshAdminStatus();
 setInterval(fetchStatus, 3000);
 oracleInterval = setInterval(updateOracle, 12000);
 


### PR DESCRIPTION
## Phase 2 — make the admin-auth feature usable

The Phase-1 admin-auth backend (`/api/admin/status|set-pin|login|logout`) shipped with **no UI**, so the PIN/session protection was unreachable from the dashboard — meaning every device stayed in the "open" state forever. This adds the missing UI to complete the feature.

### What it does
An **"Admin Access"** section in the dashboard's control modal (`index_html.h`) that:
- Calls `/api/admin/status` on page load and when the modal opens.
- **Unprovisioned** → shows a "⚠ Unprotected" status and a **Set PIN** field (min 4 chars).
- **Provisioned + locked** → shows a **Log In** field; handles `429` lockout.
- **Authenticated** → shows a **Log Out** button.
- Logs every action to the retro terminal via the existing `termPrint()` helper.

It mirrors the existing CGA-retro styling (reuses the `.btn-retro` / input CSS and the modal/fetch patterns), so it's visually consistent and minimal in surface area.

### Verification (local)
- ✅ Host build (raw-string integrity intact)
- ✅ cppcheck gate — 0 findings
- ✅ HTTP smoke suite — **29/29** on a fresh server
- ✅ Served HTML carries the new controls; live `set-pin → status → login` flow confirmed
- ✅ ESP-IDF esp32s3 **display** build — 1,575,936 B app image (fits the 6 MB `ota_0` slot)

### Notes
- **Base:** `main` (now current with the Phase-1 work) — diff is exactly the admin-UI change, and CI runs on this PR.
- **Backend already enforces auth** (mutating endpoints return `401` when provisioned and unauthenticated); this PR only adds the UI to reach it. Per-button UI gating (graceful messaging when locked) is a small follow-up.

https://claude.ai/code/session_013VYe6XE2S7P7zw4ND3QuQ6