### PR TITLE
Code-review hardening: SIP engine + ESP-IDF firmware; CI to v6.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf-version: [ 'v5.1.2', 'v5.2.1' ]
+        # v6.0.1 added so the v6-only code paths (the standalone espressif/w5500
+        # managed component, the ESP_IDF_VERSION >= 6 includes in esp_main_eth.cpp,
+        # and the wolfSSL patcher) get compiled in CI instead of staying dark.
+        idf-version: [ 'v5.1.2', 'v5.2.1', 'v6.0.1' ]
         target-chip: [ 'esp32', 'esp32s3' ]
         sip-transport: [ 'wifi', 'eth' ]
+        # The W5500 'eth' transport's default board pin maps (LilyGO T-ETH-ELITE /
+        # Waveshare ESP32-S3-ETH) use ESP32-S3-only GPIOs (47/48 on the Elite), so an
+        # esp32 + eth build is meaningless and only gave false coverage — exclude it.
+        # (Internal-EMAC Ethernet on the classic ESP32 is the separate 'lan8720'
+        # transport, not 'eth'.)
+        exclude:
+          - target-chip: 'esp32'
+            sip-transport: 'eth'
         # The "display" transport is esp32s3-only and pulls heavy managed
         # components (lvgl ^8.3.11, esp_lcd_touch, the AXS15231B driver — see
         # main/idf_component.yml). Verified to build on esp32s3 + ESP-IDF v5.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,10 +195,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # v6.0.1 added so the v6-only code paths (the standalone espressif/w5500
-        # managed component, the ESP_IDF_VERSION >= 6 includes in esp_main_eth.cpp,
-        # and the wolfSSL patcher) get compiled in CI instead of staying dark.
-        idf-version: [ 'v5.1.2', 'v5.2.1', 'v6.0.1' ]
+        # v6.0.1 only: the managed components (espressif/w5500, espressif/lan87xx,
+        # wolfSSL/wolfSSH) and the source guards have moved to the v6 APIs, so the
+        # older v5.1.2/v5.2.1 legs no longer build. v6.0.1 is the single supported
+        # toolchain.
+        idf-version: [ 'v6.0.1' ]
         target-chip: [ 'esp32', 'esp32s3' ]
         sip-transport: [ 'wifi', 'eth' ]
         # The W5500 'eth' transport's default board pin maps (LilyGO T-ETH-ELITE /
@@ -209,13 +210,12 @@ jobs:
         exclude:
           - target-chip: 'esp32'
             sip-transport: 'eth'
-        # The "display" transport is esp32s3-only and pulls heavy managed
-        # components (lvgl ^8.3.11, esp_lcd_touch, the AXS15231B driver — see
-        # main/idf_component.yml). Verified to build on esp32s3 + ESP-IDF v5.2.1
-        # (set-target + build, app image ~1.5 MB), so it is added as a single
-        # include leg rather than expanding the full matrix.
+        # The "display" transport is esp32s3-only and pulls heavy managed components
+        # (lvgl ^8.3.11, esp_lcd_touch, the AXS15231B driver, wolfSSL/wolfSSH — see
+        # main/idf_component.yml). Added as a single include leg rather than expanding
+        # the full matrix.
         include:
-          - idf-version: 'v5.2.1'
+          - idf-version: 'v6.0.1'
             target-chip: 'esp32s3'
             sip-transport: 'display'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
                    --suppress=unmatchedSuppression \
                    --suppress=*:main/ui/qrcode.c \
                    --suppress=*:main/ui/qrcode.h \
+                   --suppress=unknownMacro:main/ui/ui.cpp \
                    -I src/Helpers -I src/SIP -I main \
                    src/ main/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,11 +68,13 @@ changes are compile-gated by the CI ESP-IDF matrix.
   wear-leveling contract comment on the raw `prompts` partition (`partitions.csv`).
 
 ### CI
-- Added ESP-IDF **v6.0.1** to the firmware build matrix so the v6-only code paths
-  (split `espressif/w5500` component, `ESP_IDF_VERSION >= 6` includes, wolfSSL patcher)
-  are compiled in CI; excluded the meaningless `esp32 + eth` leg (the W5500 default pin
-  maps use ESP32-S3-only GPIOs — internal-EMAC Ethernet on the classic ESP32 is the
-  separate `lan8720` transport).
+- Switched the firmware build matrix to **ESP-IDF v6.0.1 only** — the managed
+  components (espressif/w5500, espressif/lan87xx, wolfSSL/wolfSSH) and the source
+  guards have moved to the v6 APIs, so the old v5.1.2/v5.2.1 legs no longer build.
+  Excluded the meaningless `esp32 + eth` leg (the W5500 default pin maps use
+  ESP32-S3-only GPIOs — internal-EMAC Ethernet on the classic ESP32 is the separate
+  `lan8720` transport). All three esp32s3 transports (display, eth, wifi) were verified
+  building locally on v6.0.1 with these changes (`SipServer.bin` generated for each).
 
 ### Deliberately not changed (reviewed, declined)
 - **RTP task core affinity**: the media TX/RX tasks stay on Core 0 — on the display

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ changes are compile-gated by the CI ESP-IDF matrix.
   ESP32-S3-only GPIOs — internal-EMAC Ethernet on the classic ESP32 is the separate
   `lan8720` transport). All three esp32s3 transports (display, eth, wifi) were verified
   building locally on v6.0.1 with these changes (`SipServer.bin` generated for each).
