### PR TITLE
ci: clear remaining cppcheck performance findings (host job green)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ changes are compile-gated by the CI ESP-IDF matrix.
   LVGL's headers). This had been failing the host CI job since the Learn-mode
   display work landed; the suppression is scoped to `unknownMacro` on that one file
   so genuine warnings there still fire.
+- Cleared the five pre-existing cppcheck `performance` findings that had also been
+  failing the host job (real fixes, not suppressions): `SipDigest.cpp` nonce split now
+  uses `string_view::substr` instead of pointer/length construction; `SipSecretStore.cpp`
+  trims the NVS buffer via `resize(len-1)` + move instead of copying through `c_str()`;
+  two `Tui.cpp` self-prefix `substr` assignments became `resize()`; and
+  `RequestsHandler::startBroadcastFork` takes its `targets` vector by const reference.
+  Host build + GoogleTest suite re-verified green.
 
 ### Deliberately not changed (reviewed, declined)
 - **RTP task core affinity**: the media TX/RX tasks stay on Core 0 — on the display

--- a/src/Helpers/SipDigest.cpp
+++ b/src/Helpers/SipDigest.cpp
@@ -548,8 +548,9 @@ namespace SipDigest
 		{
 			return false;
 		}
-		std::string_view tsHex(nonce.data(), dot);
-		std::string_view tag(nonce.data() + dot + 1, nonce.size() - dot - 1);
+		std::string_view nonceView(nonce);
+		std::string_view tsHex = nonceView.substr(0, dot);
+		std::string_view tag = nonceView.substr(dot + 1);
 
 		uint64_t ts = 0;
 		if (!fromHexU64(tsHex, ts))

--- a/src/Helpers/SipSecretStore.cpp
+++ b/src/Helpers/SipSecretStore.cpp
@@ -116,8 +116,9 @@ namespace
 		{
 			return out;
 		}
-		// len includes the NUL; build lines from the C-string content.
-		std::string s(buf.c_str());
+		// len includes the trailing NUL; trim it to get the stored text.
+		if (len > 0) buf.resize(len - 1);
+		std::string s = std::move(buf);
 		size_t start = 0;
 		while (start < s.size())
 		{

--- a/src/Helpers/Tui.cpp
+++ b/src/Helpers/Tui.cpp
@@ -1521,7 +1521,7 @@ void Tui::drawMonitorFrame()
                     const RosterRow& rr = ms.roster[idx];
                     std::string lbl = rr.ext;
                     if (!rr.name.empty()) lbl += " " + rr.name;
-                    if ((int)lbl.size() > width) lbl = lbl.substr(0, width);
+                    if ((int)lbl.size() > width) lbl.resize((size_t)width);
                     char b[40]; std::snprintf(b, sizeof(b), " %-*s ", width, lbl.c_str());
                     body += col(Role::Text, b);
                     int vis = 0; appendStateChip(rr.state, body, vis);
@@ -5374,7 +5374,7 @@ void Tui::onKeyPbxGroupEdit(Key k, unsigned char ch)
                 // Extract the bare ext (the label may be "101 Maria").
                 std::string ext = _grpMembers[i];
                 size_t sp = ext.find(' ');
-                if (sp != std::string::npos) ext = ext.substr(0, sp);
+                if (sp != std::string::npos) ext.resize(sp);
                 int ord = (i < _grpOrder.size()) ? _grpOrder[i] : 0;
                 picked.push_back({ ord > 0 ? ord : 1000000 + (int)i, ext });
             }

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1494,7 +1494,7 @@ void RequestsHandler::buildInviteFork(const std::shared_ptr<SipMessage>& invite,
 
 void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
 	std::shared_ptr<SipClient> caller,
-	std::vector<std::shared_ptr<SipClient>> targets,
+	const std::vector<std::shared_ptr<SipClient>>& targets,
 	bool intercom)
 {
 	// Shared fan-out core: build the broadcast Session, send 180 Ringing to the

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -232,7 +232,7 @@ private:
 	// and one forked INVITE per target. Caller holds _mutex.
 	void startBroadcastFork(std::shared_ptr<SipMessage> invite,
 		std::shared_ptr<SipClient> caller,
-		std::vector<std::shared_ptr<SipClient>> targets,
+		const std::vector<std::shared_ptr<SipClient>>& targets,
 		bool intercom);
 
 	// Build and queue a single INVITE fork toward one target, re-pointing the


### PR DESCRIPTION
## What

Follow-up to #85. The host CI job (`Host Build & Simulation Testing`) had **six**
cppcheck findings failing `--error-exitcode=1`. #85 silenced the LVGL `unknownMacro`
error; this PR clears the remaining **five `performance` findings** — all pre-existing
on `main` since the SSH-terminal / digest-auth work, and all **real fixes, not
suppressions**:

| File | Finding | Fix |
|---|---|---|
| `SipDigest.cpp` | `stlcstrConstructor` | split the nonce with `string_view::substr` instead of the `(ptr, len)` constructor |
| `SipSecretStore.cpp` | `stlcstrConstructor` | trim the fixed NVS buffer via `resize(len-1)` + move rather than copying through `c_str()` (`len` already includes the NUL) |
| `Tui.cpp` (×2) | `uselessCallsSubstr` | self-prefix `s = s.substr(0, n)` → `s.resize(n)` |
| `RequestsHandler.cpp` | `passedByValue` | `startBroadcastFork` takes `targets` by const reference |

## Safety notes
- `emitEntry`'s `width` is always a positive literal (`13`), so `resize((size_t)width)` can''t underflow.
- `sp` is a checked `find('' '')` index (`!= npos`), so `resize(sp)` is in-bounds.
- `startBroadcastFork` only **iterates** `targets` and copies it into the session — no mutation, so const-ref is behaviour-preserving.

## Validation
- Host MSVC Release build: clean.
- GoogleTest suite: pass.
- Expecting the host job to go **green** for the first time since ~June 8.
