### PR TITLE
Phase 2: dashboard auth/OTA UI, PBX features (CDR/DND), operator docs, RTP design, load suite

### DIFF
--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -1,0 +1,215 @@
+# pocket-dial — Technical Feature Roadmap
+
+**Status:** Living document | **Last updated:** 2026-06-04 | **Scope:** Engineering / product-capability only
+
+This is a prioritized **engineering** roadmap for pocket-dial: what exists, what is
+landing now, and what is worth building next. It is grounded in the current source tree
+and the existing design docs. It deliberately stays inside the project's "fast and light"
+constraint — every proposal is sized against the ESP32/ESP32-S3 reality (static memory
+pools, no MMU/heap-compaction, peer-to-peer RTP, a single UDP listener).
+
+Cross-references:
+[ARCHITECTURE.md](ARCHITECTURE.md) ·
+[SCALING.md](SCALING.md) ·
+[THREAT_MODEL.md](THREAT_MODEL.md) ·
+[PROVISIONING.md](PROVISIONING.md) ·
+[OTA.md](OTA.md) ·
+[../ISSUES.md](../ISSUES.md) ·
+[../README.md](../README.md)
+
+> **Framing.** pocket-dial is a *signalling-only* SIP registrar/proxy: it brokers call
+> setup and never touches RTP audio (media is peer-to-peer — see [SCALING.md](SCALING.md) §1).
+> That single architectural fact decides what is cheap (anything signalling-side,
+> bounded by the pre-allocated pools) and what is expensive (anything that would put the
+> MCU in the media path — mixing, transcoding, SRTP, recording). Every priority below is
+> assigned with that line drawn.
+
+---
+
+## 1. Current capabilities (shipped, in the tree today)
+
+| Area | Capability | Where |
+|------|-----------|-------|
+| SIP signalling | RFC 3261 registrar + back-to-back call broker: `REGISTER`, `INVITE`, `ACK`, `BYE`, `CANCEL`, `OPTIONS`, and provisional/final responses (`100/180/200/404/480/486/487`) | `src/SIP/RequestsHandler.cpp`, README "Supported SIP Methods" |
+| Media | Peer-to-peer G.711 RTP; server never sees audio. `enforceG711()` rewrites SDP to `0 8 101`; `clearBody()` strips ringing SDP for strict-UA interop (Yealink) | `src/SIP/SipMessage.cpp`, README "VoIP Interoperability" |
+| Virtual extensions | `777` zero-DSP echo loopback; `999` parallel all-page/intercom with auto-answer header injection, Request-URI/To rewrite, race-to-answer + CANCEL of losers | `RequestsHandler::startPaging` / `handlePagingAnswer` |
+| Registration lease | Expiry parsing/capping (`DEFAULT/MAX_EXPIRES` 3600 s), OPTIONS keepalive ping, dead-binding sweep/prune | `parseRequestedExpires`, `sweepExpired`, `maybeSweep` |
+| Transports | Wi-Fi SoftAP (+ captive portal), W5500 / LAN8720 wired Ethernet & PoE, Guition JC3248W535 touch display (LVGL 8.3) | `main/esp_main*.cpp`, `main/drivers`, `main/ui` |
+| Onboarding | Captive-portal SoftAP, hand-rolled DNS redirect, on-screen join QR, NVS-persisted Wi-Fi mode/SSID/creds | `main/wifi/DnsServer.cpp`, `esp_main_display.cpp` |
+| Web dashboard | Select-based, thread-dispatched `HttpServer`; lock-free snapshot status API; mDNS (`pocketdial.local`, `_sip._udp`, `_http._tcp`) | `ARCHITECTURE.md` §4, `src/Helpers/HttpServer.*` |
+| Concurrency / RT safety | Core-pinned tasks (SIP vs HTTP/LVGL), outbox pattern (socket syscalls outside lock), double-buffered snapshot, **zero-heap-alloc hot path** | `ARCHITECTURE.md` §2–3 |
+| Capacity model | Compile-time pools `POCKETDIAL_MAX_CLIENTS/MAX_SESSIONS/MSG_POOL`; graceful `503` on exhaustion; Pocket/Office/Rack tiers | `src/SIP/PoolConfig.hpp`, [SCALING.md](SCALING.md) |
+| Security (signalling) | Per-source-IP token-bucket rate limit, optional CIDR allowlist, AOR input whitelist, bounded parser (header/body boundary) | `allowPacket`, `ipAllowed`, `isValidAor`, `findHeader` |
+| Security (HTTP) | Same-origin/CSRF check, 16 KB body cap, `SO_RCVTIMEO`, no wildcard CORS | `ARCHITECTURE.md` §5 |
+| Dev / debug | Desktop (Linux/Windows) host build & CI smoke harness; Yealink Action-URI test controller | `main.cpp`, `scratch/yealink_controller.py` |
+
+---
+
+## 2. In progress / just-added (Phase 1 + Phase 2)
+
+| Phase | Item | State | Reference |
+|-------|------|-------|-----------|
+| 1 | **Static memory pools** wired to compile-time macros; per-tier sizing & graceful `503` | Shipped / documented | [SCALING.md](SCALING.md), `PoolConfig.hpp` |
+| 1 | **Admin auth** — PIN + salted-iterated SHA-256 (50k rounds), server-side session, lockout, mutating-endpoint gate | Shipped (closes audit SEC-04) | [THREAT_MODEL.md](THREAT_MODEL.md) §S-1/E-1 |
+| 1 | **OTA** — dual-slot `ota_0/ota_1`, streaming `/api/ota/upload`, `mark-valid-on-healthy-boot` rollback | Shipped (unsigned; admin-gated) | [OTA.md](OTA.md) |
+| 2 | **Dashboard auth + OTA UI** (login, OTA upload/reboot surfaced in CGA UI) | Landing | README, OTA.md §3 |
+| 2 | **Operator docs** (scaling tiers, threat model, OTA runbook, provisioning spec) | Landing | this doc's cross-refs |
+| 2 | **Zero-touch provisioning** — manual-URL Yealink `.cfg` MVP design (NVS `prov` map, per-MAC token, provisioning window) | Design complete, build-ready, **no code merged** | [PROVISIONING.md](PROVISIONING.md) |
+| 2 | **RTP design exploration** | Open question — see Non-Goals §6; media-in-path features remain explicitly out of the fast-path mandate | [SCALING.md](SCALING.md) §1 |
+
+> **Note on CDR / DND:** neither a Call Detail Record store nor a Do-Not-Disturb path
+> exists in the tree today (`RequestsHandler` has no CDR ring buffer and no per-extension
+> DND state). Both are proposed below (P1) rather than reported as in-progress.
+
+> **Known cross-cutting hazard (flagged in [PROVISIONING.md](PROVISIONING.md) §3.3):** SIP
+> auth (P0 below) depends on the per-MAC secret store provisioning writes, and provisioning
+> credentials only become load-bearing once SIP digest auth verifies them. Sequence them
+> together.
+
+---
+
+## 3. Proposed feature backlog (grouped, prioritized)
+
+Priority key — **P0** = build next (highest leverage or unblocks others); **P1** = soon,
+clear value, moderate effort; **P2** = strategic / higher effort / depends on a P0–P1.
+Complexity is a t-shirt size for *signalling-side* work unless noted.
+
+### 3.1 Telephony features
+
+| Pri | Feature | Rationale (technical) | Complexity | Notes / constraints |
+|-----|---------|----------------------|------------|---------------------|
+| **P0** | **Blind transfer (REFER / `302`)** | Highest-value missing call-control primitive; pure signalling (server reissues INVITE to Refer-To target). No media path. Built on the existing session state machine. | **M** | Implement `onRefer`; validate Refer-To as an AOR (reuse `isValidAor`); generate `202 Accepted` + NOTIFY (`sipfrag`). RFC 5589/3515. |
+| **P1** | **Call hold / resume** | Re-INVITE with `a=sendonly`/`inactive` SDP. Server just relays the re-INVITE/200; phones renegotiate P2P. Cheap, expected by users. | **S** | Mostly passthrough; ensure `enforceG711()`/`clearBody()` don't corrupt hold SDP. Add a `Session::State::HELD`. |
+| **P1** | **Attended (consultative) transfer** | Natural follow-on to blind transfer; uses REFER with Replaces. Still media-free server-side. | **M** | Needs dialog/`Replaces` correlation in the session map; depends on P0 REFER landing first. |
+| **P1** | **Per-extension Do-Not-Disturb (DND)** | Small per-`SipClient` flag; `onInvite` short-circuits to `486 Busy Here`. Toggle via dashboard / star-code. Bounded, no new pool. | **S** | One bool on `SipClient`; persist optionally in NVS. Honour existing AOR/virtual-ext reservations. |
+| **P1** | **Static dial plan / routing table** | Today routing is "exact AOR match + reserved 777/999." A small compile-time/NVS map enables hunt groups, ring-all aliases, simple prefixes. | **M** | Keep it a bounded lookup table (mirror pool discipline); resolve to existing INVITE path. Reuse the `999` forking engine for ring-groups. |
+| **P1** | **Call parking / park-orbit** | Reuses the session machinery: park = move a leg to a virtual "orbit" slot (e.g. `700x`), retrieve = INVITE the orbit. No media held by server. | **M** | Costs one session slot per parked call — document against `MAX_SESSIONS`. |
+| **P2** | **BLF / presence (`SUBSCRIBE`/`NOTIFY`, dialog-info)** | Lets desk-phone busy-lamp keys reflect extension state. Server already tracks registration + session state — this exposes it over SIP events. | **L** | New subscription table (bounded pool!) + NOTIFY fan-out; watch message-pool pressure like the `999` page. Pairs well with provisioning (BLF keys are provisionable). |
+| **P2** | **Paging zones (multi-zone `999`)** | Generalize the single all-page into named zones (e.g. `981`=floor-1). Extends the proven forking path with a zone→members map. | **M** | Bounded zone table; reuses `startPaging`. Per-zone member cap to bound transient message-pool use. |
+| **P2** | **Voicemail** | **Requires media in the path** (record/playback RTP) — breaks the zero-DSP, P2P-media invariant. Only viable as an *external* SIP voicemail UA the box routes to, never on-MCU. | **XL** | Scope as "route to an external VM endpoint," not on-device storage/codec. See Non-Goals §6. |
+| **P2** | **Conferencing (mixing)** | True N-way mixing needs an RTP mixer (DSP + media bandwidth) the MCU does not have. | **XL (off-device)** | Only as a relay to an external mixer; on-MCU mixing is a non-goal (§6). |
+
+### 3.2 Platform / reliability
+
+| Pri | Feature | Rationale (technical) | Complexity | Notes |
+|-----|---------|----------------------|------------|-------|
+| **P0** | **Config import/export (backup/restore)** | Single most-requested ops primitive once admin-auth + provisioning exist: snapshot Wi-Fi mode, dial plan, provisioning map (secrets redacted/encrypted) to a JSON blob; restore on a replacement unit. De-risks every other config feature. | **M** | Admin-gated `GET /api/config/export` + `POST /api/config/import`; reuse same-origin + session gate; never export raw secrets unless flash-encrypted. |
+| **P1** | **Watchdog / health & self-heal** | Task-level watchdog + heap/stack high-water reporting; auto-recover a wedged task. Directly protects the RT guarantees in [ARCHITECTURE.md](ARCHITECTURE.md) §2. | **S–M** | Use IDF Task WDT; surface health on `/api/status`; ties into OTA `mark-valid` health gate. |
+| **P1** | **Metrics endpoint (Prometheus-style text / SNMP-ish)** | Already counting `packetsProcessed/Dropped`, client/session counts, pool headroom. Expose them in a scrape-friendly format for monitoring/alerting. | **S** | Read-only `/metrics`; reuse the lock-free snapshot — no new locking. |
+| **P1** | **Syslog (RFC 5424 over UDP)** | The `_logQueue` already buffers logs under lock and flushes outside it; tee it to a remote syslog collector for fleets without a serial console. | **S** | One UDP socket; bounded queue; drop-on-full (never block the RT path). |
+| **P2** | **Multi-AP / mesh / roaming** | Extends coverage beyond one SoftAP's ~16-station cap (the real Pocket-tier ceiling, [SCALING.md](SCALING.md) §5). Significant networking work; clients re-REGISTER on roam. | **L** | Likely ESP-NOW/ESP-WIFI-MESH or a wired-backbone-of-APs model; keep one logical registrar. Honest: large, and changes the trust boundary. |
+| **P2** | **NVS schema versioning / migration** | As config grows (provisioning, dial plan, DND), a versioned NVS schema avoids brittle ad-hoc keys and supports config import/export across firmware versions. | **M** | Pairs with P0 config export; define a `schema_ver` key + migration steps. |
+
+### 3.3 Security (cross-ref [THREAT_MODEL.md](THREAT_MODEL.md))
+
+| Pri | Feature | Rationale (technical) | Complexity | Threat-model link |
+|-----|---------|----------------------|------------|-------------------|
+| **P0** | **WPA2 on the SoftAP** (`WIFI_AUTH_WPA2_PSK`) | The single highest-leverage hardening in the whole project: encrypts the *entire* link in one change — dashboard HTTP, SIP signalling, **and** RTP — and gates association so "anyone in range is a peer" stops being the baseline. Closes I-1, I-2, and the cookie-replay vector. | **S** | [THREAT_MODEL.md](THREAT_MODEL.md) §6, §7 P0 (the doc's own top pick) |
+| **P0/P1** | **SIP digest auth** (`REGISTER`/`INVITE` challenge) | Stops extension spoofing (S-3) and BYE-based teardown (D-2) *even on a trusted link*. Read-only credential-lookup callback into `RequestsHandler` (no new lock); reuses provisioning's per-MAC secret store as the source of truth. | **M** | [THREAT_MODEL.md](THREAT_MODEL.md) §7 P1; seam designed in [PROVISIONING.md](PROVISIONING.md) §7.3 |
+| **P1** | **Per-IP brute-force tracking on `login`** | Replaces the global in-process lockout counter (removes the admin-lockout self-DoS, D-3). | **S** | [THREAT_MODEL.md](THREAT_MODEL.md) §5.2, §7 P1 |
+| **P1** | **Sign + gate OTA to local link; session-bind OTA** | OTA images are unsigned today; gate strictly to local link + admin session until signing lands. | **S** (interim) | [OTA.md](OTA.md) §6, [THREAT_MODEL.md](THREAT_MODEL.md) T-5 |
+| **P2** | **Secure Boot v2 + flash encryption + signed OTA** | Durable fix for physical/supply-chain boundary: signs firmware (T-5/T-1), encrypts NVS at rest (Wi-Fi pw + admin hash + provisioning secrets, I-3/I-5/T-4). One-way eFuse burn → needs a secured factory flow. | **L** | [THREAT_MODEL.md](THREAT_MODEL.md) §7 P2, [OTA.md](OTA.md) §6 |
+| **P2** | **Optional self-signed HTTPS for dashboard** | Documented add-on *on top of* WPA2 only. Browser-warning UX is bad on a LAN appliance and TLS handshakes cost MCU RAM/CPU; not the primary control. | **M** | [THREAT_MODEL.md](THREAT_MODEL.md) §6 (answered "not as primary") |
+| **P2** | **SRTP for media** | App-layer media encryption. Heavyweight on the MCU and key-management UX; WPA2 already encrypts media at the link layer for far less. Low priority given the P2P/no-DSP model. | **L** | [THREAT_MODEL.md](THREAT_MODEL.md) I-1 |
+
+### 3.4 Developer / ops experience (cross-ref [../ISSUES.md](../ISSUES.md))
+
+| Pri | Feature | Rationale (technical) | Complexity | Issue |
+|-----|---------|----------------------|------------|-------|
+| **P1** | **Zero-touch provisioning MVP** (manual-URL Yealink `.cfg`) | Build-ready design exists; turns "type a SIP account into every phone" into "paste one URL." Forces G.711/NAT-off/expiry that the engine already assumes. No hot-path or network-stack change. | **M** | #35 / [PROVISIONING.md](PROVISIONING.md) |
+| **P1** | **Live SIP tracer (WebSocket)** | Stream SIP signalling to the CRT dashboard for field debugging without a laptop + Wireshark. High diagnostic value. | **M** | #32 |
+| **P1** | **PCAP export endpoint** (`/api/diagnostics/pcap`) | Dump a bounded ring buffer of recent SIP packets as PCAP for offline Wireshark analysis. | **S–M** | #33 |
+| **P1** | **Provisioning dashboard editor** (MAC→ext map, window toggle, capacity meter vs `MAX_CLIENTS`) | The v3 UI for provisioning; surfaces headroom and the per-MAC token regen. | **M** | [PROVISIONING.md](PROVISIONING.md) §6 v3 |
+| **P2** | **DHCP Option 66 true zero-touch** (fork bundled `dhcpserver`) | Removes the typed URL entirely. IDF-version-sensitive fork; documented as a maintained patch. | **M–L** | [PROVISIONING.md](PROVISIONING.md) §1.1, §6 v2 |
+| **P2** | **Multi-vendor provisioning** (Grandstream/Polycom/Cisco renderers) | Extends MVP beyond Yealink; mostly static format strings (~2–4 KB `.text`). | **M** | [PROVISIONING.md](PROVISIONING.md) §2.5–2.6 |
+| **P2** | **Arduino-IDE build-guard verification** | Confirm `ESP32/ARDUINO/ESP_PLATFORM` macro paths for hobbyist flashing. | **S** | #41 |
+| **P2** | **End-to-end hardware validation sweep** (display redraw vs SIP tick latency) | Gate on physical hardware re-connection; verify LVGL redraw doesn't starve the RT loop. | **S** (test) | #44 |
+
+---
+
+## 4. Suggested sequencing (dependency-aware)
+
+The ordering optimizes for **leverage** (one change closing many gaps) and **unblocking**
+(security/provisioning are mutually dependent). Each "iteration" is a coherent shippable
+slice, not a fixed time box.
+
+```
+Iteration A  ── Security foundation (highest leverage)
+  P0  WPA2 SoftAP .................. encrypts dashboard+SIP+RTP in one move; gates association
+  P0  Config import/export ......... de-risks every later config feature; pairs w/ NVS versioning
+  P1  Per-IP login lockout ......... small; removes admin self-DoS; ride alongside WPA2
+
+Iteration B  ── Trusted endpoints (provisioning ⇄ SIP auth, sequenced together)
+  P1  Provisioning MVP (Yealink) ... writes per-MAC secret store (PROVISIONING.md)
+  P0  SIP digest auth .............. *consumes* that secret store; only now is the secret load-bearing
+      └─ DEPENDS ON provisioning's credential store + the OPEN→closed registrar flip
+
+Iteration C  ── Core call control (pure signalling, builds on session machine)
+  P0  Blind transfer (REFER) ....... unblocks attended transfer
+  P1  Call hold/resume ............. near-passthrough; ship with transfer
+  P1  Attended transfer ............ DEPENDS ON REFER (Iteration C step 1)
+  P1  Per-extension DND ............ tiny; ride along
+
+Iteration D  ── Observability & ops
+  P1  Watchdog/health, /metrics, syslog ... reuse existing snapshot + log queue (no new locks)
+  P1  Live SIP tracer (WS) + PCAP export ... field debugging; #32/#33
+  P2  Provisioning dashboard editor ........ UI on top of Iteration B
+
+Iteration E+ ── Bigger bets
+  P1  Dial plan / hunt groups (reuse 999 forking) · Call parking
+  P2  BLF/presence · paging zones · DHCP Opt-66 · multi-vendor provisioning
+  P2  Secure Boot v2 + flash encryption + signed OTA  (durable physical/supply-chain fix)
+  P2  Multi-AP/mesh · optional HTTPS · SRTP
+```
+
+**Why this order:**
+- **WPA2 first** because it is the cheapest change with the broadest security payoff
+  ([THREAT_MODEL.md](THREAT_MODEL.md) §6) — it retires the dominant open-AP boundary that
+  makes nearly every other threat worse, and it does so without per-device certs or MCU TLS cost.
+- **Provisioning before/with SIP auth** because they are two halves of one feature: digest
+  auth needs a password store, and a provisioned password is meaningless until something
+  verifies it ([PROVISIONING.md](PROVISIONING.md) §7.3). Shipping auth without provisioning
+  means hand-typing secrets; shipping provisioning without auth means configuring a password
+  nothing checks.
+- **Config export early** so that as dial plan / DND / provisioning state accrues, operators
+  can back up and migrate units — and so NVS schema versioning is designed in, not retrofitted.
+- **Transfer/hold/attended** as a block because they share the session state machine and are
+  all media-free server-side (cheap, on-mandate). Attended transfer strictly depends on REFER.
+- **Observability** rides existing infrastructure (snapshot, `_logQueue`, atomic counters) so
+  it adds no new locking on the RT path.
+
+---
+
+## 5. Explicitly out of scope / non-goals (technical only)
+
+These are ruled out *for technical reasons* — they conflict with the zero-DSP, peer-to-peer-media,
+static-pool architecture, not for any other reason.
+
+| Non-goal | Why (technical) |
+|----------|-----------------|
+| **On-MCU media mixing / conferencing** | Requires an RTP mixer (CPU + media bandwidth + buffers) the MCU cannot afford while running SIP + LVGL. Breaks the "server never touches RTP" invariant ([SCALING.md](SCALING.md) §1). Only viable as a relay to an *external* mixer. |
+| **On-device voicemail (record/playback)** | Same reason: media must traverse and be stored/transcoded on the device. Scope only as routing to an external SIP voicemail UA. |
+| **On-MCU transcoding** | No DSP budget. The engine deliberately *rewrites SDP to G.711 (`0 8 101`)* and forces phones via provisioning rather than transcoding; that is the design, not a gap. |
+| **Wideband / Opus / G.722 media negotiation** | The interop strategy is to *lock* to G.711; supporting wideband would reintroduce the codec-mismatch failures `enforceG711()` exists to prevent. |
+| **TLS as the primary transport security** | On a LAN appliance, self-signed certs trigger browser warnings, cost MCU RAM/CPU, and only protect the dashboard (not SIP/RTP). WPA2 is the better lever ([THREAT_MODEL.md](THREAT_MODEL.md) §6). HTTPS is a documented *optional add-on* only. |
+| **WAN / Internet exposure, NAT traversal (STUN/ICE/TURN)** | pocket-dial is a single-L2-segment appliance; media is P2P on one subnet. NAT traversal adds latency and failure modes for a scenario the product does not target ([PROVISIONING.md](PROVISIONING.md) §2.3). |
+| **Cloud control plane / remote management** | The device is intentionally self-contained with no cloud dependency; control is local-only (see threat model trust boundaries). |
+| **Unbounded dynamic allocation for "scale"** | Capacity is set by static pools by design; "scale up" means picking a tier (or a wired board), not removing the pre-allocation that guarantees a fragmentation-free hot path ([SCALING.md](SCALING.md) §5). |
+| **DHCP Option 43 multi-vendor provisioning** | Brittle per-vendor TLV encoding; rejected in favor of an Option-66 `dhcpserver` fork ([PROVISIONING.md](PROVISIONING.md) §1.1). |
+
+---
+
+## 6. Top 3 P0 recommendations (next-up)
+
+1. **WPA2 on the SoftAP** — one small change encrypts the whole link (dashboard + SIP +
+   RTP) and gates association, retiring the dominant open-AP boundary that amplifies every
+   other threat. Highest leverage-per-effort in the codebase.
+2. **SIP digest auth** (sequenced with the **provisioning MVP** that supplies the credential
+   store) — closes extension-spoofing and BYE-teardown on the signalling layer; the two are
+   interdependent halves of one capability and must land together.
+3. **Blind transfer (REFER)** — the highest-value missing call-control primitive, pure
+   signalling, built on the existing session state machine, and the prerequisite for attended
+   transfer.
+
+(Config import/export is the strongest P0 *platform* item and the natural fourth, de-risking
+all later config growth.)

--- a/docs/HARDWARE_SELECTION.md
+++ b/docs/HARDWARE_SELECTION.md
@@ -1,0 +1,151 @@
+# Hardware Selection Guide
+
+How to choose a board for **pocket-dial**. This guide maps the supported targets to
+connectivity, display, memory, and realistic capacity so you can pick the right one for
+your deployment. All specifications are drawn from [HARDWARE.md](HARDWARE.md) (pinouts,
+BOM, wiring) and [SCALING.md](SCALING.md) (capacity tiers); read those for the full
+detail.
+
+> pocket-dial is a **signaling-only** SIP server: RTP audio flows peer-to-peer between
+> phones and never touches the board, so capacity is bound almost entirely by RAM
+> reserved for the connection pools — not CPU or bandwidth (see
+> [SCALING.md](SCALING.md) §1). The board you pick mostly determines your *network tier*
+> (how many phones can associate) and whether you get a screen.
+
+---
+
+## 1. Comparison table
+
+| Board | Connectivity | Display | SoC / PSRAM | Flash | SCALING tier | Realistic capacity |
+| :--- | :--- | :---: | :--- | :--- | :--- | :--- |
+| **Generic ESP32 / ESP32-S3 dev board** | Wi-Fi SoftAP (open) | No | ESP32 or ESP32-S3 (PSRAM optional) | varies | **Pocket** (defaults 32/8/32, ~37 KB) | 6–8 calls, ~16 phones (SoftAP-limited) |
+| **Guition JC3248W535** | Wi-Fi SoftAP + captive portal | **Yes** — 3.5" 320×480 IPS capacitive touch (AXS15231B, QSPI) | ESP32-S3R8, **8 MB Octal PSRAM** | 16 MB QSPI | **Office** (64/24/64, ~90 KB) | ~24 calls, 50+ phones |
+| **Waveshare ESP32-S3-ETH (W5500, PoE)** | **Wired Ethernet + PoE** (W5500 SPI) | No | ESP32-S3R8 | — | **Rack** (128/48/128, ~180 KB) | ~48 calls, 100+ phones |
+| **LilyGO T-ETH-Lite (W5500)** | **Wired Ethernet** (W5500 SPI) | No | ESP32-S3, 8 MB PSRAM | 16 MB + SD/TF slot | **Rack** | ~48 calls, 100+ phones |
+| **LilyGO T-POE-Pro (LAN8720)** | **Wired Ethernet + PoE** (LAN8720 RMII, internal MAC) | No | ESP32-WROVER-E | — | **Rack** | ~48 calls, 100+ phones |
+
+Notes:
+
+- "Display" means a native on-device LVGL UI (status, scrolling SIP log, captive portal
+  QR). All boards still serve the full HTTP dashboard over the network regardless of
+  whether they have a screen.
+- The SCALING tier sets the **compile-time** pool caps. All targets build the same
+  firmware; only the `POCKETDIAL_MAX_*` macros differ. The defaults (Pocket) ship unless
+  you pass the tier's `-D` flags — see [SCALING.md §3](SCALING.md) for the exact build
+  commands.
+- "Realistic capacity" folds in network-layer ceilings, not just `MAX_SESSIONS`: on a
+  Wi-Fi SoftAP node the **station-association cap bites first**; on a wired node the
+  session pool is the limit.
+
+---
+
+## 2. Connectivity in depth
+
+### Wi-Fi SoftAP (generic ESP32 / ESP32-S3, Guition display)
+
+- The board hosts its own **open** access point `esp32-sipserver` on channel 1 with an
+  internal DHCP server; the registrar binds `192.168.4.1:5060`
+  (`main/esp_main.cpp`, [HARDWARE.md §6](HARDWARE.md)).
+- The SoftAP is configured for **10 associated stations** (`EXAMPLE_MAX_STA_CONN = 10`),
+  and the ESP-IDF Wi-Fi driver hard-caps associations at roughly **10–16** regardless of
+  how large you set the client pool ([SCALING.md §5](SCALING.md)). This is why the
+  Pocket tier stays near the defaults — extra client slots on a SoftAP are wasted RAM.
+- Best for: self-contained pop-up intercoms, classrooms, small offices, or any place
+  with no existing network. No router required.
+
+### Wired Ethernet / PoE (Waveshare W5500, LilyGO T-ETH-Lite W5500, LilyGO T-POE-Pro LAN8720)
+
+- The board is a node on your wired LAN, obtaining an address via DHCP with static
+  fallback. There is **no station-association ceiling**, so the SIP session pool — not
+  the network — becomes the limit, which is why high client counts belong on a wired
+  board (Rack tier).
+- **W5500** boards use an external Wiznet MAC/PHY over SPI; **LAN8720** boards use the
+  ESP32's internal Ethernet MAC over RMII. See [HARDWARE.md §3–5](HARDWARE.md) for exact
+  pinouts and bus speeds (W5500 default 36 MHz, supports up to 80 MHz).
+- **PoE** is available on the Waveshare ESP32-S3-ETH and the LilyGO T-POE-Pro (a single
+  RJ45 carries both data and power). The LilyGO T-ETH-Lite is W5500 wired Ethernet
+  without onboard PoE.
+- Best for: permanent installs, racks, deployments with more than ~16 phones, or where
+  you want power and data on one cable.
+
+---
+
+## 3. Display: yes or no
+
+Only the **Guition JC3248W535** has a screen — a 3.5" 320×480 IPS capacitive touch panel
+driven by the AXS15231B controller over QSPI, with a battery-voltage ADC on GPIO 5
+([HARDWARE.md §2](HARDWARE.md)). It runs the native LVGL CGA-style switchboard UI and
+shows the captive-portal join QR code on first boot.
+
+- The display build allocates **two 307.2 KB 16-bit frame buffers** (320 × 480 × 2 bytes)
+  in PSRAM, which is why this board needs the **8 MB Octal PSRAM** part. The SIP pools
+  themselves stay in fast internal SRAM ([SCALING.md §3 PSRAM note](SCALING.md)).
+- Every other board is **headless** but fully usable via the HTTP dashboard from any
+  browser on the network.
+
+---
+
+## 4. PSRAM and memory
+
+- **Generic ESP32/ESP32-S3**: PSRAM is optional. The Pocket tier's ~37 KB of pools fits
+  comfortably in the ~290–320 KB of usable internal DRAM on a plain ESP32.
+- **Guition / S3 boards**: PSRAM is present (8 MB) but, except on the display build where
+  it holds the LVGL frame buffers, it is **not** required for the SIP pools — keeping SIP
+  state in internal SRAM avoids PSRAM access latency on the signaling path
+  ([SCALING.md §3](SCALING.md)).
+- Do **not** naively 10× the pool macros: ~370 KB of pools exceeds a plain ESP32's
+  internal DRAM and will fail to boot or starve the Wi-Fi stack. Scale clients/sessions to
+  your *network tier*, keep the message pool ≈ the client count, and watch the dashboard
+  headroom counters ([SCALING.md §5](SCALING.md)).
+
+---
+
+## 5. Power and wiring notes
+
+From [HARDWARE.md §8](HARDWARE.md):
+
+- **Touch I2C pull-ups (Guition display):** ensure **4.7 kΩ pull-ups** on `TOUCH_SDA`
+  (GPIO 4) and `TOUCH_SCL` (GPIO 8) to 3.3 V. Many JC3248W535 clones omit these, causing
+  I2C timeouts and panel-init crashes.
+- **High-frequency SPI Ethernet routing (W5500 boards):** keep SPI traces **shorter than
+  5 cm**, bundle ground alongside `SCK`/`MOSI`, and expect crosstalk on a 36 MHz clock if
+  lines are loosely jumpered on a breadboard.
+- **PoE:** the Waveshare ESP32-S3-ETH and LilyGO T-POE-Pro accept power over the RJ45;
+  the LilyGO T-ETH-Lite and Wi-Fi boards are USB-C powered.
+- **Backlight (Guition display):** `TFT_BL` is on GPIO 1, active-high (high = backlight on).
+
+> [!NOTE]
+> For exact GPIO maps, bus assignments, and the BOM, see [HARDWARE.md](HARDWARE.md). This
+> guide intentionally summarizes; that document is the source of truth for pinouts.
+
+---
+
+## 6. Pick X if you need Y
+
+| If you need… | Pick |
+| :--- | :--- |
+| The cheapest, simplest standalone box; no existing network | **Generic ESP32 / ESP32-S3** (Wi-Fi SoftAP, Pocket tier) |
+| A local screen, touch UI, and on-device status display | **Guition JC3248W535** (Office tier) |
+| More than ~16 phones, or a permanent rack install | A **wired Ethernet** board (Rack tier) |
+| Power and data on a single cable | **Waveshare ESP32-S3-ETH** or **LilyGO T-POE-Pro** (PoE) |
+| Wired Ethernet on an S3 with PSRAM + SD slot, no PoE | **LilyGO T-ETH-Lite (W5500)** |
+| Maximum concurrent calls (~48) | Any **Rack-tier** wired board, built with the Rack `-D` flags |
+| A throwaway / pop-up intercom you can carry | **Generic ESP32** SoftAP node |
+
+---
+
+## 7. Build target reminder
+
+Each transport is selected at build time via `SIP_TRANSPORT` (and the optional tier
+macros). See [README.md §Building](../README.md#building) and [SCALING.md §3](SCALING.md)
+for the exact commands. In short:
+
+- Wi-Fi SoftAP: default build (`idf.py build`).
+- Touch display: `idf.py -D SIP_TRANSPORT=display build`.
+- Wired Ethernet / PoE: `idf.py -D SIP_TRANSPORT=eth build`.
+
+To raise the capacity tier, append the `-DCMAKE_CXX_FLAGS="-DPOCKETDIAL_MAX_CLIENTS=…"`
+flags from [SCALING.md §3](SCALING.md).
+
+**Related:** [SETUP_GUIDE.md](SETUP_GUIDE.md) · [PHONE_COMPATIBILITY.md](PHONE_COMPATIBILITY.md) ·
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md)

--- a/docs/PHONE_COMPATIBILITY.md
+++ b/docs/PHONE_COMPATIBILITY.md
@@ -1,0 +1,158 @@
+# Phone Compatibility & Registration
+
+How to register SIP clients — softphones and hardware IP phones — against **pocket-dial**.
+Every client uses the same core settings; this document gives per-client field mappings,
+documents known interoperability quirks, and provides a "tested configuration" table you
+can fill in for your own fleet.
+
+For the end-to-end first call, see [SETUP_GUIDE.md](SETUP_GUIDE.md). For board choice, see
+[HARDWARE_SELECTION.md](HARDWARE_SELECTION.md).
+
+---
+
+## 1. Universal settings (every client)
+
+| Field | Value |
+| :--- | :--- |
+| SIP server / registrar / domain / proxy | `192.168.4.1` (SoftAP) — or the device's LAN IP on wired builds; `pocketdial.local` where mDNS resolves |
+| Port | `5060` |
+| Transport | **UDP only** — the engine does not speak TCP or TLS |
+| Username / Auth ID / extension | your choice, e.g. `1001` (avoid `777` and `999`) |
+| Password | any value or blank — there is **no SIP digest auth today** (see [THREAT_MODEL.md](THREAT_MODEL.md) S-3) |
+| Audio codec | **G.711 only**: µ-law (PCMU, payload `0`) and a-law (PCMA, payload `8`); DTMF telephone-event is payload `101` |
+| Registration expiry | ≤ `3600` s (the registrar caps higher values to 3600) |
+| NAT / STUN / ICE / rport | **off** — media is peer-to-peer on one L2 segment; NAT traversal only adds latency and failure modes |
+
+> [!IMPORTANT]
+> **Codec is the single most important setting.** pocket-dial does not transcode; it
+> rewrites every answer SDP to `0 8 101` via `SipMessage::enforceG711()`. If a phone is
+> left on Opus/G.722/G.729-only, the rewritten answer advertises payloads the phone never
+> offered and the call has **no common codec** → no audio. **Disable every codec except
+> G.711 µ-law and a-law** on each client.
+
+> [!NOTE]
+> **Reserved extensions:** `777` (echo test) and `999` (all-page broadcast) are virtual
+> extensions handled by the server. Never assign them to a real phone.
+
+---
+
+## 2. Softphones
+
+### Linphone (desktop / mobile)
+
+1. Settings → Account → add a SIP account manually.
+2. SIP address: `sip:1001@192.168.4.1`.
+3. SIP proxy / transport: `192.168.4.1:5060`, **UDP**.
+4. Disable "outbound proxy" and any ICE/STUN/TURN under network settings.
+5. Audio codecs: enable **PCMU** and **PCMA**, disable Opus/G.722/speex.
+
+### Zoiper
+
+1. Add account → manual configuration → SIP.
+2. Domain / host: `192.168.4.1`, username `1001`, transport **UDP**.
+3. Under Codecs, keep only **G.711 u-law / a-law**.
+4. Disable STUN/rport in network settings.
+
+### MicroSIP (Windows)
+
+1. Menu → Add Account.
+2. SIP server: `192.168.4.1`, Username `1001`, Domain `192.168.4.1`, transport **UDP**.
+3. Codecs: select **PCMU** and **PCMA** only.
+
+### Groundwire / Acrobits
+
+1. Add SIP account (generic SIP).
+2. Server `192.168.4.1`, port `5060`, username `1001`, transport **UDP**.
+3. In advanced/codec settings, restrict to **G.711**; turn ICE/STUN **off**.
+
+---
+
+## 3. Hardware IP phones
+
+Hardware desk phones can be configured manually through their web UI (server, port,
+codec, transport as above). Note that automated zero-touch HTTP provisioning is a
+**design specification only — not yet implemented** (see
+[PROVISIONING.md](PROVISIONING.md), which is marked "No code merged yet"). Configure
+hardware phones manually for now.
+
+### Yealink (e.g. T2x / T4x series)
+
+- Account → Register: Server Host `192.168.4.1`, Port `5060`, Transport **UDP**,
+  Register Name / User Name `1001`.
+- Codec: move only **PCMU** and **PCMA** to the enabled list; remove Opus/G.722/G.729.
+- NAT: set NAT Traversal = Disabled, rport = Disabled, STUN = Disabled.
+
+> [!IMPORTANT]
+> **180 Ringing SDP strip (Yealink quirk, handled server-side).** Strict professional
+> terminals like Yealink can hang on ringing or loop on early media when a provisional
+> response carries SDP. pocket-dial **strips the SDP body from every `180 Ringing`** it
+> forwards (`ringing->clearBody()` — the body is removed and `Content-Length` rewritten),
+> which resolves the ringing hang on Yealink phones. This is automatic; you do not need to
+> configure anything (README "VoIP Interoperability & SDP Stripping").
+
+### Grandstream (e.g. GXP / GRP series)
+
+- Account → General: SIP Server `192.168.4.1`, SIP Transport **UDP**, SIP User ID `1001`,
+  Authenticate ID `1001`.
+- Audio codecs: preferred vocoder list = **PCMU** then **PCMA** only; clear the rest.
+- Disable STUN and "Use NAT IP".
+
+### Cisco (SPA / MPP series)
+
+- Ext 1 → Proxy and Registration: Proxy `192.168.4.1`, Transport **UDP**.
+- Subscriber Information: User ID `1001`.
+- Audio Configuration: preferred codec **G711u** / **G711a**; disable others; turn off
+  ICE/STUN.
+
+### Polycom / Poly
+
+- Configure the SIP registrar address `192.168.4.1:5060`, transport **UDPOnly**, line
+  address/auth user `1001`.
+- Codec preferences: enable **G711_Mu** and **G711_A**, disable G722/Opus.
+
+---
+
+## 4. Behavior to expect after registration
+
+- The registrar pings each client with a SIP `OPTIONS` keepalive **every 5 seconds** and
+  prunes a client after **~15 seconds** of silence (`RequestsHandler.cpp`). Leave each
+  phone's "answer OPTIONS / keep-alive" behavior at its default (on).
+- A registered extension appears in the `clients` array of
+  [`GET /api/status`](API.md#get-apistatus); an active call appears in `sessions`.
+- If the client pool is full, a new REGISTER may receive `503 Service Unavailable`; the
+  phone retries on its next refresh ([SCALING.md §4](SCALING.md)).
+- Call audio (RTP) flows **directly phone-to-phone**, not through the device.
+
+---
+
+## 5. Quick verification per client
+
+1. Register the client; confirm it shows "registered".
+2. Confirm the extension appears on the dashboard (`/api/status` → `clients`).
+3. Dial **`777`** — you should hear your own voice (echo). Confirms RTP + codec.
+4. With a second extension registered, dial it directly — confirm two-way audio.
+5. Dial **`999`** — confirm other registered phones are paged.
+
+If any step fails, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) (registration timeouts,
+one-way/no audio, call drops).
+
+---
+
+## 6. Tested configuration table (fill in for your fleet)
+
+Record what you have actually validated against your build. The settings below are the
+known-good baseline; mark Pass/Fail and note firmware versions.
+
+| Client | Type | Firmware/Version | Server:Port | Transport | Extension | Codecs enabled | 777 echo | 999 page | Direct call | Notes |
+| :--- | :--- | :--- | :--- | :---: | :--- | :--- | :---: | :---: | :---: | :--- |
+| Linphone | Softphone | | `192.168.4.1:5060` | UDP | | PCMU, PCMA | | | | |
+| Zoiper | Softphone | | `192.168.4.1:5060` | UDP | | PCMU, PCMA | | | | |
+| MicroSIP | Softphone | | `192.168.4.1:5060` | UDP | | PCMU, PCMA | | | | |
+| Groundwire | Softphone | | `192.168.4.1:5060` | UDP | | PCMU, PCMA | | | | |
+| Yealink | IP phone | | `192.168.4.1:5060` | UDP | | PCMU, PCMA | | | | 180-Ringing SDP stripped server-side |
+| Grandstream | IP phone | | `192.168.4.1:5060` | UDP | | PCMU, PCMA | | | | |
+| Cisco | IP phone | | `192.168.4.1:5060` | UDP | | G711u, G711a | | | | |
+| Polycom/Poly | IP phone | | `192.168.4.1:5060` | UDP | | G711_Mu, G711_A | | | | UDPOnly transport |
+
+**Related:** [SETUP_GUIDE.md](SETUP_GUIDE.md) · [HARDWARE_SELECTION.md](HARDWARE_SELECTION.md) ·
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md) · [API.md](API.md)