+- Suppressed a pre-existing cppcheck `unknownMacro` false-positive on
+  `main/ui/ui.cpp` (the LVGL `LV_SYMBOL_RIGHT` glyph macro — cppcheck can't see
+  LVGL's headers). This had been failing the host CI job since the Learn-mode
+  display work landed; the suppression is scoped to `unknownMacro` on that one file
+  so genuine warnings there still fire.
 
 ### Deliberately not changed (reviewed, declined)
 - **RTP task core affinity**: the media TX/RX tasks stay on Core 0 — on the display

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Changelog
 
+## Unreleased (fix/code-review-hardening) - 2026-06-10
+
+Code-review pass across the cross-platform SIP engine (`src/`) and all four ESP-IDF
+entry points (`main/`). Engine changes verified on the host build: clean compile,
+113/113 GoogleTest cases, and the `tests/http/test_api.sh` smoke suite. Firmware
+changes are compile-gated by the CI ESP-IDF matrix.
+
+### Fixed — engine (`src/`)
+- **CRITICAL `getFormParam` token-boundary collision** (`Helpers/HttpServer.cpp`):
+  the form parser matched a key as a bare substring, so `getFormParam("…&on=1", "on")`
+  could match the `n=` inside `extension=…` and return the wrong value — silently
+  **inverting `POST /api/dnd`** when `extension` preceded `on`. Now anchors each match
+  to a real parameter boundary (start-of-body or after `&`).
+- **`_dummyClient` shared mutable state** (`SIP/RequestsHandler.cpp`): the echo (`777`),
+  media (`440`) and `*11`/`*69` star-code paths all reset and shared one
+  `_dummyClient`, so a second concurrent virtual call overwrote the first session's
+  destination identity. Each dummy session now owns its own `SipClient`; the shared
+  member is removed.
+- **`440` media answered before the RTP stream started** (`SIP/RequestsHandler.cpp`):
+  `onMediaInvite` sent `200 OK` before `RtpSender::start()`, so a socket/task failure
+  left the caller in a silently-answered call. Now starts RTP first (→ `500` on
+  failure), allocates the session (→ `503` + stream stop if the pool is full), and only
+  then sends `200 OK`.
+- **Rate limiting serialized on the main registrar mutex** (`SIP/RequestsHandler.cpp`):
+  every packet — including ones from already-blocked IPs — took the global `_mutex`
+  before being dropped. Per-source admission now runs under a dedicated `_rateMutex`
+  *before* `_mutex`, so a flood can't serialize against legitimate signaling.
+- **Nonce tag was MD5(secret‖msg), length-extension forgeable** (`Helpers/SipDigest.cpp`):
+  replaced with a proper HMAC-MD5 (RFC 2104) over the timestamp.
+- **Admin session had no sliding expiry** (`Helpers/AdminAuth.cpp`): an active admin was
+  logged out at the absolute TTL mid-session; `validateSession` now extends the deadline
+  on each successful check.
+- **Port-blind same-origin check** (`Helpers/HttpServer.cpp`): `isSameOrigin` stripped
+  ports before comparing; it now also requires the Origin/Host ports to match when both
+  are explicitly present.
+- Removed the dead no-op `registerClient()` hook and made `setCallState()` return `void`
+  (its result was always ignored).
+
+### Fixed — firmware (`main/`)
+- **CRITICAL cross-core `g_sipServer` data race** (all four entry points —
+  `esp_main.cpp`, `esp_main_eth.cpp`, `esp_main_eth_lan8720.cpp`, `esp_main_display.cpp`):
+  the pointer was published by the SIP task and polled by the HTTP/status tasks as a
+  plain `SipServer*` with no barrier (stale-null / half-built-object read; hoistable
+  poll). Now `std::atomic<SipServer*>` with release-store / acquire-load.
+- **CRITICAL DnsServer data race + use-after-free** (`wifi/DnsServer.cpp`/`.hpp`):
+  `_running`/`_socketFd` are now `std::atomic`; `stop()` closes the socket once
+  (single-owner `exchange`) and joins `dns_task` via an exit semaphore before returning,
+  so the object can't be destroyed out from under a running task. Added a 500 ms
+  `SO_RCVTIMEO` so the loop observes `_running` without depending on close-unblocks-recv.
+- **CRITICAL unbounded `g_sipServer` poll hangs the display dashboard**
+  (`esp_main_display.cpp`): `http_server_task` spun forever if the SIP server failed to
+  construct (e.g. OOM). Now bounded (~30 s) then self-exits with an error log.
+- **HIGH unbounded provisioning spin** (`esp_main.cpp`, `esp_main_eth.cpp`,
+  `esp_main_eth_lan8720.cpp`): the "wait for admin credential" loop could hang forever
+  with no watchdog; now capped at 30 min, then `esp_restart()` to retry cleanly.
+- **HIGH `esp_restart()` racing concurrent flash writes** (`esp_main_display.cpp`):
+  the captive-decay reboot now calls `esp_wifi_stop()` to quiesce the radio first.
+- **MEDIUM deprecated `esp_event_handler_register`** (`esp_main_eth.cpp`,
+  `esp_main_eth_lan8720.cpp`): switched to `esp_event_handler_instance_register` (no
+  more duplicate-handler risk on a re-init path), matching the wifi/display builds.
+- **MEDIUM ISR-unsafe log hook** (`esp_main_display.cpp`): `screen_log_vprintf` is
+  installed via `esp_log_set_vprintf` and can run in ISR context; it now dispatches
+  `xQueueSendFromISR` when `xPortInIsrContext()`.
+- **LOW** discarded `esp_eth_new_netif_glue`/`esp_netif_attach` returns (eth builds),
+  leaked STA/ETH event groups on the failure/fallback paths, and a missing erase/
+  wear-leveling contract comment on the raw `prompts` partition (`partitions.csv`).
+
+### CI
+- Added ESP-IDF **v6.0.1** to the firmware build matrix so the v6-only code paths
+  (split `espressif/w5500` component, `ESP_IDF_VERSION >= 6` includes, wolfSSL patcher)
+  are compiled in CI; excluded the meaningless `esp32 + eth` leg (the W5500 default pin
+  maps use ESP32-S3-only GPIOs — internal-EMAC Ethernet on the classic ESP32 is the
+  separate `lan8720` transport).
+
+### Deliberately not changed (reviewed, declined)
+- **RTP task core affinity**: the media TX/RX tasks stay on Core 0 — on the display
+  build LVGL owns Core 1, and the existing comments make the placement a deliberate
+  choice so the 20 ms RTP cadence isn't stolen by full-screen LVGL blits. Moving them
+  would *create* the contention the design avoids.
+- **`_messagePool` static storage**: `getMessageFromPool` is a static method called by
+  `SipMessageFactory` (which has no handler instance), so the pool must stay static; the
+  feared "dangling on handler destruction" doesn't occur (static storage outlives any
+  instance).
+- **pthread default stack for wolfSSH**: already handled — wolfSSH runs in its own
+  explicit 24 KB FreeRTOS task, not a `std::thread` (see `sdkconfig.defaults`).
+- A handful of hardware-verified display-timing / PSRAM-routing items were left as-is to
+  avoid regressing the validated panel path; see the review notes.
+
 ## v1.2.0 - 2026-06-04
 
 Production-hardening + feature release. Verified end-to-end on a JC3248W535

--- a/main/esp_main.cpp
+++ b/main/esp_main.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <string>
+#include <atomic>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
@@ -35,8 +36,11 @@
 
 static const char *TAG = "wifi softAP";
 
-// Global pointers so the HTTP task can reach the SIP engine
-static SipServer* g_sipServer = nullptr;
+// Global pointer so the HTTP task (Core 0) can reach the SIP engine built by the
+// SIP task (Core 1). Atomic with acquire/release: a plain pointer is a cross-core
+// data race on the SMP Xtensa (the reader could see a stale null or a half-built
+// object, and the compiler could hoist the poll out of the loop).
+static std::atomic<SipServer*> g_sipServer{nullptr};
 
 // ── Event bits for STA connect ────────────────────────────────────────────────
 #define STA_GOT_IP_BIT BIT0
@@ -180,11 +184,12 @@ void sip_server_task(void *pvParameters)
     int port = 5060;
     ESP_LOGI("SipServerTask", "Starting SipServer on %s:%d", s_sip_ip.c_str(), port);
 
-    g_sipServer = new SipServer(s_sip_ip, port);
+    SipServer* srv = new SipServer(s_sip_ip, port);
+    // Publish with release so the HTTP task's acquire-load sees a fully-constructed
+    // object (not a half-initialised one) the moment it observes the non-null pointer.
+    g_sipServer.store(srv, std::memory_order_release);
     while (1) {
-        if (g_sipServer) {
-            g_sipServer->getHandler().tick();
-        }
+        srv->getHandler().tick();
         vTaskDelay(pdMS_TO_TICKS(1000));
     }
 
@@ -213,8 +218,9 @@ void http_server_task(void *pvParameters)
     bool handlerAttached = false;
     while (1) {
         vTaskDelay(pdMS_TO_TICKS(1000));
-        if (!handlerAttached && g_sipServer != nullptr) {
-            http.attachHandler(&g_sipServer->getHandler());
+        SipServer* srv = g_sipServer.load(std::memory_order_acquire);
+        if (!handlerAttached && srv != nullptr) {
+            http.attachHandler(&srv->getHandler());
             handlerAttached = true;
             ESP_LOGI("HttpTask", "Dashboard: live SIP registrar attached");
         }
@@ -287,6 +293,10 @@ extern "C" void app_main(void)
             // and the ESP_ERROR_CHECK inside wifi_init_softap() would abort → boot loop.
             esp_wifi_stop();    // returns ESP_ERR_WIFI_NOT_STARTED if STA never started; ignored
             esp_wifi_deinit();
+            // Free the STA event group created by wifi_init_sta(); after deinit no
+            // more Wi-Fi events fire, so it can't be referenced again (the handler
+            // null-checks it). Prevents a small FreeRTOS-heap leak on this fallback.
+            if (s_sta_event_group) { vEventGroupDelete(s_sta_event_group); s_sta_event_group = nullptr; }
             topology_mode = TOPOLOGY_INFRA;
         }
     }
@@ -321,11 +331,21 @@ extern "C" void app_main(void)
     if (!is_provisioned) {
         ESP_LOGW(TAG, "[boot] device unprovisioned — SIP stack held dark until credential committed");
 
-        // Spin-wait: poll AdminAuth every 2 s until a credential is set via the
-        // HTTP dashboard. The drain task runs at priority 1 and will flush logs
-        // to UART during the delays.
+        // Bounded wait: poll AdminAuth every 2 s until a credential is set via the
+        // HTTP dashboard. The drain task (priority 1) flushes logs during the delays.
+        // If nothing arrives within the cap — e.g. the HTTP stack failed to come up —
+        // reboot to retry from a clean state rather than hang here forever (no
+        // watchdog covers this provisioning gate, so an unbounded spin is unrecoverable).
+        constexpr int kMaxCredentialWaitSec = 1800;   // 30 minutes
+        int credentialWaitSec = 0;
         while (!AdminAuth::credentialIsSet()) {
             vTaskDelay(pdMS_TO_TICKS(2000));
+            credentialWaitSec += 2;
+            if (credentialWaitSec >= kMaxCredentialWaitSec) {
+                ESP_LOGE(TAG, "[boot] no admin credential after %d s — rebooting to retry",
+                         kMaxCredentialWaitSec);
+                esp_restart();
+            }
             ESP_LOGI(TAG, "[boot] waiting for admin credential...");
         }
 

--- a/main/esp_main_display.cpp
+++ b/main/esp_main_display.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <cstdio>
+#include <atomic>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
@@ -66,8 +67,11 @@ static const char *TAG = "main_display";
 #define ONBOARDING_SSID "My-Ap"
 #define ONBOARDING_PASS "12345678"
 
-// Active server objects
-static SipServer* g_sipServer = nullptr;
+// Active server objects. g_sipServer is built by sip_server_task and read by the
+// http/status tasks; atomic with acquire/release so a reader never observes a
+// half-built object or a hoisted-out-of-loop poll (it also future-proofs the read
+// against a cross-core move).
+static std::atomic<SipServer*> g_sipServer{nullptr};
 static HttpServer* g_httpServer = nullptr;
 static DnsServer* g_dnsServer = nullptr;
 static QueueHandle_t s_log_queue = NULL;
@@ -142,8 +146,17 @@ extern "C" {
                 buf[len-1] = '\0';
                 len--;
             }
-            if (len > 0) {
-                xQueueSend(s_log_queue, buf, 0);  // non-blocking; drop if full
+            if (len > 0 && s_log_queue) {
+                // esp_log_set_vprintf hooks ALL ESP_LOGx, including any logged from
+                // ISR context. The plain xQueueSend must never run in an ISR, so
+                // dispatch the FromISR variant when we are in one (M-3).
+                if (xPortInIsrContext()) {
+                    BaseType_t hp = pdFALSE;
+                    xQueueSendFromISR(s_log_queue, buf, &hp);
+                    if (hp) portYIELD_FROM_ISR();
+                } else {
+                    xQueueSend(s_log_queue, buf, 0);  // non-blocking; drop if full
+                }
             }
         }
         if (original_log_vprintf) {
@@ -394,16 +407,17 @@ static void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t e
 // ─── Server Tasks on Core 0 ───
 static void sip_server_task(void *pvParameters) {
     ESP_LOGI("SipTask", "Starting SipServer engine on Core 0 IP %s:%d", g_localIp.c_str(), 5060);
-    g_sipServer = new SipServer(g_localIp, 5060);
+    SipServer* srv = new SipServer(g_localIp, 5060);
     // Plumb the live registrar into the SSH sysop-terminal TUI so its hub status
     // line + title-bar clock show real extension/call counts (thread-safe: the
     // handler's dashboard getters snapshot-copy under their own mutex). Attaching
-    // a raw pointer is safe — g_sipServer lives for the process lifetime.
-    SshServer::instance().attachHandler(&g_sipServer->getHandler());
+    // a raw pointer is safe — the SipServer lives for the process lifetime.
+    SshServer::instance().attachHandler(&srv->getHandler());
+    // Publish with release so the http/status tasks' acquire-load sees a fully
+    // constructed object the moment they observe the non-null pointer.
+    g_sipServer.store(srv, std::memory_order_release);
     while (1) {
-        if (g_sipServer) {
-            g_sipServer->getHandler().tick();
-        }
+        srv->getHandler().tick();
         vTaskDelay(pdMS_TO_TICKS(30)); // match Arduino 30ms latency cycle
     }
     vTaskDelete(NULL);
@@ -411,11 +425,20 @@ static void sip_server_task(void *pvParameters) {
 
 static void http_server_task(void *pvParameters) {
     ESP_LOGI("HttpTask", "Starting Web CGA CRT dashboard on Core 0 IP %s:80", g_localIp.c_str());
-    // block task until SipServer is fully instanced
-    while (g_sipServer == nullptr) {
+    // Block until the SIP task publishes the handler — but BOUNDED: if the SipServer
+    // failed to construct (e.g. OOM after the PSRAM frame buffers), an unbounded poll
+    // would hang this task (and the whole dashboard) forever with no watchdog. Give
+    // up after ~30 s and self-exit instead of spinning silently.
+    SipServer* srv = nullptr;
+    for (int i = 0; i < 300 && (srv = g_sipServer.load(std::memory_order_acquire)) == nullptr; ++i) {
         vTaskDelay(pdMS_TO_TICKS(100));
     }
-    g_httpServer = new HttpServer(g_localIp, 80, &g_sipServer->getHandler());
+    if (srv == nullptr) {
+        ESP_LOGE("HttpTask", "SipServer never came up after 30 s — dashboard task aborting");
+        vTaskDelete(NULL);
+        return;
+    }
+    g_httpServer = new HttpServer(g_localIp, 80, &srv->getHandler());
     g_httpServer->start();
     ESP_LOGI("HttpTask", "CGA Web UI Running successfully!");
 
@@ -447,9 +470,11 @@ static void system_status_task(void *pvParameters) {
         if (g_setupComplete) {
             uint32_t uptime = esp_timer_get_time() / 1000000;
 
-            // Query extensions and active VoIP call counts
-            int clientCount = g_sipServer ? g_sipServer->getHandler().getClientCount() : 0;
-            int sessionCount = g_sipServer ? g_sipServer->getHandler().getSessionCount() : 0;
+            // Query extensions and active VoIP call counts. Load the registrar
+            // pointer once (acquire) and use the snapshot for the whole tick.
+            SipServer* srv = g_sipServer.load(std::memory_order_acquire);
+            int clientCount = srv ? srv->getHandler().getClientCount() : 0;
+            int sessionCount = srv ? srv->getHandler().getSessionCount() : 0;
 
             // Free-heap % for the wallboard vitals line (internal heap; PSRAM excluded so
             // the figure reflects the constrained pool that actually matters for stability).
@@ -469,8 +494,8 @@ static void system_status_task(void *pvParameters) {
             board.extCount = 0;
             board.dndCount = 0;
             board.dndOverflow = 0;
-            if (g_sipServer) {
-                RequestsHandler& h = g_sipServer->getHandler();
+            if (srv) {
+                RequestsHandler& h = srv->getHandler();
                 auto clients  = h.getActiveClients();   // {ext, ip:port}
                 auto sessions = h.getActiveSessions();   // {a, b, stateStr, durationSec}
                 auto dndList  = h.getDndExtensions();    // {ext...}
@@ -572,9 +597,13 @@ static void captive_decay_task(void *pvParameters) {
     nvs_handle_t h;
     if (nvs_open("storage", NVS_READWRITE, &h) == ESP_OK) {
         nvs_set_u8(h, "decayed", 1);
-        nvs_commit(h);
+        nvs_commit(h);   // synchronous: the flag is on flash before this returns
         nvs_close(h);
     }
+    // Quiesce the radio before resetting so no Wi-Fi-driven flash/NVS write from
+    // another task is in flight across esp_restart() (which does not coordinate with
+    // concurrent SPI-flash operations). nvs_commit above already flushed our write.
+    esp_wifi_stop();
     vTaskDelay(pdMS_TO_TICKS(200));
     esp_restart();
 }

--- a/main/esp_main_eth.cpp
+++ b/main/esp_main_eth.cpp
@@ -16,6 +16,7 @@
 
 #include <cstring>
 #include <string>
+#include <atomic>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -112,8 +113,11 @@ static EventGroupHandle_t s_eth_event_group = nullptr;
 static esp_netif_t*       s_eth_netif       = nullptr;
 static std::string        s_ip_addr;
 
-// Global SIP server pointer so the HTTP dashboard task can reach the handler
-static SipServer*         g_sipServer = nullptr;
+// Global SIP server pointer so the HTTP dashboard task (Core 0) can reach the
+// handler built by the SIP task. Atomic with acquire/release: a plain pointer is a
+// cross-core data race on the SMP Xtensa (stale-null / half-built-object read, and
+// the compiler could hoist the poll out of the attach loop).
+static std::atomic<SipServer*> g_sipServer{nullptr};
 
 #define HTTP_DASHBOARD_PORT 80
 
@@ -236,16 +240,17 @@ static void sip_server_task(void* pvParameters)
 {
     ESP_LOGI(TAG, "Starting SipServer on %s:%d", s_ip_addr.c_str(), SIP_PORT);
 
-    g_sipServer = new SipServer(s_ip_addr, SIP_PORT);
+    SipServer* srv = new SipServer(s_ip_addr, SIP_PORT);
+    // Publish with release so the HTTP task's acquire-load sees a fully-constructed
+    // object the moment it observes the non-null pointer.
+    g_sipServer.store(srv, std::memory_order_release);
     ESP_LOGI(TAG, "SIP server is RUNNING.  Point softphones at %s:%d",
              s_ip_addr.c_str(), SIP_PORT);
 
     unsigned long lastHeartbeat = 0;
     while (true)
     {
-        if (g_sipServer) {
-            g_sipServer->getHandler().tick();
-        }
+        srv->getHandler().tick();
         vTaskDelay(pdMS_TO_TICKS(1000));
         unsigned long nowSec = (unsigned long)(esp_timer_get_time() / 1000000);
         if (nowSec - lastHeartbeat >= 30)
@@ -283,9 +288,10 @@ static void http_server_task(void* pvParameters)
     while (true)
     {
         vTaskDelay(pdMS_TO_TICKS(1000));
-        if (!handlerAttached && g_sipServer != nullptr)
+        SipServer* srv = g_sipServer.load(std::memory_order_acquire);
+        if (!handlerAttached && srv != nullptr)
         {
-            http.attachHandler(&g_sipServer->getHandler());
+            http.attachHandler(&srv->getHandler());
             handlerAttached = true;
             ESP_LOGI(TAG, "Dashboard: live SIP registrar attached");
         }
@@ -339,10 +345,13 @@ extern "C" void app_main(void)
     s_eth_event_group = xEventGroupCreate();
 
     // ── Register event handlers ─────────────────────────────────────────
-    ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID,
-                                               &eth_event_handler, nullptr));
-    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP,
-                                               &ip_event_handler, nullptr));
+    // Use the _instance_ form (the bare esp_event_handler_register is deprecated
+    // since IDF v4.2 and returns no instance handle, so a re-init path would stack
+    // duplicate handlers → double dispatch). Matches the wifi/display builds.
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(ETH_EVENT, ESP_EVENT_ANY_ID,
+                                               &eth_event_handler, nullptr, nullptr));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_ETH_GOT_IP,
+                                               &ip_event_handler, nullptr, nullptr));
 
     // ── Create default netif for Ethernet ───────────────────────────────
     esp_netif_config_t netif_cfg = ESP_NETIF_DEFAULT_ETH();
@@ -352,7 +361,16 @@ extern "C" void app_main(void)
     esp_eth_handle_t eth_handle = eth_init_w5500();
 
     // ── Glue driver to netif ────────────────────────────────────────────
-    esp_netif_attach(s_eth_netif, esp_eth_new_netif_glue(eth_handle));
+    // Both calls can fail (glue alloc on OOM; attach returns esp_err_t). Discarding
+    // them left the driver installed but unconnected to lwIP, so the board waited
+    // forever for a DHCP lease that could never arrive — fail loudly instead.
+    auto eth_glue = esp_eth_new_netif_glue(eth_handle);
+    if (eth_glue == nullptr) {
+        ESP_LOGE(TAG, "FATAL: esp_eth_new_netif_glue failed (out of memory)");
+        if (s_eth_event_group) { vEventGroupDelete(s_eth_event_group); s_eth_event_group = nullptr; }
+        return;
+    }
+    ESP_ERROR_CHECK(esp_netif_attach(s_eth_netif, eth_glue));
 
     // ── Static IP (optional) ────────────────────────────────────────────
 #if USE_STATIC_IP
@@ -377,6 +395,7 @@ extern "C" void app_main(void)
     if (!(bits & ETH_GOT_IP_BIT))
     {
         ESP_LOGE(TAG, "FATAL: No IP after 30 s.  Check cable / PoE / DHCP.");
+        if (s_eth_event_group) { vEventGroupDelete(s_eth_event_group); s_eth_event_group = nullptr; }
         return;
     }
 
@@ -419,8 +438,18 @@ extern "C" void app_main(void)
     if (!is_provisioned) {
         ESP_LOGW(TAG, "[boot] device unprovisioned — SIP stack held dark until credential committed");
 
+        // Bounded wait (see esp_main.cpp): reboot to retry if no credential arrives
+        // within the cap rather than hang forever with no watchdog on this gate.
+        constexpr int kMaxCredentialWaitSec = 1800;   // 30 minutes
+        int credentialWaitSec = 0;
         while (!AdminAuth::credentialIsSet()) {
             vTaskDelay(pdMS_TO_TICKS(2000));
+            credentialWaitSec += 2;
+            if (credentialWaitSec >= kMaxCredentialWaitSec) {
+                ESP_LOGE(TAG, "[boot] no admin credential after %d s — rebooting to retry",
+                         kMaxCredentialWaitSec);
+                esp_restart();
+            }
             ESP_LOGI(TAG, "[boot] waiting for admin credential...");
         }
 

--- a/main/esp_main_eth_lan8720.cpp
+++ b/main/esp_main_eth_lan8720.cpp
@@ -23,6 +23,7 @@
 
 #include <cstring>
 #include <string>
+#include <atomic>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -95,8 +96,11 @@ static EventGroupHandle_t s_eth_event_group = nullptr;
 static esp_netif_t*       s_eth_netif       = nullptr;
 static std::string        s_ip_addr;
 
-// Global SIP server pointer so the HTTP dashboard task can reach the handler
-static SipServer*         g_sipServer = nullptr;
+// Global SIP server pointer so the HTTP dashboard task (Core 0) can reach the
+// handler built by the SIP task. Atomic with acquire/release: a plain pointer is a
+// cross-core data race on the SMP Xtensa (stale-null / half-built-object read, and
+// the compiler could hoist the poll out of the attach loop).
+static std::atomic<SipServer*> g_sipServer{nullptr};
 
 #define HTTP_DASHBOARD_PORT 80
 
@@ -202,16 +206,17 @@ static void sip_server_task(void* pvParameters)
 {
     ESP_LOGI(TAG, "Starting SipServer on %s:%d", s_ip_addr.c_str(), SIP_PORT);
 
-    g_sipServer = new SipServer(s_ip_addr, SIP_PORT);
+    SipServer* srv = new SipServer(s_ip_addr, SIP_PORT);
+    // Publish with release so the HTTP task's acquire-load sees a fully-constructed
+    // object the moment it observes the non-null pointer.
+    g_sipServer.store(srv, std::memory_order_release);
     ESP_LOGI(TAG, "SIP server is RUNNING.  Point softphones at %s:%d",
              s_ip_addr.c_str(), SIP_PORT);
 
     unsigned long lastHeartbeat = 0;
     while (true)
     {
-        if (g_sipServer) {
-            g_sipServer->getHandler().tick();
-        }
+        srv->getHandler().tick();
         vTaskDelay(pdMS_TO_TICKS(1000));
         unsigned long nowSec = (unsigned long)(esp_timer_get_time() / 1000000);
         if (nowSec - lastHeartbeat >= 30)
@@ -249,9 +254,10 @@ static void http_server_task(void* pvParameters)
     while (true)
     {
         vTaskDelay(pdMS_TO_TICKS(1000));
-        if (!handlerAttached && g_sipServer != nullptr)
+        SipServer* srv = g_sipServer.load(std::memory_order_acquire);
+        if (!handlerAttached && srv != nullptr)
         {
-            http.attachHandler(&g_sipServer->getHandler());
+            http.attachHandler(&srv->getHandler());
             handlerAttached = true;
             ESP_LOGI(TAG, "Dashboard: live SIP registrar attached");
         }
@@ -305,10 +311,13 @@ extern "C" void app_main(void)
     s_eth_event_group = xEventGroupCreate();
 
     // ── Register event handlers ─────────────────────────────────────────
-    ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID,
-                                               &eth_event_handler, nullptr));
-    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP,
-                                               &ip_event_handler, nullptr));
+    // Use the _instance_ form (the bare esp_event_handler_register is deprecated
+    // since IDF v4.2 and returns no instance handle, so a re-init path would stack
+    // duplicate handlers → double dispatch). Matches the wifi/display builds.
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(ETH_EVENT, ESP_EVENT_ANY_ID,
+                                               &eth_event_handler, nullptr, nullptr));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_ETH_GOT_IP,
+                                               &ip_event_handler, nullptr, nullptr));
 
     // ── Create default netif for Ethernet ───────────────────────────────
     esp_netif_config_t netif_cfg = ESP_NETIF_DEFAULT_ETH();
@@ -318,7 +327,16 @@ extern "C" void app_main(void)
     esp_eth_handle_t eth_handle = eth_init_lan8720();
 
     // ── Glue driver to netif ────────────────────────────────────────────
-    esp_netif_attach(s_eth_netif, esp_eth_new_netif_glue(eth_handle));
+    // Both calls can fail (glue alloc on OOM; attach returns esp_err_t). Discarding
+    // them left the driver installed but unconnected to lwIP, so the board waited
+    // forever for a DHCP lease that could never arrive — fail loudly instead.
+    auto eth_glue = esp_eth_new_netif_glue(eth_handle);
+    if (eth_glue == nullptr) {
+        ESP_LOGE(TAG, "FATAL: esp_eth_new_netif_glue failed (out of memory)");
+        if (s_eth_event_group) { vEventGroupDelete(s_eth_event_group); s_eth_event_group = nullptr; }
+        return;
+    }
+    ESP_ERROR_CHECK(esp_netif_attach(s_eth_netif, eth_glue));
 
     // ── Static IP (optional) ────────────────────────────────────────────
 #if USE_STATIC_IP
@@ -343,6 +361,7 @@ extern "C" void app_main(void)
     if (!(bits & ETH_GOT_IP_BIT))
     {
         ESP_LOGE(TAG, "FATAL: No IP after 30 s.  Check cable / link / DHCP.");
+        if (s_eth_event_group) { vEventGroupDelete(s_eth_event_group); s_eth_event_group = nullptr; }
         return;
     }
 
@@ -383,8 +402,18 @@ extern "C" void app_main(void)
     if (!is_provisioned) {
         ESP_LOGW(TAG, "[boot] device unprovisioned — SIP stack held dark until credential committed");
 
+        // Bounded wait (see esp_main.cpp): reboot to retry if no credential arrives
+        // within the cap rather than hang forever with no watchdog on this gate.
+        constexpr int kMaxCredentialWaitSec = 1800;   // 30 minutes
+        int credentialWaitSec = 0;
         while (!AdminAuth::credentialIsSet()) {
             vTaskDelay(pdMS_TO_TICKS(2000));
+            credentialWaitSec += 2;
+            if (credentialWaitSec >= kMaxCredentialWaitSec) {
+                ESP_LOGE(TAG, "[boot] no admin credential after %d s — rebooting to retry",
+                         kMaxCredentialWaitSec);
+                esp_restart();
+            }
             ESP_LOGI(TAG, "[boot] waiting for admin credential...");
         }
 

--- a/main/wifi/DnsServer.cpp
+++ b/main/wifi/DnsServer.cpp
@@ -1,5 +1,6 @@
 #include "DnsServer.hpp"
 #include <cstring>
+#include <errno.h>
 #include <sys/param.h>
 #include "lwip/sockets.h"
 #include "lwip/err.h"
@@ -27,41 +28,59 @@ struct DnsAnswerHeader {
 };
 #pragma pack(pop)
 
-DnsServer::DnsServer() : _resolvedIp("192.168.4.1"), _taskHandle(nullptr), _socketFd(-1), _running(false) {}
+DnsServer::DnsServer()
+    : _resolvedIp("192.168.4.1"), _taskHandle(nullptr), _socketFd(-1), _running(false),
+      _exitSem(xSemaphoreCreateBinary()) {}
 
 DnsServer::~DnsServer() {
     stop();
+    if (_exitSem) {
+        vSemaphoreDelete(_exitSem);
+        _exitSem = nullptr;
+    }
 }
 
 bool DnsServer::start(const std::string& resolvedIp) {
-    if (_running) return true;
-    
-    _resolvedIp = resolvedIp;
-    _running = true;
-    
+    if (_running.load(std::memory_order_acquire)) return true;
+
+    _resolvedIp = resolvedIp;   // read once by dns_task at startup (after task create)
+    _running.store(true, std::memory_order_release);
+    // Drain any stale exit signal left by a previous run so stop()'s join is honest.
+    if (_exitSem) xSemaphoreTake(_exitSem, 0);
+
     BaseType_t ret = xTaskCreatePinnedToCore(&DnsServer::dns_task, "dns_task", 4096, this, 5, &_taskHandle, 0);
     if (ret != pdPASS) {
         ESP_LOGE(TAG, "Failed to create DNS task");
-        _running = false;
+        _running.store(false, std::memory_order_release);
         return false;
     }
-    
+    _taskStarted = true;
     return true;
 }
 
 void DnsServer::stop() {
-    if (!_running) return;
-    
-    _running = false;
-    if (_socketFd != -1) {
-        close(_socketFd);
-        _socketFd = -1;
+    bool wasRunning = _running.exchange(false, std::memory_order_acq_rel);
+
+    // Close the socket to unblock a parked recvfrom() immediately. exchange() makes
+    // the close single-owner: whichever of stop()/dns_task gets the real fd closes
+    // it once; the other gets -1 and skips, so there is no double close.
+    int fd = _socketFd.exchange(-1, std::memory_order_acq_rel);
+    if (fd != -1) {
+        shutdown(fd, SHUT_RDWR);
+        close(fd);
     }
-    
-    // DNS server task will terminate on its own when _running is false or socket is closed.
-    // Clean up task handle if still valid.
+
+    // Join dns_task before returning so a caller that destroys this object right
+    // after stop() cannot race a still-running task touching our members (UAF).
+    // The ~1 s cap backstops a wedged task. Only wait if a task was actually created.
+    if (_taskStarted && _exitSem) {
+        xSemaphoreTake(_exitSem, pdMS_TO_TICKS(1000));
+        _taskStarted = false;
+    }
     _taskHandle = nullptr;
-    ESP_LOGI(TAG, "DNS server stopped.");
+    if (wasRunning) {
+        ESP_LOGI(TAG, "DNS server stopped.");
+    }
 }
 
 void DnsServer::dns_task(void* pvParameters) {
@@ -73,20 +92,31 @@ void DnsServer::dns_task(void* pvParameters) {
     dest_addr.sin_family = AF_INET;
     dest_addr.sin_port = htons(53); // Standard DNS port
 
-    self->_socketFd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
-    if (self->_socketFd < 0) {
+    int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (sock < 0) {
         ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
-        self->_running = false;
+        self->_running.store(false, std::memory_order_release);
+        if (self->_exitSem) xSemaphoreGive(self->_exitSem);
         vTaskDelete(NULL);
         return;
     }
+    self->_socketFd.store(sock, std::memory_order_release);
 
-    int err = bind(self->_socketFd, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
+    // Bounded recv timeout (M-2): lets the loop observe _running even if the socket
+    // close in stop() does not unblock recvfrom() on this lwIP build, and bounds a
+    // silent sender. Mirrors UdpServer / RtpReceiver's 500 ms SO_RCVTIMEO pattern.
+    struct timeval tv;
+    tv.tv_sec  = 0;
+    tv.tv_usec = 500000;   // 500 ms
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    int err = bind(sock, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
     if (err < 0) {
         ESP_LOGE(TAG, "Socket unable to bind: errno %d", errno);
-        close(self->_socketFd);
-        self->_socketFd = -1;
-        self->_running = false;
+        int fd = self->_socketFd.exchange(-1, std::memory_order_acq_rel);
+        if (fd != -1) close(fd);
+        self->_running.store(false, std::memory_order_release);
+        if (self->_exitSem) xSemaphoreGive(self->_exitSem);
         vTaskDelete(NULL);
         return;
     }
@@ -107,17 +137,20 @@ void DnsServer::dns_task(void* pvParameters) {
         }
     }
 
-    while (self->_running) {
-        int len = recvfrom(self->_socketFd, rx_buffer, sizeof(rx_buffer), 0, (struct sockaddr *)&source_addr, &socklen);
+    while (self->_running.load(std::memory_order_acquire)) {
+        int len = recvfrom(sock, rx_buffer, sizeof(rx_buffer), 0, (struct sockaddr *)&source_addr, &socklen);
         if (len < 0) {
-            if (self->_running) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;   // SO_RCVTIMEO expiry: re-check _running and loop
+            }
+            if (self->_running.load(std::memory_order_acquire)) {
                 ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
             }
-            break;
+            break;          // real error, or socket closed by stop()
         }
 
         // Process only if it looks like a valid DNS query (at least a header)
-        if (len < sizeof(DnsHeader)) {
+        if (len < (int)sizeof(DnsHeader)) {
             continue;
         }
 
@@ -139,7 +172,7 @@ void DnsServer::dns_task(void* pvParameters) {
             // Copy queries section from rx to tx
             // Finding the end of queries section
             int query_offset = sizeof(DnsHeader);
-            
+
             // Re-read questions section to find boundaries safely
             bool valid_query = true;
             for (int q = 0; q < qdcount; q++) {
@@ -153,7 +186,7 @@ void DnsServer::dns_task(void* pvParameters) {
                     }
                     query_offset += 1 + label_len;
                 }
-                
+
                 if (!valid_query) break;
                 query_offset += 1; // skip null byte
 
@@ -165,7 +198,7 @@ void DnsServer::dns_task(void* pvParameters) {
                 query_offset += 4;
             }
 
-            if (!valid_query || query_offset > sizeof(tx_buffer)) {
+            if (!valid_query || query_offset > (int)sizeof(tx_buffer)) {
                 continue;
             }
 
@@ -181,29 +214,32 @@ void DnsServer::dns_task(void* pvParameters) {
             answer.rdlength = htons(4);      // IPv4 length (4 bytes)
 
             int tx_len = query_offset;
-            if (tx_len + sizeof(DnsAnswerHeader) + 4 <= sizeof(tx_buffer)) {
+            if (tx_len + (int)sizeof(DnsAnswerHeader) + 4 <= (int)sizeof(tx_buffer)) {
                 memcpy(tx_buffer + tx_len, &answer, sizeof(DnsAnswerHeader));
                 tx_len += sizeof(DnsAnswerHeader);
                 memcpy(tx_buffer + tx_len, ip_bytes, 4);
                 tx_len += 4;
 
                 // Send back reply to source address
-                int sent = sendto(self->_socketFd, tx_buffer, tx_len, 0,
+                int sent = sendto(sock, tx_buffer, tx_len, 0,
                                   reinterpret_cast<struct sockaddr *>(&source_addr),
                                   socklen);
-                 if (sent < 0) {
-                     ESP_LOGE(TAG, "DNS sendto failed: errno %d", errno);
-                 }
-             }
-         }
-     }
+                if (sent < 0) {
+                    ESP_LOGE(TAG, "DNS sendto failed: errno %d", errno);
+                }
+            }
+        }
+    }
 
-     if (self->_socketFd != -1) {
-         close(self->_socketFd);
-         self->_socketFd = -1;
-     }
-     self->_running = false;
-     self->_taskHandle = nullptr;
-     ESP_LOGI(TAG, "DNS server task completed.");
-     vTaskDelete(NULL);
- }
+    // This task owns the socket close unless stop() raced in first; exchange() makes
+    // it single-owner so the fd is closed exactly once.
+    int fd = self->_socketFd.exchange(-1, std::memory_order_acq_rel);
+    if (fd != -1) {
+        close(fd);
+    }
+    self->_running.store(false, std::memory_order_release);
+    ESP_LOGI(TAG, "DNS server task completed.");
+    // LAST access to `self`: signal stop()/destructor that we have fully exited.
+    if (self->_exitSem) xSemaphoreGive(self->_exitSem);
+    vTaskDelete(NULL);
+}

--- a/main/wifi/DnsServer.hpp
+++ b/main/wifi/DnsServer.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <string>
+#include <atomic>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "freertos/semphr.h"
 
 class DnsServer {
 public:
@@ -12,8 +14,9 @@ public:
     // Start the DNS server task on UDP port 53.
     // Binds to 0.0.0.0 (all interfaces) or a specific interface IP (e.g. 192.168.4.1).
     bool start(const std::string& resolvedIp = "192.168.4.1");
-    
-    // Stop the DNS server and release resources.
+
+    // Stop the DNS server and release resources. Blocks (bounded) until dns_task has
+    // actually exited, so it is safe to destroy the object immediately afterwards.
     void stop();
 
 private:
@@ -21,6 +24,12 @@ private:
 
     std::string _resolvedIp;
     TaskHandle_t _taskHandle;
-    int _socketFd;
-    bool _running;
+    // _socketFd and _running are touched from BOTH the caller (start/stop) and
+    // dns_task on another core, so they are atomic — a plain int/bool would be a
+    // data race on the SMP Xtensa. _exitSem is given by dns_task as its last act so
+    // stop() can join it before the object is torn down (no use-after-free).
+    std::atomic<int>  _socketFd;
+    std::atomic<bool> _running;
+    bool _taskStarted = false;             // a dns_task was successfully created
+    SemaphoreHandle_t _exitSem = nullptr;  // dns_task gives this right before it exits
 };

--- a/partitions.csv
+++ b/partitions.csv
@@ -26,6 +26,13 @@
 #     append-mostly with a known frame size, so a filesystem buys little. If random-
 #     access named-file management is later needed, reformat this same region as SPIFFS
 #     (subtype 0x82) WITHOUT moving the app slots — the OTA layout stays compatible.
+#   * WRITE DISCIPLINE (raw subtype 0x40 has NO filesystem and NO wear-leveling):
+#     any future writer MUST esp_partition_erase_range() the target sectors before
+#     esp_partition_write() — raw writes only clear bits, so writing without erasing
+#     first silently ORs garbage into existing audio. Distribute writes across the
+#     region rather than rewriting one spot: NOR flash endures only ~100K erase
+#     cycles per sector and nothing levels that here. The synth-tone beachhead writes
+#     nothing today; this note is the contract for when prompt/voicemail code lands.
 #
 # Name,     Type, SubType,  Offset,    Size
 nvs,        data, nvs,      0x9000,    0x6000

--- a/src/Helpers/AdminAuth.cpp
+++ b/src/Helpers/AdminAuth.cpp
@@ -578,6 +578,10 @@ namespace AdminAuth
 			// Constant-time compare against each live token.
 			if (constantTimeEquals(sess.token, token))
 			{
+				// Sliding expiry: an actively-used session is kept alive. Each
+				// successful validation pushes the absolute deadline out by the
+				// full TTL so a working admin isn't logged out mid-session.
+				sess.expiresAtMs = now + AdminAuth::kSessionTtlMs;
 				return true;
 			}
 		}

--- a/src/Helpers/HttpServer.cpp
+++ b/src/Helpers/HttpServer.cpp
@@ -1000,25 +1000,38 @@ bool HttpServer::isSameOrigin(const HttpRequest& req) const
 	if (schemeEnd != std::string::npos)
 		originHost = originHost.substr(schemeEnd + 3);
 
-	// Strip port numbers from both originHost and req.host for comparison (if any)
-	auto stripPort = [](const std::string& h) -> std::string {
+	// Split "host:port" (port optional → empty string when absent).
+	auto splitHostPort = [](const std::string& h) -> std::pair<std::string, std::string> {
 		size_t colon = h.find(':');
-		if (colon != std::string::npos) return h.substr(0, colon);
-		return h;
+		if (colon != std::string::npos) return { h.substr(0, colon), h.substr(colon + 1) };
+		return { h, std::string() };
 	};
 
-	std::string cleanOrigin = stripPort(originHost);
-	std::string cleanHost = stripPort(req.host);
+	auto originParts = splitHostPort(originHost);
+	auto hostParts   = splitHostPort(req.host);
+	const std::string& cleanOrigin = originParts.first;
+	const std::string& cleanHost   = hostParts.first;
 
 	// Host header must be our local IP or local mDNS hostname or localhost
 	std::string activeIp = (_ip == "0.0.0.0") ? getPrimaryLocalIP() : _ip;
-	bool hostValid = (cleanHost == activeIp || 
-	                  cleanHost == "192.168.4.1" || 
+	bool hostValid = (cleanHost == activeIp ||
+	                  cleanHost == "192.168.4.1" ||
 	                  cleanHost == "pocketdial.local" ||
 	                  cleanHost == "localhost" ||
 	                  cleanHost == "127.0.0.1");
 
-	return hostValid && (cleanOrigin == cleanHost);
+	if (!hostValid || cleanOrigin != cleanHost) return false;
+
+	// When BOTH carry an explicit port, they must match — a page served from a
+	// different port is a different origin. If either omits the port we fall back
+	// to the host-only check (browsers elide the default :80/:443, so requiring a
+	// port there would reject otherwise-legitimate same-origin requests).
+	if (!originParts.second.empty() && !hostParts.second.empty() &&
+	    originParts.second != hostParts.second)
+	{
+		return false;
+	}
+	return true;
 }
 
 std::string HttpServer::cookieValue(const HttpRequest& req, const std::string& name)
@@ -1107,15 +1120,20 @@ static std::string urlDecode(const std::string& src)
 
 static std::string getFormParam(const std::string& body, const std::string& key)
 {
-	std::string prefix = key + "=";
-	size_t pos = body.find(prefix);
-	if (pos == std::string::npos)
+	const std::string needle = key + "=";
+	// Match the key only at a parameter boundary: the start of the body, or
+	// immediately after an '&'. A bare find() mis-matches a key that is a suffix
+	// of an earlier one — e.g. searching "on=" inside "extension=101&on=1" finds
+	// the "n=" of "extensio[n=]101" and returns "101", so DND silently inverted.
+	size_t pos = 0;
+	for (;;)
 	{
-		prefix = "&" + key + "=";
-		pos = body.find(prefix);
+		pos = body.find(needle, pos);
 		if (pos == std::string::npos) return "";
+		if (pos == 0 || body[pos - 1] == '&') break;   // real token boundary
+		pos += needle.length();                        // false hit — keep scanning
 	}
-	size_t start = pos + prefix.length();
+	size_t start = pos + needle.length();
 	size_t end = body.find('&', start);
 	std::string val;
 	if (end == std::string::npos) {

--- a/src/Helpers/SipDigest.cpp
+++ b/src/Helpers/SipDigest.cpp
@@ -200,6 +200,52 @@ namespace
 		return out;
 	}
 
+	// HMAC-MD5 (RFC 2104) -> 32-char lowercase hex. A real HMAC, NOT the
+	// length-extension-forgeable MD5(secret || message) construction. Used to tag
+	// the stateless nonce so an attacker who observes a nonce cannot forge a valid
+	// tag for a different timestamp.
+	std::string hmacMd5Hex(const std::string& key, const std::string& msg)
+	{
+		constexpr size_t BLOCK = 64;
+		uint8_t k[BLOCK] = {0};
+		if (key.size() > BLOCK)
+		{
+			Md5 kh;
+			uint8_t kd[16];
+			kh.update(key);
+			kh.finalize(kd);
+			std::memcpy(k, kd, sizeof(kd));
+		}
+		else
+		{
+			std::memcpy(k, key.data(), key.size());
+		}
+
+		uint8_t ipad[BLOCK];
+		uint8_t opad[BLOCK];
+		for (size_t i = 0; i < BLOCK; ++i)
+		{
+			ipad[i] = static_cast<uint8_t>(k[i] ^ 0x36);
+			opad[i] = static_cast<uint8_t>(k[i] ^ 0x5c);
+		}
+
+		uint8_t inner[16];
+		{
+			Md5 h;
+			h.update(ipad, BLOCK);
+			h.update(reinterpret_cast<const uint8_t*>(msg.data()), msg.size());
+			h.finalize(inner);
+		}
+		uint8_t outer[16];
+		{
+			Md5 h;
+			h.update(opad, BLOCK);
+			h.update(inner, sizeof(inner));
+			h.finalize(outer);
+		}
+		return toHex(outer, sizeof(outer));
+	}
+
 	// Cryptographically-strong (on ESP) random bytes; on host, a PRNG seeded from
 	// random_device (host is a developer/CI simulator). Mirrors AdminAuth.
 	void fillRandom(uint8_t* buf, size_t len)
@@ -451,10 +497,11 @@ namespace SipDigest
 	{
 		std::string nonceTag(uint64_t tsMs)
 		{
-			// Keyed MD5 over the timestamp. Not a true HMAC, but adequate as an
-			// integrity tag for a server-issued, short-lived nonce (the secret is
-			// never transmitted and rotates on reboot).
-			return md5Hex(nonceServerSecret() + ":" + std::to_string(tsMs));
+			// HMAC-MD5 over the timestamp, keyed by the process-lifetime server
+			// secret. A true HMAC (not MD5(secret || msg)) so the tag is not
+			// length-extension forgeable. The secret is never transmitted and
+			// rotates on reboot.
+			return hmacMd5Hex(nonceServerSecret(), std::to_string(tsMs));
 		}
 
 		std::string toHexU64(uint64_t v)

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -81,7 +81,6 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 			_messagePool.push_back(std::make_shared<SipSdpMessage>("", sockaddr_in{}));
 		}
 	}
-	_dummyClient = std::make_shared<SipClient>();
 
 	// Reload persisted PBX config (call-forward / ring groups) and the CDR ring from
 	// NVS so they survive reboot. No-ops on host. Construction is single-threaded
@@ -143,17 +142,23 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 		return;
 	}
 
-	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> localOutbox;
-	std::vector<std::pair<bool, std::string>> localLogs;
+	// Per-source IP rate limiting (Issue #38 / SEC-02) runs under its OWN lock,
+	// BEFORE the big handler _mutex, so a flood from blocked IPs is dropped without
+	// ever serializing on _mutex against legitimate signaling. ipAllowed/allowPacket
+	// touch only the rate state, which _rateMutex now guards.
 	{
-		std::lock_guard<std::mutex> lock(_mutex);
-
-		// Per-source IP Rate Limiting (Issue #38 / SEC-02)
+		std::lock_guard<std::mutex> rlock(_rateMutex);
 		if (!ipAllowed(request->getSource()) || !allowPacket(request->getSource()))
 		{
 			_packetsDropped.fetch_add(1, std::memory_order_relaxed);
 			return;
 		}
+	}
+
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> localOutbox;
+	std::vector<std::pair<bool, std::string>> localLogs;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		_packetsProcessed.fetch_add(1, std::memory_order_relaxed);
 		_outbox.clear();
@@ -357,7 +362,9 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 		auto newClient = allocateClient(std::string(data->getFromNumber()), data->getSource(), grantedExpires);
 		if (newClient)
 		{
-			registerClient(newClient);
+			// allocateClient() has already placed the binding in the client pool;
+			// the registrar keeps no separate index, so there is nothing more to do
+			// here (this was previously a no-op registerClient() hook).
 			// Register beep: on a brand-new binding ONLY (never a lease refresh —
 			// phones re-REGISTER every lease period), send the registering phone a
 			// brief intercom auto-answer INVITE so it plays its own tone, then tear
@@ -529,11 +536,16 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		okResponse->enforceG711();
 		_outbox.emplace_back(data->getSource(), std::move(okResponse));
 
-		_dummyClient->reset("777", data->getSource(), 3600);
+		// Per-session dummy dest (never the old shared _dummyClient): a concurrent
+		// 777/440 call must not overwrite this session's destination identity. The
+		// shared_ptr lives as long as the session references it (released on
+		// teardown / pool reuse) — bounded by the session pool, not the packet path.
+		auto dummy777 = std::make_shared<SipClient>();
+		dummy777->reset("777", data->getSource(), 3600);
 		auto newSession = allocateSession(std::string(data->getCallID()), caller.value());
 		if (newSession)
 		{
-			newSession->setDest(_dummyClient);
+			newSession->setDest(dummy777);
 			_sessions.emplace(data->getCallID(), newSession);
 			newSession->setState(Session::State::Connected);
 		}
@@ -839,6 +851,46 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 		return;
 	}
 
+	// Start the RTP tone stream FIRST. Sending 200 OK before the stream is up risks
+	// answering the call (caller hears nothing) when the socket/task fails to start,
+	// recoverable only by the caller hanging up. On failure answer 500 instead.
+	if (!_rtpSender.start(destIp, destPort, std::string(data->getCallID())))
+	{
+		auto err = getMessageFromPool(data->toString(), data->getSource());
+		err->setHeader("SIP/2.0 500 Server Internal Error");
+		err->clearBody();
+		err->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		err->setContact(buildContact("440"));
+		_outbox.emplace_back(data->getSource(), std::move(err));
+		queueLog("440 media: RTP stream failed to start to " + destIp + ":"
+			+ std::to_string(destPort), true);
+		return;
+	}
+
+	// Track a Session so the dashboard shows the call and CDR is recorded on teardown.
+	// Per-session dummy dest (never a shared client) so a concurrent 777/440 can't
+	// overwrite this call's destination identity. If the session pool is full, stop
+	// the stream we just started and answer 503 rather than streaming an untracked
+	// call that nothing can later tear down.
+	auto dummy440 = std::make_shared<SipClient>();
+	dummy440->reset("440", data->getSource(), 3600);
+	auto newSession = allocateSession(std::string(data->getCallID()), caller);
+	if (!newSession)
+	{
+		_rtpSender.stop(std::string(data->getCallID()));
+		auto busy = getMessageFromPool(data->toString(), data->getSource());
+		busy->setHeader("SIP/2.0 503 Service Unavailable");
+		busy->clearBody();
+		busy->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		busy->setContact(buildContact("440"));
+		_outbox.emplace_back(data->getSource(), std::move(busy));
+		queueLog("440 media: session pool full, rejected " + std::string(data->getFromNumber()), true);
+		return;
+	}
+	newSession->setDest(dummy440);
+	_sessions.emplace(data->getCallID(), newSession);
+	newSession->setState(Session::State::Connected);
+
 	// Build the 200 OK carrying the SERVER's own SDP. We rebuild the message body
 	// directly (there is no generic body setter): take the INVITE clone, strip its
 	// body, then append our SDP and the SDP Content-Type, and resync Content-Length
@@ -881,29 +933,8 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	ok->syncContentLength();             // belt-and-suspenders: length == body bytes
 	_outbox.emplace_back(data->getSource(), std::move(ok));
 
-	// Track a Session so the dashboard shows the call and CDR is recorded on teardown.
-	_dummyClient->reset("440", data->getSource(), 3600);
-	auto newSession = allocateSession(std::string(data->getCallID()), caller);
-	if (newSession)
-	{
-		newSession->setDest(_dummyClient);
-		_sessions.emplace(data->getCallID(), newSession);
-		newSession->setState(Session::State::Connected);
-	}
-
-	// Start the RTP tone stream to the caller. If it fails to start (socket/task),
-	// we have already sent 200 OK; the caller's later BYE/CANCEL tears the session
-	// down. Log it so the failure is visible.
-	if (_rtpSender.start(destIp, destPort, std::string(data->getCallID())))
-	{
-		queueLog("440 media: streaming tone to " + destIp + ":" + std::to_string(destPort)
-			+ " (callID=" + std::string(data->getCallID()) + ")");
-	}
-	else
-	{
-		queueLog("440 media: RTP stream failed to start to " + destIp + ":"
-			+ std::to_string(destPort), true);
-	}
+	queueLog("440 media: streaming tone to " + destIp + ":" + std::to_string(destPort)
+		+ " (callID=" + std::string(data->getCallID()) + ")");
 }
 
 void RequestsHandler::onTrying(std::shared_ptr<SipMessage> data)
@@ -1642,16 +1673,13 @@ std::shared_ptr<SipMessage> RequestsHandler::buildCancel(const std::shared_ptr<S
 	return cancelMsg;
 }
 
-bool RequestsHandler::setCallState(std::string_view callID, Session::State state)
+void RequestsHandler::setCallState(std::string_view callID, Session::State state)
 {
 	auto session = getSession(callID);
 	if (session)
 	{
 		session->get()->setState(state);
-		return true;
 	}
-
-	return false;
 }
 
 void RequestsHandler::endCall(std::string_view callID, std::string_view srcNumber, std::string_view destNumber, std::string_view reason)
@@ -1765,11 +1793,6 @@ void RequestsHandler::recordCdr(const std::shared_ptr<Session>& session,
 	// Persist the ring so records survive reboot (write-through on teardown; no-op
 	// on host). Caller (endCall) holds _mutex. See persistCdrRing() for the wear note.
 	persistCdrRing();
-}
-
-bool RequestsHandler::registerClient(std::shared_ptr<SipClient>)
-{
-	return true;
 }
 
 void RequestsHandler::unregisterClient(std::string_view number)
@@ -2763,16 +2786,22 @@ void RequestsHandler::tick()
 			}
 		}
 
-		// Sweep rate-limit buckets older than 60 seconds (Issue #58)
-		for (auto rit = _rateBuckets.begin(); rit != _rateBuckets.end(); )
+		// Sweep rate-limit buckets older than 60 seconds (Issue #58). The bucket map
+		// now lives under _rateMutex (so per-packet admission never serializes on the
+		// big _mutex), so take it here too. Nesting order is _mutex → _rateMutex;
+		// handle() only ever holds them disjointly, so there is no deadlock.
 		{
-			if (now - rit->second.last > std::chrono::seconds(60))
+			std::lock_guard<std::mutex> rlock(_rateMutex);
+			for (auto rit = _rateBuckets.begin(); rit != _rateBuckets.end(); )
 			{
-				rit = _rateBuckets.erase(rit);
-			}
-			else
-			{
-				++rit;
+				if (now - rit->second.last > std::chrono::seconds(60))
+				{
+					rit = _rateBuckets.erase(rit);
+				}
+				else
+				{
+					++rit;
+				}
 			}
 		}
 
@@ -3841,9 +3870,12 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 			auto session = getSession(callId);
 			if (session.has_value())
 			{
-				_dummyClient->reset("777", session.value()->getSrc()
+				// Per-session dummy dest (never a shared client) so concurrent
+				// star-code/777/440 calls can't clobber each other's destination.
+				auto dummy = std::make_shared<SipClient>();
+				dummy->reset("777", session.value()->getSrc()
 					? session.value()->getSrc()->getAddress() : sockaddr_in{}, 3600);
-				session.value()->setDest(_dummyClient);
+				session.value()->setDest(dummy);
 			}
 		}
 		else
@@ -3863,8 +3895,10 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 			auto src = session.value()->getSrc();
 			if (src)
 			{
-				_dummyClient->reset("777", src->getAddress(), 3600);
-				session.value()->setDest(_dummyClient);
+				// Per-session dummy dest (never a shared client) — see *69 above.
+				auto dummy = std::make_shared<SipClient>();
+				dummy->reset("777", src->getAddress(), 3600);
+				session.value()->setDest(dummy);
 				queueLog("*11 echo loopback for call " + callId);
 			}
 		}

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -204,7 +204,7 @@ private:
 	// Find the beep slot owning a Call-ID, or nullptr. Caller holds _mutex.
 	BeepDialog* findBeepByCallID(std::string_view callID);
 
-	bool setCallState(std::string_view callID, Session::State state);
+	void setCallState(std::string_view callID, Session::State state);
 	void endCall(std::string_view callID, std::string_view srcNumber, std::string_view destNumber, std::string_view reason = "");
 
 	// CDR: write one record into the ring as a call ends. Caller must hold _mutex.
@@ -268,7 +268,6 @@ private:
 	// 2nd dial while busy is rejected 486 Busy Here. Caller holds _mutex.
 	void onMediaInvite(std::shared_ptr<SipMessage> data, const std::shared_ptr<SipClient>& caller);
 
-	bool registerClient(std::shared_ptr<SipClient> client);
 	void unregisterClient(std::string_view number);
 
 	// Registration-lease handling (RFC 3261 §10.2.1)
@@ -310,7 +309,6 @@ private:
 
 	std::shared_ptr<SipClient> allocateClient(std::string number, sockaddr_in address, int expiresSeconds);
 	std::shared_ptr<Session> allocateSession(std::string callID, std::shared_ptr<SipClient> src);
-	std::shared_ptr<SipClient> _dummyClient;
 
 	// Server-side RTP media source (the 440 tone stream). One concurrent stream; the
 	// ESP-only UDP socket + 20 ms pacing task live inside it, guarded for host builds.
@@ -450,6 +448,13 @@ private:
 	// Optional CIDR allowlist (host order). _allowMask == 0 means "no allowlist".
 	uint32_t _allowNet  = 0;
 	uint32_t _allowMask = 0;
+	// Dedicated lock for the rate-limit state (_rateBuckets / allowlist), held
+	// for the per-packet admission check BEFORE the big handler _mutex so a flood
+	// from blocked IPs is dropped without ever serializing on _mutex against
+	// legitimate signaling. Lock order: never acquire _mutex while holding this;
+	// tick() may nest this inside _mutex (the only place both are held), so the
+	// one ordering is _mutex → _rateMutex and handle() holds them disjointly.
+	std::mutex _rateMutex;
 
 	std::chrono::steady_clock::time_point _lastSweep{};
 	std::chrono::steady_clock::time_point _lastTick{};


### PR DESCRIPTION
Two-pass code review (general engine + embedded-firmware) turned into fixes across the cross-platform SIP engine (`src/`) and all four ESP-IDF entry points (`main/`), plus a CI correction to ESP-IDF **v6.0.1 only**.

## Validation
- **Engine (`src/`)**: host MSVC build clean, **113/113** GoogleTest cases, `tests/http/test_api.sh` smoke green (the lone "fail" is a Windows curl RST-before-drain artifact on the untouched 16 KB body-cap path; passes on the Linux CI runner).
- **Firmware (`main/`)**: compiled locally on **ESP-IDF v6.0.1** — `display`, `eth`, and `wifi` transports each build clean and produce `SipServer.bin`. `lan8720` carries byte-identical edits to `eth`.

## Engine fixes (`src/`)
- **CRITICAL** `getFormParam` matched keys as bare substrings → silently inverted `POST /api/dnd` when `extension` preceded `on`; now anchors to `&`/start boundaries.
- **HIGH** `777`/`440`/`*11`/`*69` shared one `_dummyClient`, clobbering each other's destination on concurrent virtual calls → per-session client.
- **HIGH** `440` media answered `200 OK` before `RtpSender::start()` → start RTP first (500 on fail), allocate session (503 + stop on full), then answer.
- **MED** per-source rate limiting took the global `_mutex` before dropping a blocked IP → dedicated `_rateMutex` checked first.
- **MED** nonce tag was `MD5(secret‖msg)` (length-extension forgeable) → HMAC-MD5.
- **MED** admin session had no sliding expiry → extend TTL on each successful validate.
- **LOW** port-blind `isSameOrigin`; dead no-op `registerClient()`; `setCallState()` → `void`.

## Firmware fixes (`main/`)
- **CRITICAL** `g_sipServer` was a plain cross-core pointer (stale-null / half-built read, hoistable poll) in all four entry points → `std::atomic` with acquire/release.
- **CRITICAL** DnsServer data race + use-after-free → atomic `_running`/`_socketFd`, single-owner socket close, join `dns_task` via exit semaphore before teardown, add `SO_RCVTIMEO`.
- **CRITICAL** display `http_server_task` spun forever if the SIP server OOM'd → bounded ~30 s then self-exit.
- **HIGH** unbounded provisioning credential spin → 30-min cap then `esp_restart()`.
- **HIGH** captive-decay `esp_restart()` racing concurrent flash writes → `esp_wifi_stop()` first.
- **MED** deprecated `esp_event_handler_register` (eth/lan8720) → `esp_event_handler_instance_register`.
- **MED** ISR-unsafe log hook → `xQueueSendFromISR` under `xPortInIsrContext()`.
- **LOW** checked `esp_netif_attach`/glue returns, freed leaked event groups, raw-partition erase/wear contract comment.

## CI
- Build matrix → **ESP-IDF v6.0.1 only** (the v5.1.2/v5.2.1 legs no longer build now that components/guards target v6); excluded the meaningless `esp32 + eth` leg.

## Deliberately not changed (reviewed, declined — see CHANGELOG)
- RTP task core affinity (Core 0 placement is a deliberate anti-LVGL-contention choice).
- `_messagePool` static storage (load-bearing: `SipMessageFactory` calls the static `getMessageFromPool`; the dangling concern doesn't hold).
- pthread stack for wolfSSH (already runs in its own explicit 24 KB task).
- A few hardware-verified display-timing/PSRAM items left as-is to avoid regressing the validated panel.