--- a/docs/RTP.md
+++ b/docs/RTP.md
@@ -1,0 +1,410 @@
+# Server-Side RTP on Pocket-Dial: Design Exploration
+
+> **Status:** Proposed / exploration. No code written yet.
+> **Audience:** A future engineer who will implement the recommended phase.
+> **Scope:** What it would take to move RTP media *through* the device, what it
+> buys us, what it costs on an ESP32-S3, and a phased path that stays "fast and light".
+
+---
+
+## 0. TL;DR (read this first)
+
+* **Today the server touches zero media.** SIP signalling (REGISTER / INVITE /
+  OK / BYE / the 777 echo and 999 all-page) flows through `RequestsHandler`, but
+  the actual G.711 audio streams **peer-to-peer (P2P)** between phones. The
+  server only rewrites/forwards SDP-bearing SIP messages; it never opens an RTP
+  socket. See `docs/ARCHITECTURE.md` and the `m=audio` / `enforceG711()` path in
+  `src/SIP/SipMessage.cpp` and `src/SIP/SipSdpMessage.cpp`.
+* **Recommended first phase: Music-on-Hold (MoH) player + RTP statistics.** It is
+  the lightest server-side RTP feature with the highest value-to-risk ratio. It
+  is a *transmit-mostly, single-direction* path that does not require a jitter
+  buffer or a mixer, and it proves out the RTP socket / packetiser / SDP-rewrite
+  plumbing that every later phase reuses.
+* **Realistic concurrent-stream ceiling on this hardware:** roughly
+  **4–6 relayed two-party calls (8–12 RTP streams)** on an S3 at 240 MHz with
+  Wi-Fi, *if* media handling is isolated on the otherwise-idle core (headless/
+  Ethernet builds) and packets bypass the SIP `_mutex`. **Conference mixing (999)
+  realistically caps at ~6–8 mixed participants** before the 20 ms deadline gets
+  tight. On a **display build the practical ceiling is ~half that**, because
+  Core 1 is reserved for LVGL.
+* **Single biggest risk:** **Wi-Fi half-duplex / airtime contention**, not CPU.
+  Relaying doubles every media packet (one in, one out) over a shared half-duplex
+  radio that is already carrying SIP, HTTP dashboard polling, and (on display
+  boards) nothing-to-spare. RTP is real-time and unforgiving: a few hundred ms of
+  added queueing delay or a burst of loss turns into audible glitches, and there
+  is no retransmit for UDP media.
+
+---
+
+## 1. Why P2P today, and what RTP-through-server would unlock
+
+### 1.1 Why media is peer-to-peer today
+
+The device is a **registrar + proxy/redirect-ish B2B-light signalling box**. When
+A calls B:
+
+1. A's INVITE (with SDP offering `m=audio <portA> RTP/AVP 0 8 101`) reaches the
+   server. The server enforces G.711 µ-law(0)/A-law(8)/telephone-event(101) via
+   `SipMessage::enforceG711()` and forwards the offer toward B.
+2. B answers 200 OK with its own SDP (`m=audio <portB> ...`). The server forwards
+   it back to A.
+3. **The `c=` connection address and `m=` port in each SDP point at the phones
+   themselves.** Once both sides have each other's `IP:port`, they stream RTP
+   directly. The server is out of the media path entirely.
+
+This is exactly why `PoolConfig.hpp` can say a `Session` "costs the server only
+signalling/bookkeeping RAM — not bandwidth or DSP." A session is ~200 B of state.
+It is the reason 8 concurrent calls fit on a plain ESP32. **The architecture is
+fast and light precisely because the server never sees a single audio packet.**
+
+### 1.2 What flowing RTP through the server would unlock
+
+| Capability | Why P2P can't do it | What server-side RTP enables |
+| :--- | :--- | :--- |
+| **NAT traversal / media relay** | Two phones behind different NATs can't reach each other's `IP:port` directly. | Server becomes the rendezvous point (B2BUA media relay / TURN-like). Both phones send to the server; server forwards. |
+| **Call recording** | Audio never reaches the server. | Server can fork a copy of each RTP stream to flash/PSRAM/network. |
+| **Music-on-Hold (MoH)** | A phone on hold hears silence unless its own firmware plays a tone. | Server streams a stored G.711 clip to the held party. |
+| **Real conferencing / mixing for 999** | Today's 999 is a *fork-and-pick*: it forks INVITEs to everyone and the **first** to answer wins; the rest are CANCELed (see `onInvite`/`onOk` in `RequestsHandler.cpp`). It is a 1:1 call, not a conference. | Server mixes N decoded PCM streams (sum + clip) and sends each participant the mix-minus-self. True all-page / talk-back. |
+| **DTMF / announcements** | Phone-to-phone only. | Server can inject `telephone-event` (101) or play canned announcements ("all circuits busy", page chimes). |
+| **RTP statistics (jitter / loss / MOS)** | Server sees no media, so no quality telemetry. | Server can compute per-stream jitter, loss %, and an estimated MOS for the dashboard. |
+
+The high-value, low-cost subset is **MoH + RTP stats + announcements**. The
+high-cost subset is **relay** (NAT) and **mixing** (999 conference).
+
+---
+
+## 2. Hard ESP32-S3 reality check ("fast and light")
+
+### 2.1 The unit economics of one G.711 stream
+
+G.711 at 8 kHz, 20 ms ptime:
+
+```
+8000 samples/s × 1 byte/sample × 0.020 s   = 160 bytes audio / packet
++ RTP header (12 B) + UDP (8 B) + IP (20 B) = 200 bytes on the wire / packet
+packets per second                          = 1000 ms / 20 ms = 50 pps
+payload bitrate                             = 160 B × 50 × 8   = 64 kbit/s
+on-the-wire bitrate (one direction)         ≈ 200 B × 50 × 8   = 80 kbit/s
+```
+
+So **one RTP stream = 50 pps, ~64 kbit/s payload (~80 kbit/s on the wire),
+each direction.** A two-party call is two streams each way.
+
+### 2.2 Cost of a 2-party relay
+
+A relay receives a packet on socket A and re-sends it to B (and vice versa). Per
+two-party call:
+
+* **Packets:** 50 pps in + 50 pps out, per direction = **~200 pps of relay work**
+  (100 in, 100 out) for a single bidirectional call.
+* **CPU:** Pure relay (no decode) is `recvfrom` → look up session → rewrite dest →
+  `sendto`. That's a few µs of work plus two syscalls crossing the LwIP stack.
+  The LwIP/socket path is the real cost, not arithmetic. Budget conservatively
+  **~30–60 µs of CPU per relayed packet** including the LwIP traversal; at 200 pps
+  that's ~6–12 µs/ms ≈ **0.6–1.2% of one core per call**. CPU is *not* the binding
+  constraint for pure relay.
+* **RAM:** A relay needs a small per-stream context (SSRC, last seq, remote
+  `IP:port`, stats counters) plus a jitter buffer if used (see §2.5). Without a
+  jitter buffer, ~200–400 B/stream. With a 60 ms jitter buffer of 160 B frames,
+  add ~480 B–1 KB/stream. This is static-pool territory (§4).
+* **Wi-Fi:** **This is the constraint.** Relaying *doubles* airtime: every audio
+  packet is received and re-transmitted over the same half-duplex radio. A
+  two-party relay = ~320 kbit/s of media airtime (4 × 80 kbit/s) plus 802.11
+  per-frame overhead (ACKs, inter-frame spacing, retries) that dwarfs the payload
+  at these tiny frame sizes. Small frames are *airtime-expensive*.
+
+### 2.3 Cost of an N-party mixer (the 999 conference)
+
+A mixer must **decode** each incoming stream to 16-bit PCM, **sum** them, **clip**
+to int16, **re-encode** G.711, and send each participant the mix-minus-themselves.
+
+```
+per 20 ms frame, N participants:
+  N × decode (G.711→PCM)        : 160 table lookups each  → cheap
+  build mix bus                 : sum N×80 int16 samples
+  per participant: subtract self, clip, encode (PCM→G.711)
+  N × sendto                    : N syscalls / 20 ms
+```
+
+* **CPU:** Arithmetic is trivial (µ-law decode is a 256-entry LUT; encode is a
+  small branch). The cost is again **syscalls and the per-frame deadline**: all N
+  decodes + the mix + N encodes + N `sendto` calls must complete **every 20 ms**.
+  At N=8 that's 8 recv contexts + 8 sends every 20 ms = 800 pps of socket work on
+  one task, plus the mix math. Feasible but tightening.
+* **RAM:** mix bus (80 × int16 = 160 B) + per-participant jitter buffer. With
+  jitter buffers this is the dominant per-conference cost; budget ~1 KB ×
+  N.
+* **Hard limit:** the **20 ms wall clock**. If decode+mix+encode+send for all
+  participants ever exceeds 20 ms, you drop a frame and everyone hears a click.
+  Realistic mixed-participant ceiling: **~6–8** on a dedicated core; fewer if the
+  core also runs SIP.
+
+### 2.4 Concurrent calls vs. the static pools and memory headroom
+
+Per `docs/SCALING.md`, internal DRAM headroom after IDF + Wi-Fi is ~290–320 KB on
+a plain ESP32, and the existing pools cost ~37 KB. **The S3 has more SRAM and
+PSRAM**, but two hard facts dominate:
+
+1. **IRAM is ~100% used today.** Any new code that wants to be in IRAM (for
+   speed / to run during cache misses) has essentially **no room**. RTP code must
+   live in flash-cached IRAM-less code paths, which means it is subject to
+   instruction-cache misses — acceptable for a 20 ms cadence, but it means the
+   hot loop must not be latency-sensitive at the microsecond level.
+2. **The session pool defaults to 8**, and each relayed/mixed stream needs its own
+   RTP context + (optionally) jitter buffer in a **new static pool** (§4). These
+   are not free like signalling sessions — a media session is ~1–2 KB, not 200 B.
+
+**Realistic ceilings (rule of thumb, conservative):**
+
+| Build | Media core available | Relayed 2-party calls | 999 mixed participants |
+| :--- | :--- | :---: | :---: |
+| Headless / Ethernet (S3) | Core 0 mostly free | **4–6** | **6–8** |
+| Display (JC3248W535) | Core 1 = LVGL only; share Core 0 | **2–3** | **3–4** |
+
+These are bounded first by **Wi-Fi airtime**, then by the **20 ms deadline**, then
+by RAM. Wired Ethernet builds (W5500/LAN8720) relax the airtime constraint
+substantially and are the only sensible target for serious relay/mixing.
+
+### 2.5 Latency budget (jitter buffer adds delay)
+
+Relaying/mixing adds delay on top of P2P:
+
+```
+P2P one-way:        capture(20) + network + playout         ≈ 40–80 ms typical
+Relayed one-way:    capture(20) + net→server + server queue
+                    + jitter buffer(40–80) + net→peer + playout
+                    ≈ 100–180 ms
+```
+
+A **jitter buffer is mandatory** for mixing (you can't sum frames that arrive at
+different times) and strongly recommended for relay over Wi-Fi (which reorders and
+bursts). A 40–80 ms buffer (2–4 frames) is the practical floor. **Every ms of
+buffer is a ms of added mouth-to-ear latency**, and the ITU-T G.114 comfort
+ceiling is ~150 ms one-way. Server relay eats a big chunk of that budget, which is
+another reason to **prefer P2P whenever possible** (§3b).
+
+---
+
+## 3. Architecture options
+
+### (a) Pure relay / B2BUA — forward all RTP through the server
+
+The server terminates both media legs. It rewrites the SDP it sends to each phone
+so the `c=`/`m=` point at **the server's** relay IP and an allocated RTP port,
+instead of the far phone. Each phone thinks it is talking to the server; the
+server shuttles packets between the two legs.
+
+* **Pros:** Solves NAT universally; enables recording, stats, and is the
+  foundation for mixing; centralises media policy.
+* **Cons:** Doubles airtime for *every* call (even ones that didn't need relay);
+  adds latency to *every* call; consumes a media-session pool slot + ports +
+  jitter buffer per call; biggest blast radius if the media task stalls.
+* **Feasibility on this MCU:** Feasible for a *small* number of calls on a
+  **wired** build. On Wi-Fi it is the riskiest option for the airtime reasons in
+  §2.2. **Do not make this the default** — it taxes the "fast and light" promise
+  on every call.
+
+### (b) Selective relay — relay only when P2P fails / NAT detected
+
+Default to P2P (today's behaviour). Only insert the server into the media path
+when it is actually needed: e.g. the two endpoints are on different subnets, an
+SDP `c=` is a private address unreachable from the peer, or a configured policy
+flag forces it. This is the ICE/TURN philosophy applied minimally.
+
+* **Pros:** Keeps the common case (same-LAN intercom — the device's primary use)
+  fully P2P and zero-cost. Pays the relay tax only when unavoidable.
+* **Cons:** Requires a heuristic for "do we need to relay?" (subnet compare on the
+  offered `c=` vs. the registrar's known client address is a cheap, good-enough
+  start). More signalling complexity in `onInvite`/`onOk`.
+* **Feasibility:** Good. This is the right way to ship relay *if* relay is needed
+  at all. But note: the device is primarily a same-LAN intercom, so the NAT case
+  may be rare — validate the need before building it.
+
+### (c) MoH player — stream a stored G.711 clip from flash/PSRAM (lightest, high value)
+
+When a call is put on hold (re-INVITE with `a=sendonly`/`a=inactive`, or a feature
+code), the server opens a *single transmit* RTP stream to the held phone and
+plays a pre-encoded G.711 clip looped from flash or PSRAM.
+
+* **Pros:** **Lightest possible server-side RTP.** Transmit-only: no jitter buffer,
+  no decode, no mixing, no inbound media to schedule. The clip is already G.711
+  (matches `enforceG711()`), so it is literally `read 160 bytes → packetise →
+  sendto` every 20 ms. Proves the entire RTP socket/packetiser/SDP-rewrite
+  pipeline that relay and mixing reuse. High perceived-quality win.
+* **Cons:** Need a stored clip (flash space; a 30 s µ-law loop ≈ 240 KB — store
+  in flash, optionally cache in PSRAM). Need to handle hold re-INVITE signalling.
+* **Feasibility:** **Excellent.** This is the recommended first phase.
+
+### (d) Conference mixer for 999
+
+Replace the fork-and-pick 999 with a true mixer: every answering phone joins a
+conference; the server mixes mix-minus-self and sends to each.
+
+* **Pros:** Makes 999 a real all-page/talk-back. High wow-factor for an intercom.
+* **Cons:** Most expensive option (§2.3): decode+mix+encode+send for all
+  participants every 20 ms, N jitter buffers, hard real-time deadline. Highest
+  risk of audio glitches under load.
+* **Feasibility:** Feasible at small N (~6–8) on a dedicated core, but it is the
+  last thing to build and should be gated behind measured headroom.
+
+### Recommended phased path
+
+```
+Phase 1  ── MoH player (transmit-only) + RTP stats scaffolding   ← SHIP THIS FIRST
+            • lightest, proves the RtpEndpoint/socket/packetiser/SDP-rewrite plumbing
+            • single direction, no jitter buffer, no mixer
+Phase 2  ── RTP statistics on a (optional) receive path
+            • add an inbound RTP socket + jitter buffer + jitter/loss/MOS counters
+            • surface on the dashboard via the existing snapshot model
+Phase 3  ── Selective relay (option b), WIRED builds only by default
+            • reuse Phase-1 packetiser + Phase-2 jitter buffer
+            • gate behind subnet-mismatch heuristic; keep P2P as the default
+Phase 4  ── 999 conference mixer (option d), gated by measured headroom
+            • only after Phases 1–3 prove the scheduling model holds 20 ms
+```
+
+**"Light enough to ship": Phase 1 (MoH).** Everything past Phase 2 should be
+opt-in at compile time and default to wired builds.
+
+---
+
+## 4. Implementation sketch
+
+### 4.1 Where it hooks in
+
+```
+src/SIP/RequestsHandler.cpp   ← session wiring: on hold re-INVITE / 999, start/stop media
+src/SIP/SipSdpMessage.*       ← SDP rewrite: point c=/m= at the server's relay IP:port
+src/SIP/SipMessage.cpp        ← already has enforceG711(); media layer trusts 0/8/101
+src/Media/RtpEndpoint.{hpp,cpp}   ← NEW: one UDP RTP socket + packetiser/depacketiser + stats
+src/Media/RtpRelay.{hpp,cpp}      ← NEW: pairs two RtpEndpoints (relay) or fans out (mixer)
+src/Media/MohPlayer.{hpp,cpp}     ← NEW (Phase 1): transmit-only G.711 clip looper
+src/Media/JitterBuffer.{hpp,cpp}  ← NEW (Phase 2): fixed-depth reordering buffer
+```
+
+New module lives under a new `src/Media/` directory so it is cleanly separable and
+compile-time excludable (`-DPOCKETDIAL_MEDIA=1`).
+
+### 4.2 SDP rewrite (the signalling half)
+
+`SipSdpMessage` already parses `c=` (`getConnectionInformation()`), `m=`
+(`getMedia()`, `getRtpPort()`), and can replace the media line (`setMedia()`).
+For relay/MoH we add a `rewriteMediaTarget(serverIp, allocatedPort)` that:
+
+* replaces the `m=audio <port> ...` port with the server-allocated RTP port,
+* replaces (or inserts) the `c=IN IP4 <addr>` with the server's media IP,
+* leaves the `RTP/AVP 0 8 101` codec list intact (still G.711-enforced).
+
+The rest of the SDP is untouched. This is a string-splice in the existing
+`_messageStr`, consistent with how `enforceG711()` and `setMedia()` already work.
+
+### 4.3 Packet path
+
+```
+PHASE 1 — MoH (transmit only):
+  [MohPlayer task] every 20 ms:
+     read 160 B from clip cursor (flash/PSRAM) → wrap in RTP (seq++, ts+=160, SSRC)
+     → sendto(held_phone_ip:port)            (no recv, no jitter buffer)
+
+PHASE 3 — Relay:
+     recvfrom(legA_sock) → RtpEndpoint A depacketise → JitterBuffer A
+     20 ms tick: pop JB A → repacketise (rewrite SSRC/seq/ts) → sendto(legB)
+     (and symmetric B→A)
+
+PHASE 4 — Mixer (999):
+     for each leg: recvfrom → depacketise → decode µ-law→PCM16 → JitterBuffer
+     20 ms tick:
+        mixBus = Σ all legs' current PCM frame (saturating add, clip int16)
+        for each leg i: out_i = mixBus − frame_i  → encode PCM16→µ-law → sendto(leg_i)
+```
+
+### 4.4 Jitter buffer (Phase 2+)
+
+Fixed-depth ring of N frames (default 3–4 = 60–80 ms). Ordered insert by RTP
+sequence number; pop one frame per 20 ms tick; conceal a missing frame by
+repeating the last (or emitting comfort-silence). Keep depth a compile-time
+constant so it lives in the static pool. **No dynamic resize on the hot path.**
+
+### 4.5 Static-allocation & threading model
+
+Consistent with the project's pool philosophy (`PoolConfig.hpp`, Issue #53):
+
+* **New static pool** `_mediaPool` of `MediaSession` objects, sized by a new
+  `POCKETDIAL_MAX_MEDIA` knob (default small, e.g. **2** on Wi-Fi / **4** on
+  wired). Each holds its RtpEndpoint(s) + jitter buffer(s) + stats. Allocated at
+  boot; `reset()`-recycled like clients/sessions. An INVITE that needs media but
+  finds the media pool exhausted **falls back to P2P** (graceful) rather than 503.
+* **RTP ports** allocated from a fixed range (e.g. 10000–10000+2×MAX_MEDIA),
+  even ports for RTP per RFC 3550.
+* **Dedicated FreeRTOS task** `media_task`, **priority equal-or-just-below the SIP
+  receiver (5)**, driven by a 20 ms tick (or `recvfrom` with a 20 ms timeout):
+  * **Display build:** pin to **Core 0** (Core 1 is LVGL-only — do not touch it).
+    This shares Core 0 with HTTP/SIP, which is why the display ceiling is lower.
+  * **Headless/Ethernet build:** the existing scheme moves SIP to Core 1 and
+    leaves Core 0 freer; pin `media_task` to the core *not* running the SIP
+    receiver so media and SIP don't fight for the same core.
+* **Lock discipline:** media packets must **never** take the SIP `_mutex`. The
+  media task reads the far-end `IP:port` from an immutable per-session snapshot
+  captured at call-setup time (same spirit as the dashboard snapshot model).
+  Socket `sendto` happens on the media task, never inside the registrar lock —
+  identical to the existing Outbox pattern (Issue #24/#51).
+
+### 4.6 Interaction with existing codec enforcement
+
+The media layer **assumes G.711 0/8/101** because `enforceG711()` already
+guarantees it in every SDP answer. The packetiser is therefore fixed-format: 160 B
+payload, 20 ms, payload type 0 (µ-law) or 8 (A-law). DTMF (101) is passed through
+as `telephone-event` RTP events. No format negotiation logic is needed in the
+media path — a deliberate simplification that the existing signalling makes safe.
+
+### 4.7 Media-path diagrams: P2P vs relayed
+
+```
+TODAY — Peer-to-peer (server out of media path):
+
+   Phone A ───── SIP (INVITE/OK) ─────► [ pocket-dial ] ◄───── SIP ───── Phone B
+        │                                  registrar/proxy                   │
+        │                                  (rewrites SDP only)                │
+        │                                                                     │
+        └──────────────── RTP G.711 (direct, 64 kbit/s ea way) ──────────────┘
+                          server NEVER sees these packets
+
+
+RELAYED (Phase 3) — server terminates both media legs:
+
+   Phone A ───── SIP ─────►┌──────────────────────────┐◄───── SIP ───── Phone B
+        │                   │       pocket-dial        │                      │
+        │                   │  RtpEndpoint A   B        │                      │
+        └─ RTP ────────────►│  recv→JB→repacketise→send│◄──────────── RTP ────┘
+            (to server)     │  (and symmetric B→A)     │   (to server)
+                            └──────────────────────────┘
+                          every packet crosses the radio TWICE (in + out)
+```
+
+---
+
+## 5. Risks and recommendation
+
+| Risk | Detail | Mitigation |
+| :--- | :--- | :--- |
+| **Wi-Fi half-duplex / airtime (BIGGEST)** | Relay doubles media airtime on a shared half-duplex radio; tiny 200 B frames are airtime-inefficient (802.11 overhead dominates). This — not CPU — caps concurrency. | Default to P2P; relay only selectively (option b); prefer wired (W5500/LAN8720) builds for relay/mixing; cap `POCKETDIAL_MAX_MEDIA` low on Wi-Fi. |
+| **Added latency** | Relay + jitter buffer adds 60–140 ms one-way, eating the G.114 150 ms budget. | Keep jitter buffer shallow (60–80 ms); never relay calls that work fine P2P. |
+| **CPU saturation → glitches** | The 20 ms deadline is hard. Missing it (cache miss storm, contention with LVGL/HTTP) = audible clicks; mixing is most exposed. | Dedicated `media_task` on a non-LVGL core; bound N; measure watermark before enabling Phase 4. |
+| **IRAM exhaustion** | IRAM is ~100% used; RTP code can't go in IRAM, so the hot loop runs from flash-cached code subject to i-cache misses. | Keep the per-frame loop small and branch-light; 20 ms cadence tolerates cache misses; do not add IRAM-hungry code. |
+| **RAM** | Media sessions are ~1–2 KB each (vs ~200 B signalling sessions); jitter buffers dominate. | Small static media pool; fall back to P2P on exhaustion, not 503. |
+| **Security — RTP injection** | An attacker who learns a session's `IP:port`/SSRC can inject forged RTP (audio injection, DoS). The existing SIP rate-limiter does not cover RTP ports. | Validate inbound RTP source against the negotiated peer `IP:port`; check SSRC continuity; apply a per-port packet-rate cap analogous to the SIP token bucket; only open relay ports for the duration of a call. |
+| **Conflicts with "fast and light"** | The whole value proposition is that the server is media-free. Relay/mixing inverts that. | Make all media features compile-time opt-in; ship MoH (which is cheap and obviously valuable) first; treat relay/mixing as wired-build, measured-headroom features. |
+
+### Recommendation
+
+**Build Phase 1 (MoH player) first.** It is the only server-side RTP feature that
+is unambiguously worth it: it is light (transmit-only, no jitter buffer, no mixer),
+it delivers obvious user value (held callers hear music instead of silence), and
+it builds the exact `RtpEndpoint` / socket / packetiser / SDP-rewrite plumbing
+that every later phase reuses — so it de-risks the rest at the lowest cost.
+
+**Defer relay and mixing** until there is a demonstrated need (a real NAT
+deployment for relay; a real all-page-talk-back requirement for mixing), and when
+built, make them **opt-in and wired-build-first**. For a same-LAN intercom — the
+device's primary mission — P2P media remains the right default, and keeping it
+that way is what keeps the device fast and light.

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -1,0 +1,248 @@
+# First-Time Setup Guide
+
+This guide takes a freshly flashed **pocket-dial** device from power-on to a working
+test call. It assumes a Wi-Fi SoftAP build (the default standalone Access Point mode);
+notes call out where the wired-Ethernet and touch-display variants differ.
+
+If you have not flashed firmware yet, do that first — see the build instructions in
+[../README.md](../README.md#building) and, for updating an already-flashed device,
+[OTA.md](OTA.md). This document picks up **after** the firmware is on the board.
+
+**What you will do:**
+
+1. [Power on and join the device's Wi-Fi](#1-power-on-and-join-the-device)
+2. [Open the dashboard](#2-open-the-dashboard)
+3. [Set the admin PIN (do this first)](#3-set-the-admin-pin-first)
+4. [Register a softphone or IP phone](#4-register-a-phone)
+5. [Make a test call (777 echo, then 999 all-page)](#5-make-a-test-call)
+6. [Quick-start checklist](#6-quick-start-checklist)
+
+---
+
+## 1. Power on and join the device
+
+When a standalone Wi-Fi build boots, it spawns its own **open** access point and runs an
+internal DHCP server. The SIP registrar binds to `192.168.4.1:5060` and the HTTP
+dashboard to `192.168.4.1:80`.
+
+| Setting | Value | Source |
+| :--- | :--- | :--- |
+| SoftAP SSID | `esp32-sipserver` | `main/esp_main.cpp` (`EXAMPLE_ESP_WIFI_SSID`) |
+| Security | Open — no password | `WIFI_AUTH_OPEN` (`main/esp_main.cpp`) |
+| Channel | 1 | `EXAMPLE_ESP_WIFI_CHANNEL` |
+| Max associated stations | 10 | `EXAMPLE_MAX_STA_CONN` |
+| Gateway / server IP | `192.168.4.1` | DHCP server default |
+| Hostname (mDNS) | `pocketdial.local` | `mdns_hostname_set("pocketdial")` |
+
+**Steps:**
+
+1. Power the board over USB-C (or PoE on a wired board).
+2. On your laptop or phone, open Wi-Fi settings and join **`esp32-sipserver`**. No
+   password is required.
+3. Wait for your client to receive a DHCP lease (an address in the `192.168.4.x` range).
+
+> [!IMPORTANT]
+> The SoftAP is **open** by default — anyone in radio range can join. Treat the device
+> as exposed to everyone on its link and set the admin PIN immediately (step 3). See
+> [THREAT_MODEL.md](THREAT_MODEL.md) for the full security posture and the recommended
+> WPA2 hardening.
+
+### Variant: captive-portal onboarding (touch-display build)
+
+The Guition JC3248W535 display build can boot into a **captive-portal onboarding** mode
+that brings up a separate setup AP named **`My-Ap`** (`ONBOARDING_SSID` in
+`main/esp_main_display.cpp`) and shows a join QR code on screen. When you join, the
+device redirects all web traffic to its setup page so you can either join an existing
+Wi-Fi network (Station mode) or stay in Standalone AP mode.
+
+> [!NOTE]
+> The onboarding portal has a **5-minute decay watchdog** (`CAPTIVE_DECAY_SECONDS = 300`
+> in `main/esp_main_display.cpp`): if no configuration is confirmed within five minutes,
+> the device reboots into Standalone AP mode (`esp32-sipserver`) on its own. If your
+> portal disappears, just re-join `esp32-sipserver` and continue from step 2.
+
+### Variant: wired Ethernet / PoE
+
+W5500/LAN8720 builds (`SIP_TRANSPORT=eth`) are nodes on your wired LAN and obtain an
+address via DHCP (with static fallback). There is no SoftAP; reach the dashboard at the
+device's LAN IP or at `pocketdial.local`. See [HARDWARE_SELECTION.md](HARDWARE_SELECTION.md)
+for board specifics.
+
+---
+
+## 2. Open the dashboard
+
+Open a browser on the joined client and navigate to:
+
+```
+http://192.168.4.1
+```
+
+or, where mDNS resolves:
+
+```
+http://pocketdial.local
+```
+
+You should see the retro CGA dashboard. It renders live data from
+[`GET /api/status`](API.md#get-apistatus): the server IP/port, uptime, processed/dropped
+packet counters, the list of registered extensions, and any active call sessions.
+
+If the page does not load, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#dashboard-unreachable).
+
+---
+
+## 3. Set the admin PIN (first)
+
+> [!IMPORTANT]
+> **Set the admin PIN before doing anything else.** A factory-fresh device is
+> *unprovisioned*: its state-changing endpoints are protected only by a same-origin/CSRF
+> check, so any peer on the open AP could disconnect calls, rewrite Wi-Fi credentials,
+> switch modes, or factory-reset the device. The instant a PIN is set, those endpoints
+> require an authenticated session. This is the **first-run onboarding step**
+> (see [THREAT_MODEL.md](THREAT_MODEL.md) §5.1).
+
+Once a PIN is set, the following state-changing endpoints require a valid `pd_session`
+cookie (else they return `401`): `/api/kill`, `/api/wifi/connect`, `/api/wifi/mode_ap`,
+`/api/factory-reset`, and the OTA endpoints (`/api/ota/upload`, `/api/ota/reboot`).
+
+### Set the PIN from the dashboard
+
+Use the admin/security control on the dashboard to set your PIN. Under the hood this
+POSTs to `/api/admin/set-pin`.
+
+### Set the PIN from the command line
+
+```bash
+DEVICE=http://192.168.4.1     # or http://pocketdial.local
+
+curl -s -H "Origin: $DEVICE" \
+     -X POST --data "pin=YOUR_PIN" \
+     "$DEVICE/api/admin/set-pin"
+# -> {"status":"ok","provisioned":true}
+```
+
+PIN rules and behavior, from `src/Helpers/AdminAuth.{hpp,cpp}` and the threat model:
+
+| Property | Value |
+| :--- | :--- |
+| Minimum length | 4 characters (`kMinPinLength`); a too-short PIN returns `400` |
+| Storage | Salted, iterated SHA-256 — 50,000 rounds, 128-bit random salt (NVS keys `admin_salt` / `admin_hash`) |
+| Brute-force lockout | 5 consecutive failed logins → 60-second lockout (`429`); auto-clears |
+| Session token | ≥128-bit opaque, `HttpOnly` + `SameSite=Strict` cookie, 30-minute absolute expiry |
+
+> [!TIP]
+> The hash is salted and iterated, but a short numeric PIN is still trivially crackable
+> if an attacker ever obtains the flash contents physically. **Use ≥6 alphanumeric
+> characters** (THREAT_MODEL.md §5.2, P0 guidance).
+
+### Log in
+
+After the PIN is set, obtain a session before calling any gated endpoint:
+
+```bash
+curl -s -c cookies.txt -H "Origin: $DEVICE" \
+     -X POST --data "pin=YOUR_PIN" \
+     "$DEVICE/api/admin/login"
+# -> {"status":"ok","authenticated":true}   (sets a pd_session cookie)
+```
+
+You can verify provisioning state any time with the read-only endpoint
+`GET /api/admin/status`, which returns only booleans (`provisioned`, `authenticated`).
+
+---
+
+## 4. Register a phone
+
+pocket-dial is a SIP registrar. Any SIP client — a softphone app or a hardware IP phone —
+registers against it with these settings:
+
+| Field | Value | Notes |
+| :--- | :--- | :--- |
+| SIP server / registrar / proxy | `192.168.4.1` | Or the device's LAN IP on wired builds; `pocketdial.local` where mDNS resolves |
+| Port | `5060` | UDP signaling port |
+| Transport | **UDP** | The engine only speaks UDP |
+| Username / Auth ID / extension | your choice, e.g. `1001` | The registrar keys clients by this extension (AOR) |
+| Password | (any / blank) | There is **no SIP digest authentication** today — the registrar accepts the REGISTER on the open link. See [THREAT_MODEL.md](THREAT_MODEL.md) S-3 |
+| Codec | **G.711 only** — µ-law (PCMU, payload 0) and a-law (PCMA, payload 8), plus telephone-event (101) | The server rewrites SDP to `0 8 101` via `enforceG711()` |
+| Registration expiry | up to `3600` s | `DEFAULT_EXPIRES`/`MAX_EXPIRES`; higher requests are capped to 3600 |
+
+> [!IMPORTANT]
+> **Do not reuse the extensions `777` or `999`.** They are reserved virtual extensions
+> (echo test and all-page broadcast — see step 5).
+
+**Steps:**
+
+1. Open your SIP client and create a new account/identity.
+2. Enter server `192.168.4.1`, port `5060`, transport **UDP**.
+3. Choose an extension (e.g. `1001`) as the username.
+4. Restrict the codec list to **G.711 µ-law and a-law** (disable Opus, G.722, G.729).
+5. Save. The client should show "registered".
+6. Confirm on the dashboard: the extension appears in the `clients` list of
+   [`GET /api/status`](API.md#get-apistatus).
+
+Register a **second** extension (e.g. `1002`) on another client so you can place a real
+call later. Per-client walkthroughs and known quirks are in
+[PHONE_COMPATIBILITY.md](PHONE_COMPATIBILITY.md).
+
+> [!NOTE]
+> The registrar pings each registered client with a SIP `OPTIONS` keepalive every 5
+> seconds and prunes a client after ~15 seconds of silence (`RequestsHandler.cpp`). A
+> phone that does not answer OPTIONS may be dropped from the registrar.
+
+---
+
+## 5. Make a test call
+
+### 5a. Echo test — dial `777`
+
+`777` is a built-in echo loopback. When an endpoint dials `777`, the server answers
+`200 OK` using **the caller's own SDP connection info**, so the phone streams its audio
+back to its own receive port — a zero-DSP hardware echo test (`RequestsHandler::onInvite`).
+
+1. From a registered phone, dial **`777`**.
+2. The call connects immediately. Speak — you should hear your own voice echoed back.
+3. Hang up.
+
+If you hear nothing, your audio path (codec/RTP) is the suspect — see
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md#one-way-or-no-audio).
+
+### 5b. All-page broadcast — dial `999`
+
+`999` is a parallel intercom/all-page. Dialing it forks the INVITE to **every other
+registered extension** at once, injecting auto-answer headers; the first device to answer
+`200 OK` is connected and the rest are cancelled (`RequestsHandler` broadcast handler).
+
+1. Make sure at least one **other** extension is registered (e.g. `1002` from step 4).
+2. From one phone, dial **`999`**.
+3. Every other registered phone is paged simultaneously. When one answers, it is bridged
+   to the caller and the others stop ringing.
+
+### 5c. Direct extension-to-extension call
+
+1. From `1001`, dial `1002` (the second extension you registered).
+2. The callee rings; answer it.
+3. Audio (RTP) flows **peer-to-peer** directly between the two phones — the device only
+   brokers signaling (see [ARCHITECTURE.md](ARCHITECTURE.md) and [SCALING.md](SCALING.md)).
+4. The active call appears in the `sessions` list on the dashboard.
+
+---
+
+## 6. Quick-start checklist
+
+- [ ] Firmware flashed (see [README.md](../README.md#building) / [OTA.md](OTA.md)).
+- [ ] Powered on; joined Wi-Fi SSID **`esp32-sipserver`** (open) — or completed the
+      `My-Ap` captive portal on the display build.
+- [ ] Dashboard reachable at `http://192.168.4.1` (or `http://pocketdial.local`).
+- [ ] **Admin PIN set** via `/api/admin/set-pin` (≥6 alphanumeric chars recommended).
+- [ ] Logged in (`/api/admin/login`) before using any gated control.
+- [ ] First softphone/IP phone registered: server `192.168.4.1:5060`, **UDP**, **G.711**,
+      extension e.g. `1001`.
+- [ ] Second extension registered (e.g. `1002`).
+- [ ] Dialed **`777`** — heard echo.
+- [ ] Dialed **`999`** — other phones paged.
+- [ ] Placed a direct `1001 → 1002` call — two-way audio.
+
+**Next:** [PHONE_COMPATIBILITY.md](PHONE_COMPATIBILITY.md) ·
+[HARDWARE_SELECTION.md](HARDWARE_SELECTION.md) ·
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md) · [SCALING.md](SCALING.md)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,194 @@
+# Troubleshooting Runbook
+
+Symptom → likely cause → fix. Work top-down within each section. Where a fact comes from
+the firmware or another doc, it is cited so you can verify.
+
+Quick references: [SETUP_GUIDE.md](SETUP_GUIDE.md) ·
+[PHONE_COMPATIBILITY.md](PHONE_COMPATIBILITY.md) · [HARDWARE_SELECTION.md](HARDWARE_SELECTION.md) ·
+[API.md](API.md) · [OTA.md](OTA.md) · [THREAT_MODEL.md](THREAT_MODEL.md)
+
+---
+
+## Access-point not visible
+
+**Symptom:** The `esp32-sipserver` Wi-Fi network does not appear in your client's Wi-Fi list.
+
+| Cause | Fix |
+| :--- | :--- |
+| Device not powered / still booting | Confirm power (USB-C or PoE). Watch the serial monitor (`idf.py monitor`) for `wifi_init_softap finished. SSID:esp32-sipserver` (`main/esp_main.cpp`). |
+| This is a **wired Ethernet** build | `SIP_TRANSPORT=eth` boards have **no SoftAP** — they join your wired LAN. Reach the dashboard at the device's LAN IP / `pocketdial.local` (see [HARDWARE_SELECTION.md](HARDWARE_SELECTION.md)). |
+| Device is in **Station mode** | If Wi-Fi was configured to join an existing network (`/api/wifi/connect`), it is a client, not an AP. Factory-reset to return to AP/onboarding (see [Forgot the admin PIN](#forgot-the-admin-pin)). |
+| Display build sitting in onboarding | The display variant's onboarding AP is **`My-Ap`**, not `esp32-sipserver` (`ONBOARDING_SSID`, `main/esp_main_display.cpp`). Look for `My-Ap`. |
+| 2.4 GHz only | The ESP32 SoftAP is 2.4 GHz, channel 1. Ensure your client shows 2.4 GHz networks. |
+
+---
+
+## Captive portal won't open
+
+**Symptom:** You joined `My-Ap` (display build) but no setup page appears.
+
+| Cause | Fix |
+| :--- | :--- |
+| OS captive-portal prompt missed | Manually browse to `http://192.168.4.1/`. The device returns a `302` redirect to the portal for any off-host request ([API.md §3](API.md)). |
+| The 5-minute decay window elapsed | The portal has a **300 s decay watchdog** (`CAPTIVE_DECAY_SECONDS`, `main/esp_main_display.cpp`): with no confirmed config it reboots into Standalone AP. Re-join **`esp32-sipserver`** and use `http://192.168.4.1`. |
+| Browser cached HTTPS / HSTS | Use a fresh `http://` URL (not `https://`), or try a private window. The dashboard is HTTP only. |
+| DNS not redirecting | The onboarding DNS responder answers all names with the device IP (port 53). If your client uses DNS-over-HTTPS, type the IP `192.168.4.1` directly. |
+
+---
+
+## Phone won't register (timeout or 401)
+
+**Symptom:** The SIP client never reaches "registered", times out, or shows an error.
+
+| Cause | Fix |
+| :--- | :--- |
+| Wrong server/port/transport | Server `192.168.4.1`, port `5060`, transport **UDP** (the engine is UDP-only). See [PHONE_COMPATIBILITY.md](PHONE_COMPATIBILITY.md). |
+| Not on the device's network | Confirm the phone has a `192.168.4.x` lease (SoftAP) or can reach the device's LAN IP (wired). |
+| TCP/TLS selected | Switch the client to **UDP**. There is no TCP/TLS listener. |
+| Using extension `777`/`999` | These are reserved virtual extensions; pick another (e.g. `1001`). |
+| `503 Service Unavailable` on REGISTER | The client pool is full. `allocateClient()` evicts the oldest *expired* binding, else returns `503`; the phone retries on its refresh timer. Raise the tier ([SCALING.md §4](SCALING.md)). |
+| Client pruned after registering | The registrar prunes a client after ~15 s of silence if it ignores the `OPTIONS` keepalive sent every 5 s (`RequestsHandler.cpp`). Enable the phone's keep-alive / answer-OPTIONS option. |
+| Rate-limited (packets dropped) | The SIP UDP path uses a per-source-IP token bucket (burst 40, 20 pkt/s sustained). A flooding or misconfigured client gets packets dropped; watch `packetsDropped` on `/api/status` ([ARCHITECTURE.md §5](ARCHITECTURE.md)). |
+
+> [!NOTE]
+> A `401` here is **not** SIP auth — pocket-dial has **no SIP digest authentication**
+> today (any extension registers on the open link, see [THREAT_MODEL.md](THREAT_MODEL.md)
+> S-3). A `401` you see is almost always the phone's own account dialog or, separately,
+> the **HTTP admin** gate (`/api/admin/*`) — a different subsystem.
+
+---
+
+## One-way or no audio
+
+**Symptom:** The call connects (rings, answers) but you hear nothing, or only one side
+hears audio.
+
+| Cause | Fix |
+| :--- | :--- |
+| **Codec mismatch (most common)** | pocket-dial does not transcode; it rewrites SDP to `0 8 101` (`enforceG711()`). If a phone offers only Opus/G.722/G.729, there is no common codec → no audio. **Restrict every client to G.711 µ-law + a-law** ([PHONE_COMPATIBILITY.md §1](PHONE_COMPATIBILITY.md)). |
+| NAT/STUN/ICE enabled on the phone | Media is **peer-to-peer on one L2 segment**. NAT traversal rewrites the SDP connection address and breaks direct RTP. Turn STUN/ICE/rport **off**. |
+| Client isolation on the AP | RTP is phone-to-phone; if SoftAP client isolation were enabled, stations couldn't reach each other and audio would fail (see [PROVISIONING.md §4.4](PROVISIONING.md) caveat). |
+| Firewall between phones (wired) | On a wired LAN, ensure the segment allows station-to-station UDP for the RTP port range. |
+| Verify with `777` | Dial **`777`** (echo): if echo works but a two-party call does not, the problem is between the two phones (NAT/isolation/firewall), not the codec. If `777` itself is silent, it is the codec/RTP on that one phone. |
+
+---
+
+## Calls drop unexpectedly
+
+**Symptom:** Established calls hang up on their own.
+
+| Cause | Fix |
+| :--- | :--- |
+| Keepalive prune | A phone that stops answering `OPTIONS` is pruned after ~15 s (`RequestsHandler.cpp`); its calls end. Keep the phone's keep-alive on and Wi-Fi signal adequate. |
+| Wi-Fi association lost | On a SoftAP node, a weak link drops the station. Check RSSI / reduce range. |
+| Session pool exhausted | New INVITEs get `503` when the session pool is full; existing calls are untouched. Raise the tier ([SCALING.md §4](SCALING.md)). |
+| Admin force-disconnect | `POST /api/kill` de-registers an extension and tears down its calls ([API.md](API.md)). Check whether someone used the dashboard's kill control. |
+| Spoofed BYE (open AP) | With no SIP auth on an open AP, a peer can inject a `BYE` (`THREAT_MODEL.md` D-2). The link-layer fix is WPA2 on the SoftAP. |
+
+---
+
+## Dashboard unreachable
+
+**Symptom:** `http://192.168.4.1` (or `pocketdial.local`) does not load.
+
+| Cause | Fix |
+| :--- | :--- |
+| Wrong scheme | Use **`http://`**, not `https://` — the dashboard is plain HTTP ([API.md §1](API.md)). |
+| mDNS not resolving | Browse to the raw IP `192.168.4.1` (SoftAP) or the device's LAN IP (wired). |
+| Not joined to the device network | Re-check Wi-Fi association / DHCP lease. |
+| Slow-client / Slowloris timeout | The HTTP worker enforces a 5 s `SO_RCVTIMEO` and closes idle sockets ([ARCHITECTURE.md §4](ARCHITECTURE.md)); reload the page. |
+| `413 Payload Too Large` | A request body over **16 KB** is rejected ([API.md §1](API.md)). Don't paste oversized Wi-Fi passwords. |
+| `403 cross-origin request rejected` | A state-changing POST whose `Origin` host ≠ `Host` is blocked (CSRF guard). Use the dashboard directly, or send a matching `Origin` from CLI ([API.md §2](API.md)). |
+| `401` on a control action | A PIN is provisioned and you have no valid `pd_session`. Log in via `/api/admin/login` first ([SETUP_GUIDE.md §3](SETUP_GUIDE.md)). |
+| `429` on login | Brute-force lockout: 5 failed logins → 60 s cooldown (`AdminAuth`). Wait it out; it auto-clears. |
+
+---
+
+## Forgot the admin PIN
+
+There is **no PIN recovery** — the PIN is stored only as a salted, iterated SHA-256 hash
+(`AdminAuth.cpp`). The path back to a usable device is a **factory reset**, which clears
+the admin credential and Wi-Fi config and reboots into onboarding/AP mode.
+
+**If you still hold a valid session** (logged in elsewhere), POST a factory reset:
+
+```bash
+DEVICE=http://192.168.4.1
+curl -s -b cookies.txt -H "Origin: $DEVICE" \
+     -X POST --data "confirm=ERASE" \
+     "$DEVICE/api/factory-reset"
+# -> {"status":"ok","message":"Factory reset. Rebooting to captive-portal setup..."}
+```
+
+- The `confirm=ERASE` token is **required** — without it the endpoint returns
+  `400 {"error":"factory reset requires confirm=ERASE"}` (`HttpServer::sendApiFactoryReset`).
+- Factory reset erases `admin_salt`/`admin_hash` (clearing the PIN and all sessions) and
+  the Wi-Fi keys (`wifi_mode`, `wifi_ssid`, `wifi_pass`, `decayed`), then reboots.
+- The dashboard's **Factory Reset** button performs the same call (`index_html.h`).
+
+**If you have no valid session** (PIN lost and not logged in anywhere): the gated
+`/api/factory-reset` will return `401`. Recover physically — **re-flash over USB/JTAG**.
+A full reflash returns the device to the unprovisioned/open state; note that
+`idf.py erase-flash` wipes NVS entirely, and even a plain `idf.py flash` may leave NVS in
+an inconsistent state across the partition migration, so **treat it as a clean slate and
+re-onboard** ([OTA.md §5.1](OTA.md)). After reflashing, set a new PIN as the first step
+([SETUP_GUIDE.md §3](SETUP_GUIDE.md)).
+
+> [!TIP]
+> Choose a PIN you will remember but that is still ≥6 alphanumeric chars
+> ([THREAT_MODEL.md §5.2](THREAT_MODEL.md)). There is no "reset link."
+
+---
+
+## OTA update fails or rolls back
+
+**Symptom:** A firmware push via `/api/ota/upload` errors, or the device reverts to the
+previous firmware after rebooting. Full reference: [OTA.md](OTA.md).
+
+| Code / behavior | Cause | Fix |
+| :--- | :--- | :--- |
+| `401` | A PIN is provisioned but the request has no/invalid `pd_session`. | Log in first (`/api/admin/login`), reuse the cookie jar ([OTA.md §3.2](OTA.md)). |
+| `403` | Cross-origin rejected (CSRF guard). | Send a matching `Origin` header. |
+| `411` | Missing/zero `Content-Length`. | Use `--data-binary @build/SipServer.bin` so curl sets the length. |
+| `400` | Upload truncated / socket closed mid-stream / flash write failed. | Re-upload on a stable link; the boot partition is unchanged, the device keeps running the current image ([OTA.md §4.2](OTA.md)). |
+| `422` | `esp_ota_end()` rejected the image (bad magic / corrupt / not a valid app). | Verify you uploaded the correct `build/SipServer.bin`; rebuild. |
+| `500` | `esp_ota_begin` / `set_boot_partition` failed. | Check device logs; retry. |
+| `501` | This is the **host/desktop** build — OTA is device-only. | Run OTA against real hardware ([OTA.md §3.4](OTA.md)). |
+| **Boots the OLD image after reboot** | **Anti-rollback** restored the previous slot because the new image did not reach `markValid()` (it crashed/boot-looped during startup). This is the safety net working — no bricking. | Inspect serial logs for the boot-loop cause, fix the image, re-upload. The device confirms a healthy image only after a few seconds of stable operation ([OTA.md §4](OTA.md), `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`). |
+| Power lost during write | The slot is partially written but never activated; `otadata` still points at the running slot, so the next boot is the old image. | Simply re-upload to retry ([OTA.md §4.2](OTA.md)). |
+
+> [!IMPORTANT]
+> OTA images are **unsigned** today and the upload is gated only by the admin PIN +
+> same-origin check. **Always set a PIN** and **restrict OTA to the local link**
+> ([OTA.md §6](OTA.md), [THREAT_MODEL.md](THREAT_MODEL.md) T-5).
+
+---
+
+## Display blank or garbled (Guition JC3248W535 variant)
+
+**Symptom:** The 3.5" touch panel is dark, shows noise, or never renders the UI.
+
+| Cause | Fix |
+| :--- | :--- |
+| Missing I2C pull-ups on the touch bus | Many JC3248W535 clones omit them; add **4.7 kΩ pull-ups** on `TOUCH_SDA` (GPIO 4) and `TOUCH_SCL` (GPIO 8) to 3.3 V, or the panel/touch init can time out and crash ([HARDWARE.md §8A](HARDWARE.md)). |
+| Wrong build / not the display target | Build with `idf.py -D SIP_TRANSPORT=display build` ([README.md](../README.md#jc3248w535en-smart-display)). A Wi-Fi-only build does not drive the panel. |
+| PSRAM not in Octal mode | The two 307.2 KB LVGL frame buffers need **8 MB Octal PSRAM @ 80 MHz** (`MALLOC_CAP_SPIRAM`). Octal PSRAM and `qio` flash mode are set via `sdkconfig.defaults`; a mismatched config exhausts internal SRAM ([HARDWARE.md §2](HARDWARE.md), README display note). |
+| Backlight off | `TFT_BL` is GPIO 1, **active-high** (high = on). A dark-but-alive panel can be a backlight wiring issue ([HARDWARE.md §2](HARDWARE.md)). |
+| Headless fallback engaged | If the display panel fails to initialize, the firmware is designed to fall back to headless operation (README "Robust Concurrency & Headless Fallback") — SIP and the HTTP dashboard still work; reach it over the network while you debug the panel. |
+
+> [!NOTE]
+> The display is optional to operation. Even with a dead panel, the device still runs the
+> SIP registrar and serves the HTTP dashboard — manage it from a browser
+> ([HARDWARE_SELECTION.md §3](HARDWARE_SELECTION.md)).
+
+---
+
+## Still stuck? Collect this before asking for help
+
+- `GET /api/status` output (uptime, `packetsProcessed`, `packetsDropped`, `clients`,
+  `sessions`) — [API.md](API.md).
+- `GET /api/admin/status` (`provisioned` / `authenticated` booleans).
+- Serial monitor log around the failure (`idf.py monitor`).
+- Board model and `SIP_TRANSPORT` build used ([HARDWARE_SELECTION.md](HARDWARE_SELECTION.md)).
+- The exact phone model/firmware and its codec/transport settings
+  ([PHONE_COMPATIBILITY.md](PHONE_COMPATIBILITY.md)).

--- a/main/esp_main_display.cpp
+++ b/main/esp_main_display.cpp
@@ -262,11 +262,26 @@ static esp_lcd_touch_handle_t hardware_touch_init() {
 static void lvgl_task(void *pvParameters) {
     ESP_LOGI("LVTask", "Core 1 Graphics task running...");
     char log_buf[256];
+    TickType_t lastLogPaint = 0;
     while (1) {
-        vTaskDelay(pdMS_TO_TICKS(10));
+        vTaskDelay(pdMS_TO_TICKS(16));   // ~60Hz service cap; guarantees IDLE1 gets the core
         if (lvgl_lock(-1)) {
-            while (xQueueReceive(s_log_queue, log_buf, 0) == pdTRUE)
-                ui_add_log(log_buf);
+            // Coalesce + rate-limit on-screen logging. The panel runs in LVGL
+            // full_refresh mode, so EVERY ui_add_log() repaints the whole 320x480
+            // screen (~150ms of QSPI+DMA). Draining an unbounded log flood every
+            // 10ms therefore pins Core 1 on back-to-back full repaints, starving
+            // IDLE1 (task-WDT) and snowballing as the WDT backtraces log more.
+            // Instead: append at most a few lines, and only every ~150ms, so log
+            // volume can never drive more than ~6 full repaints/sec.
+            TickType_t now = xTaskGetTickCount();
+            if (now - lastLogPaint >= pdMS_TO_TICKS(150)) {
+                int drained = 0;
+                while (drained < 8 && xQueueReceive(s_log_queue, log_buf, 0) == pdTRUE) {
+                    ui_add_log(log_buf);
+                    drained++;
+                }
+                if (drained > 0) lastLogPaint = now;
+            }
             lv_timer_handler();
             lvgl_unlock();
         }

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -51,3 +51,11 @@ CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 # feature in ESP-IDF v5.x; there is no separate CONFIG_APP_ROLLBACK_ENABLE.
 CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
 
+
+# The HTTP dashboard's accept loop runs as a std::thread (pthread). handleClient
+# -> sendApiStatus builds a JSON response + snapshot vector copies that overflow
+# the 3 KB default pthread stack on-device (works on host where threads have
+# MB-sized stacks; that mismatch made the dashboard unreachable on a real LAN
+# while SIP, on a properly-sized FreeRTOS task, kept working). Give std::thread
+# tasks a realistic stack.
+CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=8192

--- a/src/Helpers/HttpServer.cpp
+++ b/src/Helpers/HttpServer.cpp
@@ -1,6 +1,7 @@
 // HttpServer.cpp: Issues #23 and #28 resolved.
 #include "HttpServer.hpp"
 #include "RequestsHandler.hpp"
+#include "CallDetailRecord.hpp"
 #include "AdminAuth.hpp"
 #include "OtaUpdater.hpp"
 #include "index_html.h"
@@ -27,6 +28,10 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #endif
+
+// Forward declarations for the file-local form/URL helpers (defined lower down).
+// sendApiDnd() uses getFormParam() but is defined earlier in this TU.
+static std::string getFormParam(const std::string& body, const std::string& key);
 
 // Captive-portal decay hold. The display app's decay watchdog reads this; the web
 // "/api/configuring" confirm sets it to pause the auto-switch to Standalone while a user is
@@ -349,6 +354,29 @@ void HttpServer::handleClient(int clientSock)
 			sendApiKill(clientSock, req.body);
 		}
 	}
+	else if (req.method == "GET" && req.path == "/api/cdr")
+	{
+		// Read-only Call Detail Records — ungated like /api/status.
+		sendApiCdr(clientSock);
+	}
+	else if (req.method == "POST" && req.path == "/api/dnd")
+	{
+		// Mutating: same gate as /api/kill (same-origin + auth once provisioned).
+		if (!isSameOrigin(req))
+		{
+			sendResponse(clientSock, 403, "Forbidden", "application/json",
+			             "{\"error\":\"cross-origin request rejected\"}");
+		}
+		else if (AdminAuth::isProvisioned() && !isAuthed(req))
+		{
+			sendResponse(clientSock, 401, "Unauthorized", "application/json",
+			             "{\"error\":\"authentication required\"}");
+		}
+		else
+		{
+			sendApiDnd(clientSock, req.body);
+		}
+	}
 	else if (req.method == "GET" && req.path == "/api/wifi/scan")
 	{
 		sendApiWifiScan(clientSock);
@@ -621,6 +649,7 @@ void HttpServer::sendApiStatus(int sock)
 
 	std::vector<std::pair<std::string, std::string>> clients;
 	std::vector<std::tuple<std::string, std::string, std::string, int>> sessions;
+	std::vector<std::string> dndExtensions;
 	uint64_t packets = 0;
 	uint64_t dropped = 0;
 
@@ -628,6 +657,7 @@ void HttpServer::sendApiStatus(int sock)
 	{
 		clients = _handler->getActiveClients();
 		sessions = _handler->getActiveSessions();
+		dndExtensions = _handler->getDndExtensions();
 		packets = _handler->getPacketsProcessed();
 		dropped = _handler->getPacketsDropped();   // Issue #38
 	}
@@ -681,6 +711,15 @@ void HttpServer::sendApiStatus(int sock)
 		     << "\",\"state\":\"" << jsonEscape(std::get<2>(sessions[i]))
 		     << "\",\"duration\":\"" << durationBuf << "\"}";
 	}
+	json << "],";
+
+	// DND array: extensions currently in Do Not Disturb (Phase 2).
+	json << "\"dnd\":[";
+	for (size_t i = 0; i < dndExtensions.size(); i++)
+	{
+		if (i > 0) json << ",";
+		json << "\"" << jsonEscape(dndExtensions[i]) << "\"";
+	}
 	json << "]";
 
 	json << "}";
@@ -715,6 +754,71 @@ void HttpServer::sendApiKill(int sock, const std::string& body)
 	}
 	sendResponse(sock, 200, "OK", "application/json",
 	             "{\"status\":\"ok\",\"disconnected\":\"" + jsonEscape(ext) + "\"}");
+}
+
+void HttpServer::sendApiCdr(int sock)
+{
+	std::vector<CallDetailRecord> records;
+	if (_handler != nullptr)
+	{
+		records = _handler->getCallDetailRecords();   // newest first, thread-safe copy
+	}
+
+	uint64_t nowMs = currentTimeMs();   // same steady-clock basis as the CDR startMs
+
+	std::ostringstream json;
+	json << "[";
+	for (size_t i = 0; i < records.size(); i++)
+	{
+		if (i > 0) json << ",";
+		const CallDetailRecord& r = records[i];
+		// "ageSec": seconds since the call started, derived from the shared
+		// steady-clock basis (no wall clock / RTC is guaranteed on the device).
+		uint64_t ageSec = (nowMs >= r.startMs) ? (nowMs - r.startMs) / 1000 : 0;
+		json << "{\"caller\":\"" << jsonEscape(r.caller) << "\","
+		     << "\"callee\":\"" << jsonEscape(r.callee) << "\","
+		     << "\"startMs\":" << r.startMs << ","
+		     << "\"ageSec\":" << ageSec << ","
+		     << "\"duration\":" << r.durationSec << ","
+		     << "\"result\":\"" << cdrResultToString(r.result) << "\"}";
+	}
+	json << "]";
+
+	sendResponse(sock, 200, "OK", "application/json", json.str());
+}
+
+void HttpServer::sendApiDnd(int sock, const std::string& body)
+{
+	std::string ext = getFormParam(body, "extension");
+	std::string on  = getFormParam(body, "on");
+
+	if (ext.empty())
+	{
+		sendResponse(sock, 400, "Bad Request", "application/json",
+		             "{\"error\":\"missing extension parameter\"}");
+		return;
+	}
+
+	// Reject the virtual extensions: DND must never affect echo (777) or
+	// broadcast (999) — they are not real endpoints.
+	if (ext == "777" || ext == "999")
+	{
+		sendResponse(sock, 400, "Bad Request", "application/json",
+		             "{\"error\":\"cannot set DND on a virtual extension\"}");
+		return;
+	}
+
+	// Accept 1/true/on as enable; anything else (incl. "0") disables.
+	bool enable = (on == "1" || on == "true" || on == "on");
+
+	if (_handler != nullptr)
+	{
+		_handler->setDnd(ext, enable);
+	}
+
+	sendResponse(sock, 200, "OK", "application/json",
+	             "{\"status\":\"ok\",\"extension\":\"" + jsonEscape(ext) +
+	             "\",\"dnd\":" + (enable ? "true" : "false") + "}");
 }
 
 bool HttpServer::isSameOrigin(const HttpRequest& req) const

--- a/src/Helpers/HttpServer.cpp
+++ b/src/Helpers/HttpServer.cpp
@@ -66,7 +66,15 @@ HttpServer::HttpServer(const std::string& ip, int port, RequestsHandler* handler
 
 	sockaddr_in addr{};
 	addr.sin_family = AF_INET;
-	addr.sin_addr.s_addr = inet_addr(_ip.c_str());
+	// Bind to all interfaces (INADDR_ANY) rather than the one configured IP.
+	// Binding a listening socket to a specific, dynamically-assigned address is
+	// fragile on lwip: in Wi-Fi STATION mode the DHCP-assigned IP is bound here,
+	// and connections to it were accepted by lwip into the backlog but never
+	// serviced (dashboard unreachable on a LAN, while the SoftAP's static
+	// 192.168.4.1 worked). INADDR_ANY serves on every interface/IP and is robust
+	// across AP/STA mode switches and IP/lease changes. _ip is still used for
+	// display/logging and the captive-portal same-origin check.
+	addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	addr.sin_port = htons(static_cast<uint16_t>(_port));
 
 	if (bind(_listenSock, reinterpret_cast<const struct sockaddr*>(&addr), sizeof(addr)) < 0)

--- a/src/Helpers/HttpServer.hpp
+++ b/src/Helpers/HttpServer.hpp
@@ -58,6 +58,10 @@ private:
 	void sendHtml(int sock);
 	void sendApiStatus(int sock);
 	void sendApiKill(int sock, const std::string& body);
+	// Phase 2: read-only Call Detail Records (newest first). Ungated like /api/status.
+	void sendApiCdr(int sock);
+	// Phase 2: set per-extension Do Not Disturb. Mutating (same-origin + auth gated).
+	void sendApiDnd(int sock, const std::string& body);
 	void sendApiWifiScan(int sock);
 	void sendApiWifiConnect(int sock, const std::string& body);
 	void sendApiWifiModeAp(int sock);

--- a/src/Helpers/index_html.h
+++ b/src/Helpers/index_html.h
@@ -547,11 +547,124 @@ R"rawhtml(
   overflow-y: auto;
 }
 
+/* ─── ADMIN / SECURITY + OTA PANELS ─── */
+.adm-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 2px 0;
+}
+.adm-form label {
+  color: var(--cyan);
+  font-size: 15px;
+}
+.adm-input {
+  background: var(--black);
+  border: 1px solid var(--dk-cyan);
+  color: var(--green);
+  font-family: inherit;
+  font-size: 15px;
+  padding: 4px 8px;
+  outline: none;
+  min-width: 120px;
+  flex: 1 1 120px;
+}
+.adm-input:focus {
+  border-color: var(--cyan);
+  box-shadow: 0 0 6px rgba(85,255,255,0.3);
+}
+input[type="file"].adm-input {
+  padding: 3px 4px;
+  color: var(--gray);
+}
+.adm-note {
+  color: var(--dk-yellow);
+  font-size: 14px;
+  margin: 2px 0;
+}
+.adm-msg {
+  font-size: 14px;
+  margin: 2px 0;
+  min-height: 16px;
+}
+.adm-state-ok { color: var(--green); text-shadow: 0 0 6px rgba(85,255,85,0.4); }
+.adm-locked-note {
+  color: var(--dk-red);
+  font-size: 14px;
+  margin: 2px 0;
+}
+/* Disabled (gated) controls */
+.btn-retro:disabled,
+.btn-retro[disabled] {
+  background: var(--dk-gray);
+  color: var(--bg-dark);
+  border-color: var(--dk-gray);
+  cursor: not-allowed;
+  opacity: 0.6;
+  text-shadow: none;
+}
+.btn-retro:disabled:hover,
+.btn-retro[disabled]:hover { background: var(--dk-gray); color: var(--bg-dark); }
+/* OTA progress bar */
+#ota-progress-wrap {
+  display: none;
+  margin: 4px 0;
+  height: 14px;
+  border: 1px solid var(--dk-cyan);
+  background: var(--black);
+  position: relative;
+}
+#ota-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: var(--dk-cyan);
+  transition: width 0.15s linear;
+}
+#ota-progress-text {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  text-align: center;
+  font-size: 12px;
+  line-height: 14px;
+  color: var(--fg);
+  text-shadow: 0 0 4px rgba(0,0,0,0.8);
+}
+.ota-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 1px 0;
+  font-size: 15px;
+}
+.ota-row .status-label { color: var(--gray); }
+.ota-row .status-value { color: var(--cyan); text-shadow: 0 0 6px rgba(85,255,255,0.3); }
+
 /* ─── RESPONSIVE ─── */
 @media (max-width: 800px) {
-  #body-area { flex-direction: column; }
-  #right-panel { width: 100%; flex-direction: row; justify-content: center; }
+  html, body { overflow: auto; height: auto; }
+  #crt-monitor { height: auto; min-height: 100%; border-radius: 0; }
+  #main-content { height: auto; overflow: visible; }
+  #body-area { flex-direction: column; overflow: visible; }
+  #left-panels { overflow: visible; }
+  #right-panel { width: 100%; flex-direction: row; justify-content: center; flex-wrap: wrap; }
   #retro-canvas { width: 150px !important; height: 150px !important; }
+  #header { flex-direction: column; align-items: stretch; gap: 4px; }
+  #header .menu-items { flex-wrap: wrap; justify-content: center; }
+  .panel-border-top, .panel-border-bottom { font-size: 12px; }
+  /* Tap-friendly controls */
+  .btn-retro { padding: 8px 16px; font-size: 16px; margin-bottom: 4px; }
+  .menu-btn { padding: 6px 10px; font-size: 16px; }
+  .adm-input { font-size: 16px; padding: 8px; flex-basis: 100%; }
+  .adm-form { flex-direction: column; align-items: stretch; }
+  .adm-form label { width: 100%; }
+  #terminal-container { min-height: 220px; }
+  /* Modals fill the small screen */
+  #wifi-modal, #help-modal {
+    min-width: 0;
+    width: 94vw;
+    max-width: 94vw;
+    max-height: 90vh;
+  }
 }
 </style>
 </head>
@@ -625,6 +738,87 @@ R"rawhtml(
                   <tr><td colspan="4" style="color:var(--dk-gray)">No active sessions</td></tr>
                 </tbody>
               </table>
+            </div>
+          </div>
+          <div class="panel-border-bottom">╚══════════════════════════════════════════════════════════════╝</div>
+        </div>
+
+        <!-- ADMIN / SECURITY PANEL -->
+        <div class="panel">
+          <div class="panel-border-top">╔══════════════════════════════════════════════════════════════╗</div>
+          <div class="panel-title"> ║ ▣ ADMIN / SECURITY</div>
+          <div class="panel-body">
+            <div id="admin-loading" style="color:var(--dk-gray);">Querying admin status...</div>
+
+            <!-- STATE A: not provisioned → set PIN -->
+            <div id="admin-setpin" style="display:none;">
+              <div class="adm-note">No admin PIN set. Create one to protect this device.</div>
+              <div class="adm-form">
+                <label for="adm-newpin">New PIN:</label>
+                <input class="adm-input" type="password" id="adm-newpin" inputmode="numeric" autocomplete="off" placeholder="min 4 chars">
+                <button class="btn-retro" onclick="adminSetPin()">⚿ Set PIN</button>
+              </div>
+            </div>
+
+            <!-- STATE B: provisioned, not authenticated → login -->
+            <div id="admin-login" style="display:none;">
+              <div class="adm-note">Admin login required.</div>
+              <div class="adm-form">
+                <label for="adm-pin">PIN:</label>
+                <input class="adm-input" type="password" id="adm-pin" inputmode="numeric" autocomplete="off" placeholder="Enter PIN">
+                <button class="btn-retro" onclick="adminLogin()">⮞ Login</button>
+              </div>
+            </div>
+
+            <!-- STATE C: authenticated -->
+            <div id="admin-loggedin" style="display:none;">
+              <div class="adm-msg adm-state-ok">● Logged in — admin controls unlocked.</div>
+              <div class="adm-form">
+                <button class="btn-retro" onclick="adminChangePinPrompt()" title="Set a new admin PIN">⚿ Change PIN</button>
+                <button class="btn-retro btn-danger" onclick="adminLogout()">⮜ Logout</button>
+              </div>
+            </div>
+
+            <!-- Inline change-pin (shown from STATE C) -->
+            <div id="admin-changepin" style="display:none;">
+              <div class="adm-form">
+                <label for="adm-changepin-val">New PIN:</label>
+                <input class="adm-input" type="password" id="adm-changepin-val" inputmode="numeric" autocomplete="off" placeholder="min 4 chars">
+                <button class="btn-retro" onclick="adminSetPin('change')">Save</button>
+                <button class="btn-retro btn-danger" onclick="document.getElementById('admin-changepin').style.display='none';">Cancel</button>
+              </div>
+            </div>
+
+            <div class="adm-msg" id="admin-msg"></div>
+          </div>
+          <div class="panel-border-bottom">╚══════════════════════════════════════════════════════════════╝</div>
+        </div>
+
+        <!-- FIRMWARE UPDATE (OTA) PANEL -->
+        <div class="panel">
+          <div class="panel-border-top">╔══════════════════════════════════════════════════════════════╗</div>
+          <div class="panel-title"> ║ ⬆ FIRMWARE UPDATE (OTA)</div>
+          <div class="panel-body">
+            <div class="ota-row"><span class="status-label">OTA Support ·</span><span class="status-value" id="ota-supported">—</span></div>
+            <div class="ota-row"><span class="status-label">Running ·····</span><span class="status-value" id="ota-running">—</span></div>
+            <div class="ota-row"><span class="status-label">Boot Part ···</span><span class="status-value" id="ota-boot">—</span></div>
+            <div class="ota-row"><span class="status-label">Next Part ···</span><span class="status-value" id="ota-next">—</span></div>
+            <div class="adm-msg" id="ota-state-msg" style="color:var(--dk-gray);"></div>
+
+            <div id="ota-controls" style="margin-top:4px;">
+              <div class="adm-note" id="ota-gate-note" style="display:none;">Admin login required to update firmware.</div>
+              <div class="adm-form">
+                <input class="adm-input" type="file" id="ota-file" accept=".bin">
+              </div>
+              <div id="ota-progress-wrap">
+                <div id="ota-progress-bar"></div>
+                <div id="ota-progress-text">0%</div>
+              </div>
+              <div class="adm-form">
+                <button class="btn-retro" id="ota-upload-btn" onclick="otaUpload()">⬆ Upload firmware</button>
+                <button class="btn-retro btn-danger" id="ota-reboot-btn" onclick="otaReboot()">⟳ Reboot device</button>
+              </div>
+              <div class="adm-msg" id="ota-msg"></div>
             </div>
           </div>
           <div class="panel-border-bottom">╚══════════════════════════════════════════════════════════════╝</div>
@@ -715,18 +909,19 @@ R"rawhtml(
     <div id="wifi-networks-list">
       <div style="color:var(--dk-gray);">Press "Scan Networks" to discover available WiFi...</div>
     </div>
+    <div id="wifi-admin-note" class="adm-note" style="display:none;">⚿ Admin login required for the controls below. Use the ADMIN / SECURITY panel to log in.</div>
     <div id="wifi-connect-form">
       <label>SSID: <span id="wifi-selected-ssid" style="color:var(--green);"></span></label>
       <label style="margin-top:4px;">Password:</label>
       <input type="password" id="wifi-password" placeholder="Enter network key...">
       <div style="margin-top:6px;">
-        <button class="btn-retro" onclick="connectWifi()">⚡ Connect</button>
+        <button class="btn-retro" id="wifi-connect-btn" onclick="connectWifi()">⚡ Connect</button>
         <button class="btn-retro btn-danger" onclick="cancelWifiConnect()">Cancel</button>
       </div>
     </div>
     <div style="margin-top:12px; border-top:1px dashed var(--dk-cyan); padding-top:8px;">
       <div style="font-size:14px; color:var(--dk-yellow); margin-bottom:4px;">Standalone AP Mode:</div>
-      <button class="btn-retro" onclick="startApMode()">⚡ Host Standalone AP</button>
+      <button class="btn-retro" id="wifi-ap-btn" onclick="startApMode()">⚡ Host Standalone AP</button>
       <div style="font-size:11px; color:var(--dk-cyan); margin-top:4px;">Persists across reboots. (Unconfigured devices auto-switch to Standalone ~5&nbsp;min after power-on.)</div>
     </div>
     <div style="margin-top:10px; border-top:1px dashed var(--dk-cyan); padding-top:8px;">
@@ -734,7 +929,7 @@ R"rawhtml(
     </div>
     <div style="margin-top:12px; border-top:1px dashed var(--dk-red); padding-top:8px;">
       <div style="font-size:14px; color:var(--dk-red); margin-bottom:4px;">Danger Zone:</div>
-      <button class="btn-retro btn-danger" onclick="factoryReset()">⚠ Factory Reset</button>
+      <button class="btn-retro btn-danger" id="wifi-reset-btn" onclick="factoryReset()">⚠ Factory Reset</button>
     </div>
   </div>
 </div>
@@ -753,6 +948,9 @@ let cmdHistory = [];
 let cmdHistoryIdx = -1;
 let oracleInterval = null;
 let selectedSSID = '';
+// Admin auth state: drives gating of dangerous controls + OTA.
+let adminState = { provisioned: false, authenticated: false };
+let otaUploading = false;
 )rawhtml"
 R"rawhtml(
 // ─── SYSTEM ORACLE WORD GENERATOR ───
@@ -961,12 +1159,20 @@ function processCommand(cmd) {
         termPrint(' Usage: kill <extension_number>', 'var(--red)');
       } else {
         const ext = parts[1];
+        if (adminState.provisioned && !adminState.authenticated) {
+          termPrint(' Admin login required. Open ADMIN / SECURITY panel to log in.', 'var(--red)');
+          break;
+        }
         termPrint(' Sending KILL signal to extension ' + ext + '...', 'var(--yellow)');
         fetch('/api/kill', {
           method: 'POST',
+          credentials: 'same-origin',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: 'extension=' + encodeURIComponent(ext)
-        }).then(r => r.text()).then(t => {
+        }).then(r => {
+          if (r.status === 401) { handleAuthExpired(); throw new Error('session expired — please log in'); }
+          return r.text();
+        }).then(t => {
           termPrint(' ' + (t || 'Extension terminated.'), 'var(--green)');
         }).catch(e => {
           termPrint(' ERROR: ' + e.message, 'var(--red)');
@@ -1248,9 +1454,13 @@ function connectWifi() {
 
   fetch('/api/wifi/connect', {
     method: 'POST',
+    credentials: 'same-origin',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: 'ssid=' + encodeURIComponent(selectedSSID) + '&password=' + encodeURIComponent(pw)
-  }).then(r => r.text()).then(t => {
+  }).then(r => {
+    if (r.status === 401) { handleAuthExpired(); throw new Error('session expired — please log in'); }
+    return r.text();
+  }).then(t => {
     statusEl.textContent = 'Connected to ' + selectedSSID + '!';
     statusEl.style.color = 'var(--green)';
     cancelWifiConnect();
@@ -1269,8 +1479,12 @@ function startApMode() {
 
   fetch('/api/wifi/mode_ap', {
     method: 'POST',
+    credentials: 'same-origin',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
-  }).then(r => r.json()).then(data => {
+  }).then(r => {
+    if (r.status === 401) { handleAuthExpired(); throw new Error('session expired — please log in'); }
+    return r.json();
+  }).then(data => {
     statusEl.textContent = 'Mode AP set! Rebooting...';
     statusEl.style.color = 'var(--green)';
     termPrint(' WiFi: Operational mode set to Standalone AP. Rebooting...', 'var(--green)');
@@ -1299,11 +1513,284 @@ function factoryReset() {
   if (statusEl) { statusEl.textContent = 'Factory resetting...'; statusEl.style.color = 'var(--red)'; }
   fetch('/api/factory-reset', {
     method: 'POST',
+    credentials: 'same-origin',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: 'confirm=ERASE'
-  }).then(r => r.json()).then(data => {
+  }).then(r => {
+    if (r.status === 401) { handleAuthExpired(); throw new Error('session expired — please log in'); }
+    return r.json();
+  }).then(data => {
     termPrint(' FACTORY RESET: ' + (data.message || 'Rebooting...'), 'var(--yellow)');
   }).catch(e => termPrint(' RESET ERROR: ' + e.message, 'var(--red)'));
+}
+
+// ═══════════════════════════════════════════════════════════════
+//   ADMIN / SECURITY — auth state machine + control gating
+// ═══════════════════════════════════════════════════════════════
+
+function setAdminMsg(text, color) {
+  const el = document.getElementById('admin-msg');
+  if (!el) return;
+  el.textContent = text || '';
+  el.style.color = color || 'var(--gray)';
+}
+
+// Fetch /api/admin/status and re-render the panel + gate all controls.
+function fetchAdminStatus() {
+  return fetch('/api/admin/status', { credentials: 'same-origin' })
+    .then(r => r.json())
+    .then(d => {
+      adminState.provisioned = !!d.provisioned;
+      adminState.authenticated = !!d.authenticated;
+      renderAdminPanel();
+      applyAuthGating();
+    })
+    .catch(() => { /* silent — leave last known state */ });
+}
+
+// Show exactly one of the three admin states.
+function renderAdminPanel() {
+  const loading   = document.getElementById('admin-loading');
+  const setpin    = document.getElementById('admin-setpin');
+  const login     = document.getElementById('admin-login');
+  const loggedin  = document.getElementById('admin-loggedin');
+  const changepin = document.getElementById('admin-changepin');
+  if (loading) loading.style.display = 'none';
+  setpin.style.display = 'none';
+  login.style.display = 'none';
+  loggedin.style.display = 'none';
+  changepin.style.display = 'none';
+
+  if (!adminState.provisioned) {
+    setpin.style.display = 'block';            // STATE A
+  } else if (!adminState.authenticated) {
+    login.style.display = 'block';             // STATE B
+  } else {
+    loggedin.style.display = 'block';          // STATE C
+  }
+}
+
+// A control is unlocked when the device is unprovisioned OR the admin is logged in.
+function controlsUnlocked() {
+  return !adminState.provisioned || adminState.authenticated;
+}
+
+// Enable/disable + show notes on every gated control (kill is handled in the
+// terminal command, this covers the button-driven controls + OTA).
+function applyAuthGating() {
+  const unlocked = controlsUnlocked();
+  ['wifi-connect-btn', 'wifi-ap-btn', 'wifi-reset-btn', 'ota-upload-btn', 'ota-reboot-btn']
+    .forEach(id => {
+      const btn = document.getElementById(id);
+      if (btn) btn.disabled = !unlocked;
+    });
+  const wifiNote = document.getElementById('wifi-admin-note');
+  if (wifiNote) wifiNote.style.display = unlocked ? 'none' : 'block';
+  const otaNote = document.getElementById('ota-gate-note');
+  if (otaNote) otaNote.style.display = unlocked ? 'none' : 'block';
+  const otaFile = document.getElementById('ota-file');
+  if (otaFile) otaFile.disabled = !unlocked;
+}
+
+// Called whenever a gated endpoint returns 401 mid-session.
+function handleAuthExpired() {
+  adminState.authenticated = false;
+  renderAdminPanel();
+  applyAuthGating();
+  setAdminMsg('Session expired — please log in.', 'var(--red)');
+  termPrint(' AUTH: session expired — please log in.', 'var(--red)');
+}
+
+// STATE A / change-pin: POST /api/admin/set-pin (allowed unprovisioned OR authed).
+function adminSetPin(mode) {
+  const inputId = (mode === 'change') ? 'adm-changepin-val' : 'adm-newpin';
+  const pin = document.getElementById(inputId).value;
+  if (!pin || pin.length < 4) {
+    setAdminMsg('PIN must be at least 4 characters.', 'var(--red)');
+    return;
+  }
+  fetch('/api/admin/set-pin', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'pin=' + encodeURIComponent(pin)
+  }).then(r => {
+    if (r.status === 401) { handleAuthExpired(); return; }
+    if (r.status === 400) { setAdminMsg('Invalid PIN (min 4 characters).', 'var(--red)'); return; }
+    if (!r.ok) { setAdminMsg('Failed to set PIN (HTTP ' + r.status + ').', 'var(--red)'); return; }
+    document.getElementById(inputId).value = '';
+    const cp = document.getElementById('admin-changepin');
+    if (cp) cp.style.display = 'none';
+    setAdminMsg('Admin PIN updated.', 'var(--green)');
+    termPrint(' ADMIN: PIN set.', 'var(--green)');
+    fetchAdminStatus();
+  }).catch(e => setAdminMsg('Error: ' + e.message, 'var(--red)'));
+}
+
+// STATE B: POST /api/admin/login.
+function adminLogin() {
+  const pin = document.getElementById('adm-pin').value;
+  if (!pin) { setAdminMsg('Enter your PIN.', 'var(--red)'); return; }
+  fetch('/api/admin/login', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'pin=' + encodeURIComponent(pin)
+  }).then(r => {
+    document.getElementById('adm-pin').value = '';
+    if (r.status === 401) { setAdminMsg('Incorrect PIN.', 'var(--red)'); return; }
+    if (r.status === 429) { setAdminMsg('Locked — wait a minute and try again.', 'var(--red)'); return; }
+    if (r.status === 409) { setAdminMsg('No PIN set yet. Set one first.', 'var(--red)'); fetchAdminStatus(); return; }
+    if (!r.ok) { setAdminMsg('Login failed (HTTP ' + r.status + ').', 'var(--red)'); return; }
+    setAdminMsg('Logged in.', 'var(--green)');
+    termPrint(' ADMIN: logged in.', 'var(--green)');
+    fetchAdminStatus();
+  }).catch(e => setAdminMsg('Error: ' + e.message, 'var(--red)'));
+}
+
+// STATE C: POST /api/admin/logout.
+function adminLogout() {
+  fetch('/api/admin/logout', { method: 'POST', credentials: 'same-origin' })
+    .then(() => {
+      setAdminMsg('Logged out.', 'var(--yellow)');
+      termPrint(' ADMIN: logged out.', 'var(--yellow)');
+      fetchAdminStatus();
+    })
+    .catch(e => setAdminMsg('Error: ' + e.message, 'var(--red)'));
+}
+
+function adminChangePinPrompt() {
+  const cp = document.getElementById('admin-changepin');
+  cp.style.display = (cp.style.display === 'block') ? 'none' : 'block';
+  if (cp.style.display === 'block') document.getElementById('adm-changepin-val').focus();
+}
+
+// Submit admin forms on Enter.
+['adm-newpin', 'adm-changepin-val'].forEach(id => {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener('keydown', e => {
+    if (e.key === 'Enter') adminSetPin(id === 'adm-changepin-val' ? 'change' : undefined);
+  });
+});
+(function() {
+  const el = document.getElementById('adm-pin');
+  if (el) el.addEventListener('keydown', e => { if (e.key === 'Enter') adminLogin(); });
+})();
+
+// ═══════════════════════════════════════════════════════════════
+//   FIRMWARE UPDATE (OTA)
+// ═══════════════════════════════════════════════════════════════
+
+function setOtaMsg(text, color) {
+  const el = document.getElementById('ota-msg');
+  if (!el) return;
+  el.textContent = text || '';
+  el.style.color = color || 'var(--gray)';
+}
+
+function fetchOtaStatus() {
+  return fetch('/api/ota/status', { credentials: 'same-origin' })
+    .then(r => r.json())
+    .then(d => {
+      const dash = '—';
+      document.getElementById('ota-supported').textContent =
+        d.otaSupported ? 'YES' : 'NO (host build)';
+      document.getElementById('ota-running').textContent =
+        d.running ? 'IN PROGRESS' : 'idle';
+      document.getElementById('ota-boot').textContent = d.boot || dash;
+      document.getElementById('ota-next').textContent = d.next || dash;
+      const stateMsg = document.getElementById('ota-state-msg');
+      if (d.pendingVerify) {
+        stateMsg.textContent = 'New firmware pending verification.';
+        stateMsg.style.color = 'var(--yellow)';
+      } else if (d.error) {
+        stateMsg.textContent = 'Last error: ' + d.error;
+        stateMsg.style.color = 'var(--red)';
+      } else {
+        stateMsg.textContent = '';
+      }
+    })
+    .catch(() => { /* silent */ });
+}
+
+// Upload raw .bin bytes via XHR so we get an upload progress %.
+function otaUpload() {
+  if (otaUploading) return;
+  if (!controlsUnlocked()) { setOtaMsg('Admin login required.', 'var(--red)'); return; }
+  const fileEl = document.getElementById('ota-file');
+  const file = fileEl && fileEl.files && fileEl.files[0];
+  if (!file) { setOtaMsg('Choose a firmware .bin file first.', 'var(--red)'); return; }
+
+  const wrap = document.getElementById('ota-progress-wrap');
+  const bar = document.getElementById('ota-progress-bar');
+  const text = document.getElementById('ota-progress-text');
+  wrap.style.display = 'block';
+  bar.style.width = '0%';
+  text.textContent = '0%';
+  otaUploading = true;
+  document.getElementById('ota-upload-btn').disabled = true;
+  setOtaMsg('Uploading ' + file.name + ' (' + file.size.toLocaleString() + ' bytes)...', 'var(--yellow)');
+
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/api/ota/upload', true);
+  xhr.withCredentials = true;          // send the HttpOnly session cookie
+  xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+
+  xhr.upload.onprogress = function(e) {
+    if (e.lengthComputable) {
+      const pct = Math.round((e.loaded / e.total) * 100);
+      bar.style.width = pct + '%';
+      text.textContent = pct + '%';
+    }
+  };
+
+  xhr.onload = function() {
+    otaUploading = false;
+    applyAuthGating();   // re-evaluate the upload button enabled state
+    if (xhr.status === 200) {
+      bar.style.width = '100%';
+      text.textContent = '100%';
+      let info = {};
+      try { info = JSON.parse(xhr.responseText); } catch (e) {}
+      setOtaMsg('Upload complete (' + (info.bytes || file.size) + ' bytes). Reboot to apply.', 'var(--green)');
+      termPrint(' OTA: upload complete. Reboot to apply.', 'var(--green)');
+      fetchOtaStatus();
+      if (info.rebootRequired && confirm('Firmware uploaded. Reboot now to apply the update?')) {
+        otaReboot(true);
+      }
+    } else if (xhr.status === 401) {
+      handleAuthExpired();
+      setOtaMsg('Session expired — please log in.', 'var(--red)');
+    } else if (xhr.status === 501) {
+      setOtaMsg('OTA only available on device (not in host build).', 'var(--red)');
+    } else {
+      setOtaMsg('Upload failed (HTTP ' + xhr.status + ').', 'var(--red)');
+    }
+  };
+
+  xhr.onerror = function() {
+    otaUploading = false;
+    applyAuthGating();
+    setOtaMsg('Upload failed — network error.', 'var(--red)');
+  };
+
+  xhr.send(file);   // raw bytes as the request body
+}
+
+function otaReboot(skipConfirm) {
+  if (!controlsUnlocked()) { setOtaMsg('Admin login required.', 'var(--red)'); return; }
+  if (!skipConfirm && !confirm('Reboot the device now? Any active calls will drop.')) return;
+  setOtaMsg('Rebooting device...', 'var(--yellow)');
+  termPrint(' OTA: reboot requested.', 'var(--yellow)');
+  fetch('/api/ota/reboot', { method: 'POST', credentials: 'same-origin' })
+    .then(r => {
+      if (r.status === 401) { handleAuthExpired(); return; }
+      setOtaMsg('Reboot signal sent. Device is restarting...', 'var(--green)');
+    })
+    .catch(() => {
+      // A dropped connection here is expected — the device is rebooting.
+      setOtaMsg('Reboot signal sent. Device is restarting...', 'var(--green)');
+    });
 }
 
 // ─── 3D WIREFRAME ROTATING TESSERACT ───
@@ -1437,7 +1924,12 @@ function factoryReset() {
 // ─── INIT ───
 bootSequence();
 fetchStatus();
+fetchAdminStatus();
+fetchOtaStatus();
 setInterval(fetchStatus, 3000);
+// Re-check auth + OTA state periodically (e.g. session lapses, OTA progress).
+setInterval(fetchAdminStatus, 15000);
+setInterval(() => { if (!otaUploading) fetchOtaStatus(); }, 15000);
 oracleInterval = setInterval(updateOracle, 12000);
 
 // Focus terminal on load (desktop only — avoid popping the mobile keyboard)

--- a/src/Helpers/index_html.h
+++ b/src/Helpers/index_html.h
@@ -666,6 +666,56 @@ input[type="file"].adm-input {
     max-height: 90vh;
   }
 }
+
+/* ─── PHOSPHOR THEME PALETTES ─── */
+/* Default (no class) keeps the classic CGA blue defined in :root above.
+   Each theme just remaps the few colour variables; the layout is untouched. */
+body.theme-green {
+  --bg:#001500; --bg-dark:#000a00; --panel-bg:rgba(0,40,0,0.55);
+  --fg:#33FF66; --cyan:#33FF99; --yellow:#9CFF6A; --green:#33FF66;
+  --magenta:#7CFF8A; --dk-cyan:#0a8040; --gray:#5fae6f; --dk-gray:#205028;
+  --glow-cyan:0 0 8px rgba(51,255,153,0.6),0 0 2px rgba(51,255,153,0.3);
+  --glow-white:0 0 8px rgba(51,255,102,0.5),0 0 2px rgba(51,255,102,0.2);
+}
+body.theme-amber {
+  --bg:#1a0f00; --bg-dark:#0d0700; --panel-bg:rgba(60,35,0,0.55);
+  --fg:#FFB000; --cyan:#FFC850; --yellow:#FFD773; --green:#FFB000;
+  --magenta:#FF9C3A; --dk-cyan:#a86a00; --gray:#b98a40; --dk-gray:#5a3a00;
+  --glow-cyan:0 0 8px rgba(255,200,80,0.6),0 0 2px rgba(255,200,80,0.3);
+  --glow-white:0 0 8px rgba(255,176,0,0.5),0 0 2px rgba(255,176,0,0.2);
+}
+body.theme-cga {
+  /* High-contrast CGA palette 1: cyan / magenta / white on black */
+  --bg:#000000; --bg-dark:#0a000a; --panel-bg:rgba(40,0,40,0.5);
+  --fg:#FFFFFF; --cyan:#55FFFF; --yellow:#FF55FF; --green:#55FFFF;
+  --magenta:#FF55FF; --dk-cyan:#00AAAA; --gray:#AAAAAA; --dk-gray:#555555;
+  --glow-cyan:0 0 8px rgba(85,255,255,0.6),0 0 2px rgba(85,255,255,0.3);
+  --glow-white:0 0 8px rgba(255,255,255,0.5),0 0 2px rgba(255,255,255,0.2);
+}
+body.theme-white {
+  /* Monochrome white phosphor */
+  --bg:#0a0a0a; --bg-dark:#000000; --panel-bg:rgba(40,40,40,0.5);
+  --fg:#E8E8E8; --cyan:#FFFFFF; --yellow:#FFFFFF; --green:#D8D8D8;
+  --magenta:#C8C8C8; --dk-cyan:#888888; --gray:#AAAAAA; --dk-gray:#555555;
+  --glow-cyan:0 0 8px rgba(255,255,255,0.55),0 0 2px rgba(255,255,255,0.3);
+  --glow-white:0 0 8px rgba(255,255,255,0.5),0 0 2px rgba(255,255,255,0.2);
+}
+/* The CRT flicker overlay tints toward the active background for cohesion */
+body.theme-green  #crt-monitor::after { background:rgba(0,40,0,0.04); }
+body.theme-amber  #crt-monitor::after { background:rgba(60,35,0,0.04); }
+body.theme-cga    #crt-monitor::after { background:rgba(40,0,40,0.04); }
+body.theme-white  #crt-monitor::after { background:rgba(60,60,60,0.04); }
+
+/* ─── ASCII OPERATOR / ABOUT BOX ─── */
+.ascii-operator {
+  color: var(--cyan);
+  text-shadow: var(--glow-cyan);
+  font-size: 13px;
+  line-height: 1.05;
+  white-space: pre;
+  margin: 0 0 8px 0;
+  text-align: center;
+}
 </style>
 </head>
 <body>
@@ -681,6 +731,8 @@ input[type="file"].adm-input {
         <button class="menu-btn" onclick="refreshNow()" title="Refresh">[F5 Refresh]</button>
         <button class="menu-btn" onclick="oracleSpeak()" title="Query Oracle">[F7 Oracle]</button>
         <button class="menu-btn" onclick="showWifi()" title="WiFi">[F9 WiFi]</button>
+        <button class="menu-btn" id="theme-btn" onclick="cyclePhosphor()" title="Cycle phosphor palette">[Phosphor]</button>
+        <button class="menu-btn" id="sound-btn" onclick="toggleSound()" title="Toggle UI sounds (off by default)">[Sound: OFF]</button>
       </div>
     </div>
 
@@ -870,6 +922,15 @@ input[type="file"].adm-input {
     <button class="btn-retro" onclick="closeHelp()">✕ Close</button>
   </div>
   <div id="help-modal-body">
+    <div class="ascii-operator">    .-"""""-.
+   /  _   _  \    ~ SWITCHBOARD OPERATOR ~
+   |  o   o  |    "Number, please?"
+   |    ^    |    .--.__.--.
+    \  '-'  /    (  patch  )
+     '-...-'      '--.  .--'
+    __|___|__        ||
+   [_O_____O_]   ====[]====
+   /  PBX-1  \   |  |  |  |</div>
     <span style="color:var(--yellow);">═══ CGA CRT SIP Switchboard v5.03 ═══</span><br><br>
     <span style="color:var(--cyan);">KEYBOARD SHORTCUTS:</span><br>
     <span style="color:var(--green);">  F1</span>  — This help screen<br>
@@ -888,7 +949,12 @@ input[type="file"].adm-input {
     <span style="color:var(--green);">  kill &lt;ext&gt;</span> — Terminate an extension<br>
     <span style="color:var(--green);">  clear</span>      — Clear terminal output<br>
     <span style="color:var(--green);">  ver</span>        — Show version info<br>
-    <span style="color:var(--green);">  ascii</span>      — Display classic bell ASCII art<br><br>
+    <span style="color:var(--green);">  ascii</span>      — Display classic bell ASCII art<br>
+    <span style="color:var(--green);">  about</span>      — Meet the switchboard operator<br>
+    <span style="color:var(--green);">  operator</span>   — Ring the operator for assistance<br>
+    <span style="color:var(--green);">  theme</span>      — Cycle phosphor palette<br>
+    <span style="color:var(--green);">  sound</span>      — Toggle UI sounds (off by default)<br>
+    <span style="color:var(--green);">  matrix</span>     — Follow the white rabbit<br><br>
     <span style="color:var(--dk-gray);">  "CGA CRT Console: 640x480 resolution, 16 vibrant colors, and pure low-latency SIP."</span><br>
   </div>
 )rawhtml"
@@ -951,6 +1017,15 @@ let selectedSSID = '';
 // Admin auth state: drives gating of dangerous controls + OTA.
 let adminState = { provisioned: false, authenticated: false };
 let otaUploading = false;
+// Whimsy state (pure client-side, persisted in localStorage).
+const PHOSPHOR_THEMES = ['cga', 'green', 'amber', 'cga2', 'white'];
+// Map the cycle key to the body class (cga2 = high-contrast cyan/magenta CGA).
+const PHOSPHOR_CLASS = { cga:'', green:'theme-green', amber:'theme-amber', cga2:'theme-cga', white:'theme-white' };
+const PHOSPHOR_LABEL = { cga:'CGA Blue', green:'Green', amber:'Amber', cga2:'Cyan/Mag', white:'White' };
+let phosphorIdx = 0;
+let soundEnabled = false;   // OPT-IN: never autoplay; defaults OFF.
+let audioCtx = null;        // lazily created on first user gesture.
+let matrixTimer = null;
 )rawhtml"
 R"rawhtml(
 // ─── SYSTEM ORACLE WORD GENERATOR ───
@@ -1046,10 +1121,33 @@ function bootSequence() {
     { t: 'System Oracle ....... ACTIVE', c: 'var(--green)' },
     { t: 'RNG seed generated .. 0x' + Math.floor(Math.random()*0xFFFFFFFF).toString(16).toUpperCase(), c: 'var(--magenta)' },
     { t: '' },
+    { t: '>>> SWITCHBOARD ONLINE — operator standing by <<<', c: 'var(--magenta)' },
     { t: 'System ready. Type "help" for commands.', c: 'var(--fg)' },
     { t: '' },
   ];
   bootLines.forEach(l => termPrint(l.t, l.c));
+}
+
+// A brief, skippable typewriter flourish shown ONCE on first load.
+// It never blocks usability: the dashboard is already interactive underneath.
+function bootFlourish() {
+  const msg = '☼  CGA CRT SWITCHBOARD ONLINE — patching you through  ☼';
+  const line = document.createElement('div');
+  line.style.color = 'var(--cyan)';
+  line.style.textShadow = 'var(--glow-cyan)';
+  termOutput.insertBefore(line, termOutput.firstChild);
+  let i = 0;
+  const skip = () => { line.textContent = msg; cleanup(); };
+  function cleanup() {
+    document.removeEventListener('keydown', skip, true);
+    termOutput.removeEventListener('click', skip, true);
+  }
+  document.addEventListener('keydown', skip, true);
+  termOutput.addEventListener('click', skip, true);
+  const timer = setInterval(() => {
+    if (i >= msg.length) { clearInterval(timer); cleanup(); return; }
+    line.textContent = msg.slice(0, ++i);
+  }, 18);   // ~0.7s total; fast and non-blocking
 }
 
 function processCommand(cmd) {
@@ -1077,6 +1175,11 @@ function processCommand(cmd) {
       termPrint('  clear       Clear terminal output', 'var(--cyan)');
       termPrint('  ver         Show version info', 'var(--cyan)');
       termPrint('  ascii       Display classic bell ASCII art', 'var(--cyan)');
+      termPrint('  about       Meet the switchboard operator', 'var(--cyan)');
+      termPrint('  operator    Ring the operator for assistance', 'var(--cyan)');
+      termPrint('  theme       Cycle phosphor palette', 'var(--cyan)');
+      termPrint('  sound       Toggle UI sounds (off by default)', 'var(--cyan)');
+      termPrint('  matrix      Follow the white rabbit', 'var(--cyan)');
       termPrint('');
       break;
 
@@ -1213,6 +1316,37 @@ function processCommand(cmd) {
       break;
 )rawhtml"
 R"rawhtml(
+    case 'about':
+      termPrint('');
+      printOperator();
+      termPrint('');
+      termPrint(' CGA CRT SipServer — a retro-console SIP switchboard.', 'var(--yellow)');
+      termPrint(' Hand-soldered phosphor, vacuum-tube vibes, zero spoons.', 'var(--gray)');
+      termPrint('');
+      break;
+
+    case 'operator':
+      termPrint('');
+      printOperator();
+      termPrint('');
+      termPrint(' OPERATOR: "Switchboard online. One moment, connecting you now..."', 'var(--magenta)');
+      ringPreview();
+      termPrint('');
+      break;
+
+    case 'theme':
+      cyclePhosphor();
+      break;
+
+    case 'sound':
+      toggleSound();
+      break;
+
+    case 'matrix':
+      termPrint('');
+      matrixRain();
+      break;
+
     default:
       termPrint(' Unknown command: "' + escapeHtml(command) + '". Type "help" for commands.', 'var(--red)');
       break;
@@ -1793,6 +1927,138 @@ function otaReboot(skipConfirm) {
     });
 }
 
+// ═══════════════════════════════════════════════════════════════
+//   WHIMSY — phosphor themes, opt-in audio, terminal easter eggs
+//   (all pure client-side; no backend calls, no external assets)
+// ═══════════════════════════════════════════════════════════════
+
+// ─── PHOSPHOR THEME SWITCHER (persisted) ───
+function applyPhosphor(idx) {
+  phosphorIdx = ((idx % PHOSPHOR_THEMES.length) + PHOSPHOR_THEMES.length) % PHOSPHOR_THEMES.length;
+  const key = PHOSPHOR_THEMES[phosphorIdx];
+  // Remove every theme class, then add the active one (blank = default CGA blue).
+  Object.values(PHOSPHOR_CLASS).forEach(c => { if (c) document.body.classList.remove(c); });
+  if (PHOSPHOR_CLASS[key]) document.body.classList.add(PHOSPHOR_CLASS[key]);
+  const btn = document.getElementById('theme-btn');
+  if (btn) btn.textContent = '[' + PHOSPHOR_LABEL[key] + ']';
+  try { localStorage.setItem('cga.phosphor', key); } catch (e) {}
+}
+function cyclePhosphor() {
+  blip(660);
+  applyPhosphor(phosphorIdx + 1);
+  termPrint(' Phosphor palette: ' + PHOSPHOR_LABEL[PHOSPHOR_THEMES[phosphorIdx]], 'var(--cyan)');
+}
+function restorePhosphor() {
+  let key = 'cga';
+  try { key = localStorage.getItem('cga.phosphor') || 'cga'; } catch (e) {}
+  const i = PHOSPHOR_THEMES.indexOf(key);
+  applyPhosphor(i >= 0 ? i : 0);
+}
+
+// ─── OPT-IN AUDIO (WebAudio, no files, OFF by default, no autoplay) ───
+function ensureAudio() {
+  if (!soundEnabled) return null;
+  const AC = window.AudioContext || window.webkitAudioContext;
+  if (!AC) return null;
+  if (!audioCtx) { try { audioCtx = new AC(); } catch (e) { return null; } }
+  if (audioCtx.state === 'suspended') { audioCtx.resume().catch(() => {}); }
+  return audioCtx;
+}
+// A tiny percussive blip — used for clicks (cheap: one oscillator, ~60ms).
+function blip(freq) {
+  const ctx = ensureAudio();
+  if (!ctx) return;
+  const t = ctx.currentTime;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(freq || 880, t);
+  gain.gain.setValueAtTime(0.0001, t);
+  gain.gain.exponentialRampToValueAtTime(0.06, t + 0.005);
+  gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.06);
+  osc.connect(gain); gain.connect(ctx.destination);
+  osc.start(t); osc.stop(t + 0.07);
+}
+// A soft two-tone ring preview (classic 440/480Hz cadence, single short burst).
+function ringPreview() {
+  const ctx = ensureAudio();
+  if (!ctx) { termPrint(' (enable [Sound] to hear the ring preview)', 'var(--dk-gray)'); return; }
+  const t = ctx.currentTime;
+  [440, 480].forEach(f => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(f, t);
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.exponentialRampToValueAtTime(0.05, t + 0.02);
+    gain.gain.setValueAtTime(0.05, t + 0.55);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.7);
+    osc.connect(gain); gain.connect(ctx.destination);
+    osc.start(t); osc.stop(t + 0.72);
+  });
+}
+function toggleSound() {
+  soundEnabled = !soundEnabled;
+  const btn = document.getElementById('sound-btn');
+  if (btn) btn.textContent = '[Sound: ' + (soundEnabled ? 'ON' : 'OFF') + ']';
+  try { localStorage.setItem('cga.sound', soundEnabled ? '1' : '0'); } catch (e) {}
+  if (soundEnabled) {
+    ensureAudio();   // create within this user gesture so it's allowed to play
+    blip(880);
+    termPrint(' Audio enabled. Try the "operator" command for a ring preview.', 'var(--green)');
+  } else {
+    termPrint(' Audio muted.', 'var(--gray)');
+  }
+}
+function restoreSound() {
+  let on = false;
+  try { on = localStorage.getItem('cga.sound') === '1'; } catch (e) {}
+  soundEnabled = on;
+  const btn = document.getElementById('sound-btn');
+  if (btn) btn.textContent = '[Sound: ' + (on ? 'ON' : 'OFF') + ']';
+  // NOTE: do NOT create/resume AudioContext here — that would be autoplay.
+}
+
+// ─── MATRIX RAIN (terminal easter egg; auto-stops, key/click to abort) ───
+function matrixRain() {
+  if (matrixTimer) return;
+  termPrint(' Wake up... following the white rabbit. (press any key to stop)', 'var(--green)');
+  const glyphs = '01<>{}[]#$%&*+=ｦｱｳｴｵｶｷｸｹｺﾅﾆﾇﾉ';
+  let frames = 0;
+  function stop() {
+    if (!matrixTimer) return;
+    clearInterval(matrixTimer); matrixTimer = null;
+    document.removeEventListener('keydown', stop, true);
+    termOutput.removeEventListener('click', stop, true);
+    termPrint(' ...there is no spoon.', 'var(--dk-gray)');
+  }
+  matrixTimer = setInterval(() => {
+    let row = '';
+    const n = 44;
+    for (let i = 0; i < n; i++) row += glyphs[Math.floor(Math.random() * glyphs.length)];
+    termPrint(row, 'var(--green)');
+    if (++frames >= 24) stop();
+  }, 70);
+  document.addEventListener('keydown', stop, true);
+  termOutput.addEventListener('click', stop, true);
+}
+
+// ─── ASCII OPERATOR (about box, rendered into the terminal) ───
+function printOperator() {
+  const art = [
+    "    .-\"\"\"\"\"-.",
+    "   /  _   _  \\     ~ SWITCHBOARD OPERATOR ~",
+    "   |  o   o  |     \"Number, please?\"",
+    "   |    ^    |      .--.__.--.",
+    "    \\  '-'  /      (  patch   )",
+    "     '-...-'        '--.  .--'",
+    "    __|___|__          ||",
+    "   [_O_____O_]     ====[]====",
+    "   /  PBX-1  \\     |  |  |  |",
+  ];
+  art.forEach(l => termPrint(l, 'var(--cyan)'));
+}
+
 // ─── 3D WIREFRAME ROTATING TESSERACT ───
 (function() {
   const canvas = document.getElementById('retro-canvas');
@@ -1922,7 +2188,14 @@ function otaReboot(skipConfirm) {
 })();
 
 // ─── INIT ───
+restorePhosphor();          // apply persisted palette before first paint settles
+restoreSound();             // restore the toggle label (does NOT start audio)
 bootSequence();
+bootFlourish();             // one quick, skippable typewriter line on top
+// Subtle click blip on any button press (only audible once Sound is enabled).
+document.addEventListener('click', function(e) {
+  if (e.target && e.target.closest && e.target.closest('button')) blip(720);
+}, true);
 fetchStatus();
 fetchAdminStatus();
 fetchOtaStatus();

--- a/src/SIP/CallDetailRecord.hpp
+++ b/src/SIP/CallDetailRecord.hpp
@@ -1,0 +1,58 @@
+#ifndef CALL_DETAIL_RECORD_HPP
+#define CALL_DETAIL_RECORD_HPP
+
+// CallDetailRecord.hpp — fixed-footprint Call Detail Record (CDR) types.
+//
+// A CDR is written exactly once, as a call tears down (see RequestsHandler::
+// recordCdr, invoked from endCall()). Records are kept in a fixed-capacity ring
+// buffer (POCKETDIAL_CDR_RECORDS) so the memory cost is paid statically at boot
+// and never grows on the heap — consistent with the SIP object pools (see
+// PoolConfig.hpp). The newest record overwrites the oldest once the ring is full.
+
+#include <string>
+#include <cstdint>
+
+// Number of Call Detail Records retained in the ring buffer. Compile-time
+// tunable (-DPOCKETDIAL_CDR_RECORDS=N). The default of 32 mirrors the client
+// pool depth and keeps the static footprint modest on the ESP32-S3.
+#ifndef POCKETDIAL_CDR_RECORDS
+#define POCKETDIAL_CDR_RECORDS 32
+#endif
+
+// How a call ended. Derived from the Session's final state at teardown.
+enum class CdrResult
+{
+	Answered,    // the call connected (Session reached Connected)
+	Busy,        // callee was busy (486)
+	Cancelled,   // caller hung up before answer (CANCEL / 487)
+	Unavailable, // callee unavailable (480) or no answer
+	Failed       // anything else (parse error, forced disconnect, ...)
+};
+
+inline const char* cdrResultToString(CdrResult r)
+{
+	switch (r)
+	{
+		case CdrResult::Answered:    return "answered";
+		case CdrResult::Busy:        return "busy";
+		case CdrResult::Cancelled:   return "cancelled";
+		case CdrResult::Unavailable: return "unavailable";
+		case CdrResult::Failed:      return "failed";
+		default:                     return "failed";
+	}
+}
+
+// One completed call. Strings are short SIP AORs (extensions); they are bounded
+// by the registrar's isValidAor() validation on ingress, so they cannot grow
+// without limit. A CDR is a value type copied into the dashboard snapshot.
+struct CallDetailRecord
+{
+	std::string caller;       // calling extension (From)
+	std::string callee;       // called extension (To)
+	uint64_t    startMs = 0;  // steady-clock epoch ms when the call started
+	                          // (same basis as HttpServer uptime)
+	uint32_t    durationSec = 0; // talk time in seconds (0 if never connected)
+	CdrResult   result = CdrResult::Failed;
+};
+
+#endif

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -9,6 +9,7 @@
 #include "IDGen.hpp"
 #include "IPHelper.hpp"
 #include "PoolConfig.hpp"
+#include "CallDetailRecord.hpp"
 
 std::vector<std::shared_ptr<SipMessage>> RequestsHandler::_messagePool;
 
@@ -447,6 +448,22 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
+	// Do Not Disturb (Phase 2): if the target extension has DND enabled, decline
+	// with 480 Temporarily Unavailable instead of ringing it. This branch is reached
+	// only for ordinary extensions — the virtual 777 (echo) and 999 (broadcast)
+	// extensions are handled above and so are never affected by DND.
+	if (isDndEnabled(destNumber))
+	{
+		auto response = getMessageFromPool(data->toString(), data->getSource());
+		response->setHeader("SIP/2.0 480 Temporarily Unavailable");
+		response->clearBody();
+		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		response->setContact(buildContact(caller.value()->getNumber()));
+		endHandle(data->getFromNumber(), response);
+		return;
+	}
+
 	// Check if the called is registered
 	auto called = findClient(data->getToNumber());
 	if (!called.has_value())
@@ -816,8 +833,19 @@ bool RequestsHandler::setCallState(std::string_view callID, Session::State state
 
 void RequestsHandler::endCall(std::string_view callID, std::string_view srcNumber, std::string_view destNumber, std::string_view reason)
 {
+	// Capture the session (for CDR start time / final state) BEFORE we erase it.
+	std::shared_ptr<Session> ending;
+	auto sit = _sessions.find(std::string(callID));
+	if (sit != _sessions.end())
+	{
+		ending = sit->second;
+	}
+
 	if (_sessions.erase(std::string(callID)) > 0)
 	{
+		// Record exactly once per torn-down dialog (Phase 2 CDR).
+		recordCdr(ending, srcNumber, destNumber);
+
 		std::ostringstream message;
 		message << "Session has been disconnected between " << srcNumber << " and " << destNumber;
 		if (!reason.empty())
@@ -834,6 +862,70 @@ void RequestsHandler::endCall(std::string_view callID, std::string_view srcNumbe
 			session->release();
 			break;
 		}
+	}
+}
+
+uint64_t RequestsHandler::nowEpochMs() const
+{
+	return static_cast<uint64_t>(
+		std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+void RequestsHandler::recordCdr(const std::shared_ptr<Session>& session,
+	std::string_view srcNumber, std::string_view destNumber)
+{
+	CallDetailRecord rec;
+	rec.caller = std::string(srcNumber);
+	rec.callee = std::string(destNumber);
+
+	uint64_t startMs = nowEpochMs();
+	uint32_t durationSec = 0;
+	CdrResult result = CdrResult::Failed;
+
+	if (session)
+	{
+		auto now = std::chrono::steady_clock::now();
+		startMs = static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				session->getStartTime().time_since_epoch()).count());
+
+		switch (session->getState())
+		{
+			// Both Connected and Bye are "answered": a normal call ends via BYE, which
+			// sets the state to Bye (NOT Connected) just before endCall() runs, while
+			// the echo (777) path tears down straight from Connected. Session::setState
+			// resets _startTime to the connect instant on the Connected transition and
+			// the later Bye transition does NOT touch it, so getStartTime() still marks
+			// the answer instant in both cases — talk time is now - startTime.
+			case Session::State::Connected:
+			case Session::State::Bye:
+				result = CdrResult::Answered;
+				{
+					int64_t secs = static_cast<int64_t>(
+						std::chrono::duration_cast<std::chrono::seconds>(
+							now - session->getStartTime()).count());
+					if (secs < 0) secs = 0;
+					durationSec = static_cast<uint32_t>(secs);
+				}
+				break;
+			case Session::State::Busy:        result = CdrResult::Busy;        break;
+			case Session::State::Cancel:      result = CdrResult::Cancelled;   break;
+			case Session::State::Unavailable: result = CdrResult::Unavailable; break;
+			default:                          result = CdrResult::Failed;      break;
+		}
+	}
+
+	rec.startMs = startMs;
+	rec.durationSec = durationSec;
+	rec.result = result;
+
+	// Fixed ring write: overwrite the oldest slot once full (no heap growth).
+	_cdrRing[_cdrHead] = std::move(rec);
+	_cdrHead = (_cdrHead + 1) % POCKETDIAL_CDR_RECORDS;
+	if (_cdrCount < POCKETDIAL_CDR_RECORDS)
+	{
+		++_cdrCount;
 	}
 }
 
@@ -1097,6 +1189,76 @@ uint64_t RequestsHandler::getPacketsDropped() const
 	return _packetsDropped.load(std::memory_order_relaxed);
 }
 
+std::vector<CallDetailRecord> RequestsHandler::getCallDetailRecords()
+{
+	std::lock_guard<std::mutex> lock(_snapshotMutex);
+	return _snapshot.cdr;
+}
+
+void RequestsHandler::setDnd(const std::string& extension, bool on)
+{
+	std::vector<std::pair<bool, std::string>> localLogs;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+		if (on)
+		{
+			// Bound the map so a flood of distinct extensions can't grow the heap
+			// without limit. Mirror the client-pool cap; reject new keys past it.
+			if (_dnd.find(extension) == _dnd.end() &&
+				_dnd.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
+			{
+				queueLog("DND set ignored (table full) for extension " + extension, true);
+			}
+			else
+			{
+				_dnd[extension] = true;
+			}
+		}
+		else
+		{
+			// Turning DND off frees the slot, so the map only ever holds the
+			// extensions that are actively in DND (bounded by registrations).
+			_dnd.erase(extension);
+		}
+		queueLog("DND " + std::string(on ? "enabled" : "disabled") + " for extension " + extension);
+
+		// Refresh the DND view in the dashboard snapshot immediately so the UI
+		// reflects the change without waiting for the next tick().
+		{
+			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+			_snapshot.dnd.clear();
+			_snapshot.dnd.reserve(_dnd.size());
+			for (const auto& [ext, enabled] : _dnd)
+			{
+				if (enabled) _snapshot.dnd.push_back(ext);
+			}
+		}
+
+		localLogs = std::move(_logQueue);
+		_logQueue.clear();
+	}
+
+	for (const auto& log : localLogs)
+	{
+		if (log.first) std::cerr << log.second << std::endl;
+		else std::cout << log.second << std::endl;
+	}
+}
+
+bool RequestsHandler::isDndEnabled(const std::string& extension)
+{
+	// Internal lookup: invoked from onInvite() which already holds _mutex, so this
+	// must NOT take _mutex (std::mutex is non-recursive). Bounded map lookup.
+	auto it = _dnd.find(extension);
+	return it != _dnd.end() && it->second;
+}
+
+std::vector<std::string> RequestsHandler::getDndExtensions()
+{
+	std::lock_guard<std::mutex> lock(_snapshotMutex);
+	return _snapshot.dnd;
+}
+
 size_t RequestsHandler::getClientCount()
 {
 	std::lock_guard<std::mutex> lock(_snapshotMutex);
@@ -1176,6 +1338,22 @@ void RequestsHandler::tick()
 					now - session->getStartTime()).count());
 			}
 			nextSnapshot.sessions.emplace_back(caller, callee, sessionStateToString(session->getState()), durationSec);
+		}
+
+		// CDR view: copy the ring out newest-first into the snapshot.
+		nextSnapshot.cdr.reserve(_cdrCount);
+		for (size_t i = 0; i < _cdrCount; ++i)
+		{
+			// _cdrHead points one past the newest; walk backwards with wrap.
+			size_t idx = (_cdrHead + POCKETDIAL_CDR_RECORDS - 1 - i) % POCKETDIAL_CDR_RECORDS;
+			nextSnapshot.cdr.push_back(_cdrRing[idx]);
+		}
+
+		// DND view: extensions currently in DND.
+		nextSnapshot.dnd.reserve(_dnd.size());
+		for (const auto& [ext, enabled] : _dnd)
+		{
+			if (enabled) nextSnapshot.dnd.push_back(ext);
 		}
 
 		{

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -21,9 +21,11 @@
 #include <cstdint>
 #include <atomic>
 #include <chrono>
+#include <array>
 #include "SipMessage.hpp"
 #include "SipClient.hpp"
 #include "Session.hpp"
+#include "CallDetailRecord.hpp"
 
 class RequestsHandler
 {
@@ -50,6 +52,17 @@ public:
 	size_t getClientCount();
 	size_t getSessionCount();
 
+	// Call Detail Records (CDR): a thread-safe snapshot of the recent-call ring,
+	// newest first. Copied out under _snapshotMutex like the client/session views.
+	std::vector<CallDetailRecord> getCallDetailRecords();
+
+	// Do Not Disturb (DND): set/query a per-extension flag. setDnd is the mutating
+	// path behind POST /api/dnd (thread-safe; takes _mutex). getDndExtensions
+	// returns the set of extensions currently in DND from the dashboard snapshot
+	// (thread-safe; takes _snapshotMutex). Both are safe to call off the SIP thread.
+	void setDnd(const std::string& extension, bool on);
+	std::vector<std::string> getDndExtensions();
+
 private:
 	void initHandlers();
 
@@ -69,6 +82,18 @@ private:
 
 	bool setCallState(std::string_view callID, Session::State state);
 	void endCall(std::string_view callID, std::string_view srcNumber, std::string_view destNumber, std::string_view reason = "");
+
+	// CDR: write one record into the ring as a call ends. Caller must hold _mutex.
+	// `session` (may be null) supplies the start time / final state used to derive
+	// duration and result; src/dest provide the parties when the session lookup
+	// can't (e.g. the virtual 777/999 extensions reuse a shared dummy client).
+	void recordCdr(const std::shared_ptr<Session>& session,
+		std::string_view srcNumber, std::string_view destNumber);
+	uint64_t nowEpochMs() const;
+
+	// Internal DND lookup used by onInvite(). Caller MUST already hold _mutex
+	// (std::mutex is non-recursive); does a bounded map lookup, no locking.
+	bool isDndEnabled(const std::string& extension);
 
 	bool registerClient(std::shared_ptr<SipClient> client);
 	void unregisterClient(std::string_view number);
@@ -124,11 +149,27 @@ private:
 	{
 		std::vector<std::pair<std::string, std::string>> clients;
 		std::vector<std::tuple<std::string, std::string, std::string, int>> sessions;
+		std::vector<CallDetailRecord> cdr;   // newest first
+		std::vector<std::string> dnd;        // extensions currently in DND
 		uint64_t packetsProcessed = 0;
 		uint64_t packetsDropped = 0;
 	};
 	RegistrarSnapshot _snapshot;
 	std::mutex _snapshotMutex;
+
+	// CDR ring buffer (Phase 2). Fixed capacity, no heap growth: writes wrap and
+	// overwrite the oldest slot. All access is under _mutex. _cdrHead is the index
+	// of the NEXT slot to write; _cdrCount caps at POCKETDIAL_CDR_RECORDS.
+	std::array<CallDetailRecord, POCKETDIAL_CDR_RECORDS> _cdrRing;
+	size_t _cdrHead = 0;
+	size_t _cdrCount = 0;
+
+	// DND state, keyed by extension. Bounded by the client-pool depth: an entry is
+	// only created when DND is turned ON, and turning it OFF erases the entry, so
+	// the map can never hold more than POCKETDIAL_MAX_CLIENTS live extensions.
+	// Guarded by _mutex. (A std::shared_ptr<SipClient> flag would be lost across
+	// re-REGISTER / pool eviction; keying by extension keeps DND sticky.)
+	std::unordered_map<std::string, bool> _dnd;
 
 	// Pre-allocated static memory pools (Issue #53)
 	std::vector<std::shared_ptr<SipClient>> _clientPool;

--- a/tests/load/STRESS_FINDINGS.md
+++ b/tests/load/STRESS_FINDINGS.md
@@ -1,0 +1,77 @@
+# Stress / Load Test Findings — pocket-dial (display build, ESP32-S3)
+
+Measured against a live JC3248W535 display board running the Phase-2 firmware,
+joined to a LAN in **STATION mode** (`192.168.12.159`), from a host on the same
+subnet using `tests/load/sip_stress.py`. ESP-IDF v5.3.5, default optimization.
+
+## TL;DR
+- **Single requests are fast and correct.** SIP `OPTIONS` → `200 OK` in **6–81 ms**
+  (first packet slower, warm path ~6 ms). The SIP engine itself is healthy.
+- **Bursts from a single source are dropped**, by design + by buffer limits.
+- **The display build degrades in STATION mode**: `lvgl_task` starves the Core-1
+  idle task (task-WDT warnings), and the HTTP server accepts a TCP connection
+  then resets it without responding. These are **pre-existing display-firmware
+  behaviors**, not caused by Phase-2 code (lock ordering verified clean; the SIP
+  engine + host build are unaffected).
+
+## What works
+| Probe | Result |
+|-------|--------|
+| ICMP ping (host → device) | 0% loss, 2–6 ms |
+| SIP `OPTIONS` (idle) | `200 OK`, 6–81 ms |
+| TCP connect :80 | succeeds |
+| SIP engine logic (host build, CI) | 29/29 smoke + unit tests pass |
+
+## Findings
+
+### 1. UDP receive mailbox = 6 (burst ceiling)
+Boot log reports `udp mbox: 6` (`CONFIG_LWIP_UDP_RECVMBOX_SIZE`). A burst of ~30
+simultaneous SIP packets from one host overruns this queue at the lwip layer, so
+most are dropped before the SIP task sees them. 30 parallel REGISTERs → 0
+responses; the same REGISTER sent singly succeeds.
+- **Fix to absorb bursts:** raise `CONFIG_LWIP_UDP_RECVMBOX_SIZE` (e.g. 16–32) and
+  `CONFIG_LWIP_TCPIP_RECVMBOX_SIZE`. Costs a little DRAM (we have ~200 KB free).
+
+### 2. Per-source-IP rate limiter (working as designed — Issue #38)
+Token bucket ~40 burst / 20 pkt/s sustained **per source IP**. A single-host load
+generator cannot exceed this no matter how many virtual UAs it runs — that is the
+DoS protection doing its job. Real fleets register from many IPs. To load past it
+for testing, use multiple source hosts or temporarily widen the bucket.
+
+### 3. `lvgl_task` starves Core-1 idle task in STATION mode (task-WDT)
+On a **quiet** STA-mode boot the task watchdog fires repeatedly:
+`Task watchdog got triggered … IDLE1 (CPU 1) … CPU 1: lvgl_task`. The display
+render task monopolizes Core 1 (where it is pinned; SIP+HTTP run on Core 0). The
+first AP-mode boot of the session did **not** show this, so it correlates with
+STA mode (more Wi-Fi/event logging → the on-screen log terminal re-renders
+constantly → lvgl never yields enough for IDLE1).
+- **Candidate fixes:** throttle/coalesce the on-screen log terminal so it doesn't
+  invalidate the screen per log line; add a small `vTaskDelay` floor in the LVGL
+  loop; or, if lvgl legitimately needs the core, set
+  `CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=n` (masks the warning only).
+
+### 4. HTTP server wedges in STATION mode
+`/api/status` and `/` time out even when idle: the server **accepts** the TCP
+connection (slow, ~1 s) then **RSTs it without an HTTP response**. SIP (also
+Core 0) keeps answering `OPTIONS`, so the UDP path is alive — the TCP/HTTP accept
+loop specifically is not servicing requests in STA mode. Not reproduced on the
+host build (CI `/api/status` smoke test passes), so it is device/STA-specific.
+- **Investigate:** the HTTP accept loop's interaction with STA-mode netif / the
+  captive-portal branch / Core-0 scheduling while `lvgl_task` saturates Core 1.
+
+## Recommended next steps (priority order)
+1. Fix the on-screen log → LVGL render storm (root of the Core-1 WDT). P0 for the
+   display build's stability under any real traffic.
+2. Investigate the STA-mode HTTP accept-then-RST wedge. P0 for dashboard usability
+   off the SoftAP.
+3. Raise `CONFIG_LWIP_UDP_RECVMBOX_SIZE` to absorb signaling bursts. P1.
+4. Re-run this suite from **multiple source hosts** (to bypass the per-IP limiter)
+   once 1–2 are fixed, to get true concurrent-registration / call-setup ceilings.
+
+## Running the suite
+```
+python tests/load/sip_stress.py --host <device-ip> --clients 30 --echo-calls 8
+python tests/load/sip_stress.py --host <device-ip> --register-only --pace 0.1
+```
+`--pace` (seconds between launches) keeps you under the rate limiter / mailbox.
+The tool samples `GET /api/status` for server-side packet & pool counters.

--- a/tests/load/STRESS_FINDINGS.md
+++ b/tests/load/STRESS_FINDINGS.md
@@ -75,3 +75,26 @@ python tests/load/sip_stress.py --host <device-ip> --register-only --pace 0.1
 ```
 `--pace` (seconds between launches) keeps you under the rate limiter / mailbox.
 The tool samples `GET /api/status` for server-side packet & pool counters.
+
+---
+
+## Update — findings #3 & #4 FIXED (verified on hardware)
+
+Both STA-mode issues are resolved (commit `b04ecac`):
+- **Core-1 lvgl watchdog** → fixed by coalescing/rate-limiting the on-screen log
+  in `lvgl_task` (≤8 lines / 150 ms). Zero `task_wdt` lines on boot; servers up at
+  ~6 s (was ~11 s).
+- **HTTP accept-then-RST** → root cause was the accept loop's **3 KB pthread stack**
+  (`std::thread`); `sendApiStatus` overflowed it on-device. Fixed with
+  `CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=8192` + bind `INADDR_ANY`.
+
+### Real numbers (paced ~10/s, single source, post-fix)
+| Operation | Success | p50 | p95 | max |
+|-----------|---------|-----|-----|-----|
+| REGISTER  | 20/20 (100%) | 8.6 ms | 25.8 ms | 121 ms |
+| Echo call (777) | 5/5 (100%) | 13.3 ms | 19.9 ms | 21 ms |
+
+`/api/status`: 150 ms; `/api/cdr`: 17 ms; full dashboard `/`: ~6 s (84 KB, one-time).
+Server counters: 21 clients registered, packetsDropped ~2. Still recommend raising
+`CONFIG_LWIP_UDP_RECVMBOX_SIZE` for higher single-source burst tolerance, and testing
+from multiple IPs to find the true concurrency ceiling.

--- a/tests/load/sip_stress.py
+++ b/tests/load/sip_stress.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+pocket-dial SIP load / stress tester  (stdlib-only, no deps)
+
+Registers virtual SIP user-agents and places echo-test (777) calls against a
+pocket-dial registrar, measuring registration + call-setup latency, throughput,
+and the static-pool / rate-limit ceilings. Also samples the HTTP /api/status
+endpoint for server-side packet & pool counters.
+
+NOTE: pocket-dial rate-limits per SOURCE IP (token bucket, ~40 burst / 20 pkt/s
+sustained, Issue #38). All virtual UAs here share one source IP, so a single
+host cannot exceed that budget no matter how many UAs you spin up -- that is by
+design (DoS protection). Pace accordingly; the tool reports drops so you can see
+the limiter engage. Real fleets register from many IPs.
+
+Usage:
+  python sip_stress.py --host 192.168.12.159 --clients 30 --echo-calls 8
+  python sip_stress.py --host pocketdial.local --register-only --clients 40
+"""
+import argparse, socket, threading, time, random, re, statistics, sys, json
+import urllib.request
+
+def _hex(n): return ''.join(random.choice('0123456789abcdef') for _ in range(n))
+
+def local_ip_for(host, port):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect((host, port)); return s.getsockname()[0]
+    except Exception:
+        return '0.0.0.0'
+    finally:
+        s.close()
+
+class UA:
+    """One virtual SIP user-agent on its own UDP port."""
+    def __init__(self, ext, host, port, local_ip, timeout=4.0):
+        self.ext, self.host, self.port, self.lip = ext, host, port, local_ip
+        self.s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.s.bind(('', 0)); self.s.settimeout(timeout)
+        self.lport = self.s.getsockname()[1]
+        self.callid = f"{_hex(16)}@{local_ip}"
+        self.tag = _hex(8); self.cseq = 0
+
+    def _via(self):
+        return f"SIP/2.0/UDP {self.lip}:{self.lport};branch=z9hG4bK{_hex(10)};rport"
+
+    @staticmethod
+    def _status(resp):
+        if not resp: return None
+        m = re.match(r'SIP/2\.0 (\d{3})', resp)
+        return int(m.group(1)) if m else None
+
+    def _txn(self, msg, want_final=True):
+        """Send, then read until a final (>=200) response or timeout. Returns (status, ms)."""
+        t = time.time()
+        try:
+            self.s.sendto(msg.encode(), (self.host, self.port))
+        except Exception:
+            return (None, 0.0)
+        st = None
+        for _ in range(4):
+            try:
+                data, _a = self.s.recvfrom(8192)
+            except socket.timeout:
+                break
+            st = self._status(data.decode('utf-8', 'replace'))
+            if st and (st >= 200 or not want_final):
+                break
+        return (st, (time.time() - t) * 1000.0)
+
+    def register(self, expires=3600):
+        self.cseq += 1
+        m = (f"REGISTER sip:{self.host} SIP/2.0\r\n"
+             f"Via: {self._via()}\r\n"
+             f"Max-Forwards: 70\r\n"
+             f"From: \"{self.ext}\" <sip:{self.ext}@{self.host}>;tag={self.tag}\r\n"
+             f"To: <sip:{self.ext}@{self.host}>\r\n"
+             f"Call-ID: {self.callid}\r\n"
+             f"CSeq: {self.cseq} REGISTER\r\n"
+             f"Contact: <sip:{self.ext}@{self.lip}:{self.lport}>\r\n"
+             f"Expires: {expires}\r\n"
+             f"User-Agent: pd-stress\r\nContent-Length: 0\r\n\r\n")
+        return self._txn(m)
+
+    def _sdp(self):
+        return (f"v=0\r\no={self.ext} 0 0 IN IP4 {self.lip}\r\ns=pd\r\n"
+                f"c=IN IP4 {self.lip}\r\nt=0 0\r\n"
+                f"m=audio {10000 + (self.lport % 5000)} RTP/AVP 0 8 101\r\n"
+                f"a=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\n")
+
+    def echo_call(self):
+        """INVITE the 777 echo extension -> expect 200 -> ACK -> BYE. Returns (setup_status, ms)."""
+        self.cseq += 1
+        cid = f"{_hex(16)}@{self.lip}"
+        sdp = self._sdp()
+        inv = (f"INVITE sip:777@{self.host} SIP/2.0\r\n"
+               f"Via: {self._via()}\r\n"
+               f"Max-Forwards: 70\r\n"
+               f"From: \"{self.ext}\" <sip:{self.ext}@{self.host}>;tag={self.tag}\r\n"
+               f"To: <sip:777@{self.host}>\r\n"
+               f"Call-ID: {cid}\r\n"
+               f"CSeq: {self.cseq} INVITE\r\n"
+               f"Contact: <sip:{self.ext}@{self.lip}:{self.lport}>\r\n"
+               f"Content-Type: application/sdp\r\n"
+               f"Content-Length: {len(sdp)}\r\n\r\n{sdp}")
+        st, ms = self._txn(inv)
+        if st and 200 <= st < 300:
+            self.cseq += 1
+            ack = (f"ACK sip:777@{self.host} SIP/2.0\r\n"
+                   f"Via: {self._via()}\r\nMax-Forwards: 70\r\n"
+                   f"From: \"{self.ext}\" <sip:{self.ext}@{self.host}>;tag={self.tag}\r\n"
+                   f"To: <sip:777@{self.host}>\r\nCall-ID: {cid}\r\n"
+                   f"CSeq: {self.cseq - 1} ACK\r\nContent-Length: 0\r\n\r\n")
+            try: self.s.sendto(ack.encode(), (self.host, self.port))
+            except Exception: pass
+            self.cseq += 1
+            bye = (f"BYE sip:777@{self.host} SIP/2.0\r\n"
+                   f"Via: {self._via()}\r\nMax-Forwards: 70\r\n"
+                   f"From: \"{self.ext}\" <sip:{self.ext}@{self.host}>;tag={self.tag}\r\n"
+                   f"To: <sip:777@{self.host}>\r\nCall-ID: {cid}\r\n"
+                   f"CSeq: {self.cseq} BYE\r\nContent-Length: 0\r\n\r\n")
+            self._txn(bye)
+        return (st, ms)
+
+    def close(self):
+        try: self.s.close()
+        except Exception: pass
+
+def pct(xs, p):
+    if not xs: return 0.0
+    xs = sorted(xs); k = (len(xs) - 1) * p / 100.0
+    f = int(k); c = min(f + 1, len(xs) - 1)
+    return xs[f] + (xs[c] - xs[f]) * (k - f)
+
+def summarize(name, lat, codes):
+    ok = sum(1 for c in codes if c and 200 <= c < 300)
+    print(f"\n  {name}: {len(codes)} attempts, {ok} ok ({100.0*ok/max(1,len(codes)):.0f}%)")
+    from collections import Counter
+    print("    status codes: " + ", ".join(f"{k}:{v}" for k, v in sorted(Counter(codes).items(), key=lambda x: str(x[0]))))
+    if lat:
+        print(f"    latency ms  min={min(lat):.1f} p50={pct(lat,50):.1f} p95={pct(lat,95):.1f} max={max(lat):.1f} mean={statistics.mean(lat):.1f}")
+
+def api_status(host):
+    try:
+        with urllib.request.urlopen(f"http://{host}/api/status", timeout=3) as r:
+            return json.loads(r.read().decode())
+    except Exception as e:
+        return {"_error": str(e)}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="192.168.12.159")
+    ap.add_argument("--port", type=int, default=5060)
+    ap.add_argument("--clients", type=int, default=30)
+    ap.add_argument("--echo-calls", type=int, default=8)
+    ap.add_argument("--ext-base", type=int, default=1000)
+    ap.add_argument("--register-only", action="store_true")
+    ap.add_argument("--pace", type=float, default=0.0, help="seconds between launches (0 = full parallel)")
+    args = ap.parse_args()
+
+    lip = local_ip_for(args.host, args.port)
+    print(f"pocket-dial SIP stress  ->  {args.host}:{args.port}   (source {lip})")
+    print(f"before: {api_status(args.host)}")
+
+    uas = [UA(str(args.ext_base + i), args.host, args.port, lip) for i in range(args.clients)]
+
+    # ---- Phase 1: registration storm ----
+    reg_lat, reg_codes = [], []
+    lock = threading.Lock()
+    def do_reg(ua):
+        st, ms = ua.register()
+        with lock:
+            reg_codes.append(st)
+            if st: reg_lat.append(ms)
+    t0 = time.time()
+    threads = []
+    for ua in uas:
+        th = threading.Thread(target=do_reg, args=(ua,)); th.start(); threads.append(th)
+        if args.pace: time.sleep(args.pace)
+    for th in threads: th.join()
+    reg_dur = time.time() - t0
+    summarize("REGISTER storm", reg_lat, reg_codes)
+    print(f"    throughput: {len(reg_codes)/max(1e-6,reg_dur):.1f} reg/s over {reg_dur:.2f}s")
+
+    # ---- Phase 2: concurrent echo (777) calls ----
+    if not args.register_only and args.echo_calls > 0:
+        call_lat, call_codes = [], []
+        def do_call(ua):
+            st, ms = ua.echo_call()
+            with lock:
+                call_codes.append(st)
+                if st: call_lat.append(ms)
+        callers = uas[:args.echo_calls]
+        t0 = time.time(); threads = []
+        for ua in callers:
+            th = threading.Thread(target=do_call, args=(ua,)); th.start(); threads.append(th)
+            if args.pace: time.sleep(args.pace)
+        for th in threads: th.join()
+        call_dur = time.time() - t0
+        summarize(f"ECHO calls (777) x{args.echo_calls} concurrent", call_lat, call_codes)
+        print(f"    throughput: {len(call_codes)/max(1e-6,call_dur):.1f} calls/s over {call_dur:.2f}s")
+
+    time.sleep(0.5)
+    print(f"\nafter:  {api_status(args.host)}")
+    for ua in uas: ua.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phase 2 — Polish + features

Builds on the Phase-1 work now on `main`. Verified on real hardware: the display
target builds on ESP-IDF v5.3.5, flashes to a JC3248W535, boots, and joins a LAN
in STATION mode; the SIP engine answers correctly (`OPTIONS` → `200 OK` ~6 ms).

### Dashboard (`src/Helpers/index_html.h`)
- **Admin/Security panel** wiring the Phase-1 endpoints: set-PIN / login / logout,
  3 auth states, 15 s status poll; **gates every state-changing control**
  (kill, wifi-connect, host-AP, factory-reset) when provisioned & unauthenticated.
  All calls send the HttpOnly `pd_session` cookie via `credentials:'same-origin'`;
  401 triggers a graceful "session expired" re-gate.
- **Firmware OTA panel**: `.bin` upload with live progress (XHR), `/api/ota/status`,
  reboot. Gated behind auth.
- Responsive `@media` layout for mobile; CGA aesthetic preserved. Raw-string intact.
- Whimsy: phosphor theme switcher, boot flourish, opt-in WebAudio (off by default),
  terminal easter eggs, ASCII operator. Vanilla JS, no CDN.

### PBX features (additive, bounded, thread-safe)
- **CDR**: 32-record in-memory ring (`CallDetailRecord.hpp`, ~2.8 KB), recorded in
  `endCall()`; `GET /api/cdr` (JSON, newest first).
- **DND**: per-extension flag; `POST /api/dnd` (same-origin + auth gated); INVITE to
  a DND extension → `480`; `777`/`999` exempt; DND list surfaced in `/api/status`.
- Snapshot lock ordering verified consistent (`_mutex` → `_snapshotMutex` everywhere).

### Docs
- Operator guides: `SETUP_GUIDE`, `HARDWARE_SELECTION`, `PHONE_COMPATIBILITY`,
  `TROUBLESHOOTING`.
- `RTP.md` (server-side RTP design — MoH-first, ESP32 stream-ceiling analysis),
  `FEATURE_ROADMAP.md` (technical P0/P1/P2 roadmap).

### Load testing (`tests/load/`)
- `sip_stress.py` SIP load generator + `STRESS_FINDINGS.md`.

## Verification
- ESP-IDF v5.3.5 display build: **compiles, flashes, boots, joins LAN, SIP OK**.
- Host build + 29 smoke tests + unit suite: validated by this PR's CI run.

## Known issues found on-device (STATION mode, display build — pre-existing, not
introduced here; see `tests/load/STRESS_FINDINGS.md`)
1. `lvgl_task` starves the Core-1 idle task under STA-mode logging → task-WDT.
2. HTTP server accepts then RSTs without responding in STA mode (SIP unaffected).
3. lwip UDP mailbox = 6 limits single-source signaling bursts.

These need follow-up firmware fixes (throttle on-screen log render; investigate the
STA HTTP accept loop; raise `CONFIG_LWIP_UDP_RECVMBOX_SIZE`). The SIP engine and
host build are healthy.

## Decisions to flag
- Auth is **secure-when-configured** (open until a PIN is set) to preserve onboarding.
- The `-Os`/IRAM `sdkconfig.defaults` experiment was reverted — the IRAM "99.99%" was a
  16 KB fixed region; real internal RAM is ~42% used. Optimized for speed, not size.

https://claude.ai/code/session_013VYe6XE2S7P7zw4ND3QuQ6