### PR TITLE
feat: SIP protocol backport — call parking, BLF, session timers, hold/resume, paging zones, AnchorClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,10 +85,8 @@ host_test*.log
 # Shareable binary packages (built locally from build_host_ssh; never commit binaries)
 dist/
 
-# local docs — read the code
-docs/
+# Local scratch and rename-history artefacts
 notes/
-*.txt
 LINEAGE.md
 *.old
 *.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,32 @@ passing.
 - `tests/CMakeLists.txt`: added `PlayoutBuffer.cpp`, `LoopbackAnchorClient.cpp`, and
   the three new test files.
 
-### Fixed
+### Fixed (code-review pass — all confirmed during sip-backport review)
+
+- **Broadcast re-INVITE hold triggered first-answer connect path** (`onOk`): the guard
+  `state != Connected` was also true for `Held`, so a hold 200 OK re-overwrote the
+  established dest and cancelled already-gone pending targets. Changed guard to
+  `state == Invited`. (#69)
+- **tick()-originated INVITE forks had no Timer A/B coverage** (`tick()`): added the
+  same `classifyTxType`/`registerTx` outbox scan that exists in `handle()`, so park
+  ring-back, hunt-group next-ring, and CFNA redirect are all registered for RFC 3261
+  §17 retransmit. (#70)
+- **Park retrieve slot cleared on session-pool exhaustion** (`onParkInvite`): moved
+  `allocateSession` before queuing the 200 OK and sending the re-INVITE; returns 503
+  and leaves the slot intact if the pool is exhausted. (#71)
+- **`sweepSessionTimers` emitted malformed BYE when dialog-To was empty**: added
+  `!dTo.empty()` guard to both BYE paths. (#72)
+- **`Held` state CDR-logged as Failed with zero duration** (`recordCdr`): added
+  `Session::State::Held` to the `Connected`/`Bye` `CdrResult::Answered` case. (#73)
+- **`sendParkReinvite` emitted bare Call-ID token** (missing `"Call-ID: "` label):
+  single-character fix; RFC 3261 §20.8 violation — phones rejected or dropped the
+  retrieve re-INVITE. (part of #68 work)
+- **`getPrimaryLocalIP()` called under `_mutex`** in 7 new functions: resolved once at
+  construction into `_localIp`; all 20+ `(_serverIp == "0.0.0.0") ? getPrimaryLocalIP()
+  : _serverIp` sites replaced. Eliminates a socket/connect syscall from the packet hot
+  path. CLAUDE.md §"No blocking I/O under the registrar lock". (#67 follow-on)
+
+### Fixed (pre-existing)
 
 - `onBye` and `onCancel`: spoofed-teardown guard (`isDialogSourceAuthorized`).
 - `onCancel`: park-orbit CANCEL now tears down the orbit slot and refreshes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## Unreleased (sip-backport) - 2026-06-23
+
+Full SIP protocol feature backport into the engine. Build: zero errors (one
+pre-existing `inet_addr` deprecation warning on MSVC, pre-existing). Tests: all
+passing.
+
+### Added — SIP protocol
+
+- **RFC 3261 §17 transaction layer** (`RequestsHandler.cpp`): `SipTransaction` pool, Timer A
+  retransmit with exponential back-off, Timer B 32 s timeout; `sweepTransactions()` runs
+  each tick; `freeTxsForCallId()` cleans up on teardown. Outgoing INVITEs are
+  auto-registered on every `handle()` / `tick()` pass.
+- **RFC 4028 session timers** (`RequestsHandler.cpp`): `armSessionTimer()` called on call
+  connect; `sweepSessionTimers()` sends server-originated BYE to both legs on expiry.
+  Server is always refresher (UAS policy).
+- **RFC 3311 mid-dialog UPDATE** (`onUpdate()`): relay SDP-bearing UPDATE to the peer leg;
+  bodiless UPDATE responds `200 OK` and resets the session timer.
+- **RFC 3261 §12.2 mid-dialog re-INVITE** (`onReinvite()`): hold (`a=sendonly`/`inactive`)
+  sets `Session::State::Held`; resume restores `Connected`. CDR talk-time preserved across
+  hold/resume. 200 OK relay in `onOk()` via `sameAddress()` peer lookup.
+- **Call parking** (`onParkInvite`, `handleParkOk`, `parkSweep`, `startParkRingback`, …):
+  virtual orbit extensions 700–709; park with `a=inactive` hold SDP; SDP-swap retrieve;
+  ring-back on timeout with configurable orbit; bridged BYE relay on teardown.
+- **Paging zones** (`onInvite`, `findPageZone`, `setPageZone`, `getPageZones`, `persistPageZones`):
+  extensions 980–989; intercom auto-answer fork via `startBroadcastFork()`; NVS persistence
+  under key `"pzones"`; mirrored into `_snapshot.pageZones` for the dashboard.
+- **BLF / presence** (`onSubscribe`, `refreshSubscriptions`, `sweepSubscriptions`,
+  `buildDialogInfoXml`, `computeDialogState`, `buildDialogNotify`): RFC 6665 SUBSCRIBE /
+  NOTIFY with RFC 4235 dialog-info+xml body; 489 Bad Event for unsupported packages; change
+  detection on every `handle()` pass; terminal NOTIFY on subscription expiry.
+- **`isDialogSourceAuthorized()`**: rejects forged BYE / CANCEL from off-path addresses
+  (issue #46); wired into `onBye()` and `onCancel()`.
+- **`AnchorClient` interface** (`src/SIP/AnchorClient.hpp`): abstract class for external
+  audio systems; `makeCall`, `writeAudio`, `AudioRxCallback`, `dropCall`, lifecycle.
+- **`LoopbackAnchorClient`** (`src/SIP/LoopbackAnchorClient.cpp/hpp`): reference
+  implementation; echoes audio back to the caller; useful as a smoke test and as a
+  starting template for SIP trunk / recorder / AI pipeline integrations.
+- **`PlayoutBuffer`** (`src/SIP/PlayoutBuffer.cpp/hpp`): adaptive jitter buffer (200 ms
+  ceiling, comfort-noise underrun fill, overrun drop-oldest); used by AnchorClient paths.
+- **Virtual peer pool** (`_virtualPeerPool`): pre-allocated `POCKETDIAL_VIRTUAL_PEERS`
+  `SipClient` shared_ptrs; `allocateVirtualPeer()` recycles by use-count; park and BLF
+  use this pool instead of heap-allocating per-call.
+- **File-scope static helpers**: `sameAddress()`, `parkTagOf()`, `stripHeaderName()`;
+  forward-declared at top of `RequestsHandler.cpp`.
+- **`SipMessageTypes`**: `UPDATE`, `SUBSCRIBE`, `BAD_EVENT` constants.
+
+### Added — tests
+
+- `tests/PageZone_test.cpp`: `isPageZoneExt`, `splitZoneMembers`, `joinMembers`
+  round-trip and cap tests.
+- `tests/PlayoutBuffer_test.cpp`: write/read, underrun/overrun, clear, null-guard,
+  target-depth tests.
+- `tests/AnchorClient_test.cpp`: `LoopbackAnchorClient` lifecycle, `makeCall` event
+  delivery, audio loopback, `dropCall` Dropped event.
+- `tests/CMakeLists.txt`: added `PlayoutBuffer.cpp`, `LoopbackAnchorClient.cpp`, and
+  the three new test files.
+
+### Fixed
+
+- `onBye` and `onCancel`: spoofed-teardown guard (`isDialogSourceAuthorized`).
+- `onCancel`: park-orbit CANCEL now tears down the orbit slot and refreshes the
+  dashboard snapshot; paging zone CANCEL now forks correctly (was only handling `999`).
+- `onBye`: paging zone BYE now forks correctly (was only handling `999`).
+- `onOk`: `handleParkOk` / `handleTransferOk` intercepts added before the session
+  lookup; re-INVITE 200 OK relay (hold/resume) added; `setDialogHeaders` +
+  `setRemoteSdp` + `armSessionTimer` called on call connect.
+- `.gitignore`: `docs/` removed from exclusion list; `LINEAGE.md` and scratch artefacts
+  remain excluded.
+
+---
+
 ## Unreleased (fix/code-review-hardening) - 2026-06-10
 
 Code-review pass across the cross-platform SIP engine (`src/`) and all four ESP-IDF

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,6 +6,28 @@ This document serves as the active issue tracker and architectural roadmap for *
 
 ## Active Issues & Backlog Roadmap
 
+### 🟡 Issue #69: Hold/resume on broadcast (ring-group) calls is not yet supported
+* **Status**: ⏳ Open / Planned
+* **Labels**: `bug`, `hold-resume`, `broadcast`
+* **Severity**: Medium
+
+#### Description
+When a phone in a ring-group (or 999 broadcast) call sends a re-INVITE to hold, the
+200 OK answer from the peer is silently discarded. The hold relay block in `onOk` is
+correctly guarded by `!isBroadcast()` to avoid looping, but there is no equivalent
+broadcast-aware relay path. As a result the phone's hold request is never forwarded, the
+re-INVITE transaction times out after 32 s (Timer D), and the phone treats hold as
+failed. Unicast hold/resume is unaffected.
+
+**Root cause (found by code review):** `onOk`'s broadcast first-answer block was guarded
+by `state != Connected`, which is also true for `Held` — so a re-INVITE 200 OK re-ran
+the connect path, overwrote the established dest, and sent CANCEL to already-gone targets.
+Fixed in this release: the guard now requires `state == Invited` so only a genuine first
+answer triggers the connect path. The 200 OK is now discarded (better than the previous
+destructive behaviour). A full relay path for broadcast hold/resume is tracked here.
+
+---
+
 ### 🟡 Issue #68: Smoke-test call parking on real hardware
 * **Status**: ⏳ Open / Planned
 * **Labels**: `hardware-testing`, `parking`
@@ -114,6 +136,113 @@ template for real connector implementations.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #73: `Held` state CDR-logged as Failed with zero duration
+* **Status**: ✅ Resolved (sip-backport)
+* **Labels**: `bug`, `cdr`, `hold-resume`
+
+#### Resolution
+`recordCdr()` switch did not handle `Session::State::Held`; it fell to `default: Failed`
+with `durationSec = 0`. Any call torn down while on hold (e.g. session-timer expiry,
+`sweepSessionTimers`) produced a zero-duration Failed CDR record even for calls that had
+been answered and talked for minutes. Fixed by adding `Held` to the `Connected`/`Bye`
+`CdrResult::Answered` case, which also computes talk time from `_startTime` (preserved
+across hold/resume by the `prev == Held` guard in `Session::setState`).
+
+---
+
+### 🟢 Issue #72: `sweepSessionTimers` sends malformed BYE when dialog-To header is empty
+* **Status**: ✅ Resolved (sip-backport)
+* **Labels**: `bug`, `session-timers`, `sip`
+
+#### Resolution
+Both BYE guards in `sweepSessionTimers` checked only `!dFrom.empty()`. If `dTo` was
+empty (possible when `armSessionTimer` was called from `onReinvite` before dialog headers
+were fully captured by `onOk`), `buildServerBye` received an empty `toHeader`, producing
+a `To: \r\n` line that phones drop as malformed. The session then re-fired malformed BYEs
+on every sweep tick without ever freeing the slot. Fixed by requiring `!dTo.empty()` on
+both guards before building either BYE.
+
+---
+
+### 🟢 Issue #71: `onParkInvite` retrieve path cleared the park slot before checking session-pool availability
+* **Status**: ✅ Resolved (sip-backport)
+* **Labels**: `bug`, `parking`, `reliability`
+
+#### Resolution
+The retrieve path sent the re-INVITE to the parked party and pushed the Call-ID to
+`_parkPendingAcks` before calling `allocateSession` for the retriever. If the session
+pool was exhausted, `allocateSession` returned nullptr and the `slot = ParkSlot{}` clear
+ran unconditionally, leaving a live untracked parked dialog: the parked phone answered the
+re-INVITE, an ACK was sent, but there was no retriever session, so all subsequent BYEs
+returned 481 and CDR was never recorded. Fixed by allocating the retriever session first;
+on failure a `503 Service Unavailable` is returned and the slot is left intact. The 200 OK
+and re-INVITE are sent only after a successful allocation.
+
+---
+
+### 🟢 Issue #70: tick()-originated INVITE forks had no RFC 3261 §17 retransmit coverage
+* **Status**: ✅ Resolved (sip-backport)
+* **Labels**: `bug`, `transaction-layer`, `reliability`
+
+#### Resolution
+The `registerTx` outbox scan (which registers outgoing INVITEs for Timer A/B retransmit)
+existed only in `handle()`. `tick()` populates `_outbox` with new INVITEs via
+`parkSweep()` → `startParkRingback()`, `huntRingNext()` → `buildInviteFork()`, and
+`redirectInvite()` → `buildInviteFork()`, but had no equivalent scan — all three paths
+sent INVITEs fire-and-forget with no retransmit. On a lossy link (Wi-Fi, cross-VLAN)
+these silently fail: park ring-back never reaches the parker, CFNA redirect never arrives,
+hunt-group next-ring never rings the next member. Fixed by adding the same `classifyTxType`
+/ `registerTx` scan loop in `tick()` before the outbox drain.
+
+---
+
+### 🟢 Issue #69b (fix): Broadcast re-INVITE hold re-triggered the first-answer connect path
+* **Status**: ✅ Resolved (sip-backport, part of #69 fix)
+* **Labels**: `bug`, `hold-resume`, `broadcast`
+
+#### Resolution
+`onOk`'s broadcast first-answer block was guarded by
+`session.value()->getState() != Session::State::Connected`. After `onReinvite()` set state
+to `Held`, the condition was true and the block executed: it overwrote the established
+dest with `setDest(answeringClient)`, forced state back to `Connected`, and sent CANCEL to
+already-gone pending targets. The hold 200 OK was forwarded as if it were a fresh call
+answer; no ACK was sent to the answering phone; Timer D fired 32 s later. Fixed by
+changing the guard to `state == Session::State::Invited` so the first-answer path only
+fires for a genuine new answer from a pending fork.
+
+---
+
+### 🟢 Issue #68b (fix): `sendParkReinvite` emitted Call-ID without mandatory header name
+* **Status**: ✅ Resolved (sip-backport, found during #68 code review)
+* **Labels**: `bug`, `parking`, `sip`
+
+#### Resolution
+The retrieve re-INVITE assembled by `sendParkReinvite` emitted `slot.callID` as a bare
+line with no `"Call-ID: "` label (e.g. `abc123@192.168.1.1\r\n`), violating RFC 3261
+§20.8 which requires Call-ID in every request. The parked phone received an invalid SIP
+request and rejected it with 400 or dropped it silently, stranding the parked dialog even
+though the retriever had already been answered with 200 OK. Fixed by prepending `"Call-ID: "`.
+
+---
+
+### 🟢 Issue #67b (fix): `getPrimaryLocalIP()` called inside `_mutex` across 7 new functions
+* **Status**: ✅ Resolved (sip-backport, found during #67 code review)
+* **Labels**: `bug`, `performance`, `concurrency`
+
+#### Resolution
+`onReinvite`, `onUpdate`, `buildDialogNotify`, `sendParkReinvite`, `startParkRingback`,
+`handleParkOk`, and `handleTransferOk` all called `getPrimaryLocalIP()` while holding
+`_mutex` inside `handle()` or `tick()`. `getPrimaryLocalIP()` performs a
+`socket`/`connect`/`getsockname`/`close` syscall chain (plus `WSAStartup`/`WSACleanup`
+on Windows), violating CLAUDE.md's "no blocking I/O under the registrar lock" rule. The
+same functions also constructed `std::ostringstream` objects (heap allocation) in the
+hot path, violating the "zero heap in the packet hot path" rule. Fixed by resolving the
+local IP once at construction time into `_localIp` and replacing all
+`(_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp` expressions with `_localIp`
+throughout `RequestsHandler.cpp`.
+
+---
 
 ### 🟢 Issue #48: `RequestsHandler` Mutex Lock Contention under Status Polling
 * **Status**: ✅ Resolved (v1.3.0 / `32166b5` & `f09a98c`)

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,6 +6,34 @@ This document serves as the active issue tracker and architectural roadmap for *
 
 ## Active Issues & Backlog Roadmap
 
+### 🟡 Issue #68: Smoke-test call parking on real hardware
+* **Status**: ⏳ Open / Planned
+* **Labels**: `hardware-testing`, `parking`
+* **Severity**: Medium
+
+#### Description
+Park (700–709), retrieve, and ring-back paths were ported from production and pass the
+host unit suite, but need an end-to-end smoke test on real ESP32-S3 hardware with two
+registered SIP phones. Verify: (a) park INVITE gets `200 OK` with `a=inactive` hold SDP;
+(b) retrieve INVITE bridges both legs peer-to-peer; (c) ring-back fires after orbit
+timeout and re-bridges. Also verify NVS survives a reboot (pzones key).
+
+---
+
+### 🟡 Issue #67: Smoke-test BLF presence subscription on a Yealink / Polycom phone
+* **Status**: ⏳ Open / Planned
+* **Labels**: `hardware-testing`, `blf`
+* **Severity**: Medium
+
+#### Description
+SUBSCRIBE / NOTIFY (RFC 6665) and RFC 4235 dialog-info XML are implemented and compile
+cleanly. Need hardware validation: register a Yealink T4X or Polycom VVX with a BLF key
+pointed at another extension; verify the BLF LED goes idle → ringing → in-call → idle
+across a full call cycle. Also verify 489 Bad Event is returned for unsupported packages
+and that subscription expiry triggers a terminal NOTIFY.
+
+---
+
 ### 🟡 Issue #44: End-to-end SIP call test needed on JC3248W535EN hardware
 * **Status**: ⏳ Open / Planned
 * **Labels**: `hardware-testing`, `verification`
@@ -56,60 +84,32 @@ Stream live SIP UDP signaling packets directly to the CRT console landing page u
 
 ---
 
-## API Integration: 3CX Call Control Connector (Epic)
+## External Audio Connector (Epic)
 
-> **Goal**: let a pocket-dial / tincan handset place calls to **3CX extensions** over WAN by bridging pocket-dial's SIP/RTP world to 3CX's HTTP-based **Call Control API**.
->
-> **Why no SBC / NAT / STUN / TURN / ICE is needed**: the connector *terminates the handset's RTP locally* (one SIP hop, on-box) and re-originates the call into 3CX over **HTTPS, not SIP/RTP** — so there is no second SIP/RTP peer for ICE to traverse. Both legs are 8 kHz, so media is a pure companding swap (G.711 ⇄ PCM16) with **no resampling and no media server**. Over WAN this only requires a flat L3 (WireGuard/overlay or public IP) so the connector's advertised SDP address is directly reachable.
+The `AnchorClient` interface (`src/SIP/AnchorClient.hpp`) lets you bridge an active SIP
+call to any external audio system — a SIP trunk, a PSTN gateway, a recording server, or
+an AI voice pipeline. Implement `makeCall()`, `writeAudio()`, and `AudioRxCallback` in
+your subclass; the engine takes care of the SIP signaling on both legs.
 
-### Architecture Decision
-The connector is a **media-terminating SIP endpoint** that `REGISTER`s to pocketdial-desktop as an ordinary extension (e.g. `3000`, or a dialing prefix). pocket-dial's **existing** `onInvite` forward path (`RequestsHandler.cpp`) delivers the INVITE to it with **zero changes to the signaling-only server** — the registrar keeps sourcing no media. The connector mirrors the **`440` `RtpSender` beachhead**, except it:
-* answers `200 OK` with its **own** SDP carrying a real media address and `a=sendrecv` (the `440` path uses the server media port but is send-only/tone),
-* bridges audio to 3CX instead of synthesizing a tone,
-* maps SIP `BYE`/`CANCEL` ↔ 3CX participant `drop`.
+`LoopbackAnchorClient` (`src/SIP/LoopbackAnchorClient.cpp`) is the reference
+implementation: it echoes audio back to the caller and is useful as a smoke test and as a
+template for real connector implementations.
 
-**Open fork (must decide — gates the language of all sub-issues below):**
-* **(A) C++ connector binary in this repo** — new target reusing `SipMessage`/`SipSdpMessage`; needs a TLS HTTP/WS client (libcurl) for 3CX. One repo, one deploy.
-* **(B) Lean Node sidecar** — separate process on the Pi, registers as an extension; trivial 3CX HTTPS/WSS, no TLS-dep friction; pocket-dial untouched.
-
-### Reference: 3CX Call Control API (verified)
-* **License**: 3CX **Enterprise + CFD**; an API Client scoped to **Call Control Access**; a **Route Point DN** (`type Wroutepoint`) for origination.
-* **Auth**: OAuth2 `client_credentials` → `POST https://{fqdn}/connect/token` → Bearer. ⚠️ `expires_in` misreports ~60 s for a ~1 h grant — **trust the JWT `exp` claim**, and do **not** refresh early (a new token invalidates the one a live media stream is holding).
-* **Two planes** — don't confuse them: `/xapi/v1` (a.k.a. "Configuration REST API", OData, config/management only) vs **`/callcontrol`** (calls + media). This connector is entirely `/callcontrol`.
-* **Originate**: `POST /callcontrol/{dn}/makecall` (or `/callcontrol/{dn}/devices/{deviceId}/makecall` for a deterministic participant id under concurrency).
-* **Participant control**: `POST /callcontrol/{dn}/participants/{id}/{drop|answer|divert|routeto|transferto}`.
-* **Audio (bidirectional)**: `GET /callcontrol/{dn}/participants/{id}/stream` receives the party's audio; `POST` to the same path **injects** audio. Format both ways: **PCM 16-bit, 8 kHz, mono**, HTTP chunked octet-stream.
-* **Events**: `wss://{fqdn}/callcontrol/ws` (participant-updated, DTMF, etc.), each event carrying an `entity` path to `GET`. Polling `participants` at ~300 ms is a proven fallback.
-* **Codec alignment**: 3CX PCM16 @ 8 kHz ⇄ G.711 @ 8 kHz is a 256-entry lookup-table companding conversion — same rate, **no resampling**. 20 ms / 160-sample framing matches `RtpSender`.
-
-### Foundations (✅ Completed — the enabling base, branch `2.0`)
-* 🟢 **`RtpSender` media beachhead** (`119ca84`): first server-sourced RTP path — virtual ext **`440`** streams a one-way G.711 µ-law tone (PCMU PT0, 8 kHz, 20 ms) to the caller, answering with the server's **own** SDP (media port `5062`). Pure helpers `linearToUlaw` / `synthTone` / `buildRtpHeader` are platform-independent and host-unit-tested (`tests/Rtp_test.cpp`); the real socket + 20 ms FreeRTOS pacing task are ESP-only; single-stream cap (2nd dial → `486`).
-* 🟢 **Media crashloop fixes** (`b7e82d5`): `udp_receiver_task` 8→16 KB and `rtp_media_tx` 4→6 KB stacks (the new SDP/UAC chain overflowed them), plus an `HttpServer::acceptLoop` guard for `std::thread`-spawn `std::system_error` (uncaught throw was rebooting the device).
-
-### 🔵 Issue #60: 3CX Connector — Form-Factor Decision (C++ in-repo vs Node sidecar)
-* **Status**: ⏳ Open / **Blocking** (gates #61–#64)
-* **Labels**: `api-integration`, `architecture`, `decision`
-* **Description**: Choose option **(A)** or **(B)** above. Determines language, dependency surface (libcurl vs none), and whether the connector ships inside this repo or beside it on the Pi.
-
-### 🔵 Issue #61: RTP Receive Path + µ-law→PCM16 Decode (uplink)
+### 🔵 Issue #65: AnchorClient — real host UDP media transport
 * **Status**: ⏳ Open / Planned
-* **Labels**: `api-integration`, `media`, `rtp`
-* **Description**: Add the inverse of `RtpSender` — receive the handset's RTP on the media socket, strip the RTP header, decode G.711 µ-law→PCM16 (inverse of `linearToUlaw`), and feed it to the 3CX `POST /stream`. Needs a small jitter/ordering tolerance (the `440` sender path has none).
+* **Labels**: `media`, `desktop`, `rtp`
+* **Description**: `RtpSender` socket + 20 ms pacing are `#if ESP_PLATFORM`; the host
+  build stubs them out. For an AnchorClient to move real audio on a desktop/Pi host
+  deployment, implement the host (Linux/Windows) UDP socket and 20 ms pacing loop
+  alongside the ESP path. The `PlayoutBuffer` jitter buffer is already in place.
 
-### 🔵 Issue #62: Real Desktop (host) Media Transport
+### 🔵 Issue #66: AnchorClient — sample connector (SIP trunk / VoIP provider)
 * **Status**: ⏳ Open / Planned
-* **Labels**: `api-integration`, `media`, `desktop`
-* **Description**: `RtpSender`'s socket + pacing are `#if ESP_PLATFORM`; on the desktop build they are **no-op stubs** that only flip `_active`. For the connector to move audio on the Pi (`SipServer.exe`), implement the real host (Linux/Windows) UDP socket + 20 ms pacing loop alongside the ESP path.
-
-### 🔵 Issue #63: 3CX Call Control Client (token + makecall + /stream + events)
-* **Status**: ⏳ Open / Planned
-* **Labels**: `api-integration`, `3cx`, `http`
-* **Description**: Implement the 3CX leg per the Reference above — JWT-`exp` token lifecycle, `makecall` to the target extension, concurrent `GET`/`POST /stream` (chunked), and `wss /callcontrol/ws` (or 300 ms participant polling) to detect `Connected` and far-end hangup. (libcurl if option A.)
-
-### 🔵 Issue #64: Bridge Orchestration (virtual-ext intercept + leg mapping)
-* **Status**: ⏳ Open / Planned
-* **Labels**: `api-integration`, `sip`, `media`
-* **Description**: Wire it together — a virtual extension / prefix (`777`/`999`/`440`-style intercept in `onInvite`) hands the call to the connector, which answers with its own `a=sendrecv` SDP (real media addr), opens both 3CX streams, and replaces the `synthTone` frame source with audio pulled from 3CX. Map `INVITE`→`makecall`, `BYE`/`CANCEL`→participant `drop`, and 3CX far-end hangup→SIP `BYE`. Honor the no-ICE addressing rule (SDP `c=` must be a handset-reachable IP).
+* **Labels**: `api-integration`, `sip`, `documentation`
+* **Description**: Provide a sample concrete AnchorClient that connects pocket-dial to a
+  standard SIP trunk (REGISTER + INVITE/BYE using `libosip2` or raw UDP). This would let
+  pocket-dial place and receive PSTN calls without any cloud dependency. The interface is
+  already defined; this is just a worked example.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,69 @@
-# cermak-peddler
+# pocket-dial
 
-> read the code.
+A self-contained SIP PBX that runs on a single ESP32-S3 — no router, no SIP trunk, no cloud needed. LAN extension-to-extension calls route peer-to-peer; the device only brokers signaling. The same C++17 engine compiles to ESP-IDF firmware and a host binary for desktop use and CI.
+
+## Features
+
+- **SIP registrar** — REGISTER / auth digest (RFC 3261), per-extension HA1 cache, open/secure/learn-mode policies
+- **B2BUA call routing** — INVITE fork, ring groups (ring-all and hunt), call-forward (unconditional / busy / no-answer), DND
+- **Hold / resume** — mid-dialog re-INVITE (RFC 3261 §12.2) and UPDATE (RFC 3311); `Held` session state, CDR talk-time preserved across hold
+- **Call transfer** — blind (RFC 3515 REFER) and attended (cross-connect two live sessions)
+- **Call parking** — virtual orbit extensions 700–709; park → P2P SDP-swap retrieve → ring-back on timeout
+- **Paging zones** — extensions 980–989; intercom auto-answer fork to a configured zone member list
+- **BLF / presence** — SUBSCRIBE / NOTIFY (RFC 6665) with RFC 4235 dialog-info XML; change detection on every packet
+- **Session timers** — RFC 4028 Session-Expires negotiation; server-as-refresher; BYE on expiry
+- **SIP transaction layer** — RFC 3261 §17 Timer A retransmit (exponential back-off) and Timer B timeout; per-Call-ID sweep on teardown
+- **Virtual extensions** — `777` SDP loopback / echo test, `999` all-page broadcast, `440` server-sourced RTP tone stream
+- **Register beep** — server-originated UAC INVITE plays a short beep on a newly registered phone
+- **Blind-transfer guard** — `isDialogSourceAuthorized` rejects BYE / CANCEL from off-path addresses (issue #46)
+- **AnchorClient interface** — plug in any external audio system (SIP trunk, recorder, AI pipeline) via the `AnchorClient` abstract class; `LoopbackAnchorClient` is the reference implementation and smoke-test
+- **Adaptive jitter buffer** — `PlayoutBuffer` for AnchorClient audio paths (200 ms ceiling, comfort-noise underrun fill)
+- **SSH sysop terminal** — ANSI TUI over SSH; screens for System Monitor, Network, PBX Config, Security, CDR
+- **Dashboard HTTP API** — `getActiveClients`, `getActiveSessions`, `getParkedCalls`, CDR, DND, call-forwarding (thread-safe snapshot getters)
+- **Zero heap in the packet hot path** — fixed pools for `SipClient`, `Session`, `SipMessage`, park slots, BLF subscriptions; exhaustion degrades to `503`, never crashes
+
+## Hardware
+
+| Transport | Board | Target |
+|---|---|---|
+| `eth` (default) | LilyGO T-ETH-Elite (W5500 wired/PoE) | ESP32-S3 |
+| `wifi` | generic ESP32-S3 | ESP32-S3 |
+| `display` | Guition JC3248W535 (AXS15231B touch) | ESP32-S3 |
+| `lan8720` | classic ESP32 internal EMAC | ESP32 |
+
+## Build
+
+### Host (fastest dev loop, CI gate)
+
+```bash
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+ctest --test-dir build/tests -C Release --output-on-failure
+```
+
+### ESP-IDF firmware (v5.1 – v6.0.1)
+
+```bash
+idf.py set-target esp32s3
+idf.py -D SIP_TRANSPORT=eth build
+idf.py -p COM3 flash monitor
+```
+
+See `CLAUDE.md` for the full build matrix and flash workflow.
+
+## Architecture
+
+One C++17 SIP engine in `src/` compiled three ways (ESP-IDF, host, Arduino). Two hard invariants shape all engine code:
+
+1. **Zero heap in the packet hot path.** Every `SipClient`, `Session`, and `SipMessage` is pre-allocated in fixed pools at boot (`src/SIP/PoolConfig.hpp`). Pool sizes are the device's hard concurrency limits.
+2. **No blocking I/O under the registrar lock.** Responses are generated into a local outbox inside `_mutex`, then dispatched after release.
+
+See `docs/ARCHITECTURE.md` for the full design.
+
+## Extending
+
+To bridge calls to an external audio system, implement `AnchorClient` (`src/SIP/AnchorClient.hpp`). The engine calls `makeCall()`, feeds audio via `writeAudio()`, and receives audio back through `AudioRxCallback`. `LoopbackAnchorClient` (`src/SIP/LoopbackAnchorClient.cpp`) is a working example that echoes audio back — useful as a smoke test and as a starting template.
+
+## License
+
+MIT — see `LICENSE`.

--- a/src/SIP/AnchorClient.hpp
+++ b/src/SIP/AnchorClient.hpp
@@ -1,0 +1,90 @@
+#ifndef ANCHOR_CLIENT_HPP
+#define ANCHOR_CLIENT_HPP
+
+// AnchorClient: interface for handing a SIP call leg off to an external audio system.
+//
+// Implement this to bridge pocket-dial calls to anything: a SIP trunk, a recording
+// server, an AI voice pipeline, a PSTN gateway — whatever needs to receive and inject
+// G.711 audio into an active call. LoopbackAnchorClient (same directory) is a working
+// reference implementation that echoes audio back to the caller.
+
+#include <string>
+#include <functional>
+#include <cstdint>
+#include <cstddef>
+
+class AnchorClient
+{
+public:
+	struct CallEvent
+	{
+		// Ringing/Answered/Dropped/Dtmf describe a call the device ORIGINATED (outbound,
+		// via makeCall). Incoming is the inverse: an external system is delivering an
+		// inbound call to a DN this device monitors; ring a local extension, then call
+		// answerCall() to accept it. callerId carries the caller's number/name (best-effort).
+		enum Type { Ringing, Answered, Dropped, Dtmf, Incoming } type;
+		std::string participantId;
+		std::string dtmfDigit;
+		std::string callerId;
+	};
+	using EventCallback = std::function<void(const CallEvent&)>;
+	using AudioRxCallback = std::function<void(const std::string& participantId, const int16_t* pcmSamples, size_t count)>;
+
+	virtual ~AnchorClient() = default;
+
+	// Initialize credentials and endpoints
+	virtual bool init(const std::string& baseUrl,
+	                  const std::string& clientId,
+	                  const std::string& clientSecret,
+	                  const std::string& sourceDn) = 0;
+
+	// Connect / start the client
+	virtual bool start() = 0;
+
+	// Disconnect and release all handles
+	virtual void stop() = 0;
+
+	// Status query
+	virtual bool isConnected() const = 0;
+
+	// Originate an outbound call. If ownLegOut is non-null, on success it receives the
+	// participant id of the leg WE control so the caller can bind it to the session before
+	// any Answered event arrives — keeping call correlation correct under concurrency.
+	virtual bool makeCall(const std::string& destination, std::string* ownLegOut = nullptr) = 0;
+
+	// Accept an inbound call the external system is delivering (mirror of makeCall).
+	// Call this once the local extension has accepted; participantId is from CallEvent::Incoming.
+	virtual bool answerCall(const std::string& participantId) = 0;
+
+	// Hang up an active call
+	virtual bool dropCall(const std::string& participantId) = 0;
+
+	// Register listener for call-state events
+	virtual void setEventCallback(EventCallback cb) = 0;
+
+	// Push a PCM-16 audio chunk into an active call, keyed by participant id.
+	virtual bool writeAudio(const std::string& participantId, const int16_t* pcmSamples, size_t count) = 0;
+
+	// Register the callback that receives inbound PCM-16 audio chunks from the external system.
+	virtual void registerAudioRxCallback(AudioRxCallback cb) = 0;
+
+	// Periodic, non-blocking maintenance pump driven from RequestsHandler::tick() (≤1 Hz).
+	// Do only constant-time work here — read flags, spawn workers for blocking I/O —
+	// never block, log, or allocate inside this call.
+	virtual void tick() = 0;
+
+	// TLS handshake telemetry: full vs resumed sessions. Default 0/0 for implementations
+	// that don't maintain a persistent TLS stream.
+	virtual void getTlsHandshakeStats(uint32_t& fullOut, uint32_t& resumedOut) const
+	{
+		fullOut = 0;
+		resumedOut = 0;
+	}
+
+	// Idle re-warm cadence (SECONDS): implementations that hold a persistent TLS connection
+	// can refresh it while idle so the first call after a quiet period doesn't pay a cold
+	// handshake. 0 = disabled. Default no-op.
+	virtual void setRewarmIntervalSec(uint32_t sec) { (void)sec; }
+};
+
+#endif // ANCHOR_CLIENT_HPP

--- a/src/SIP/LoopbackAnchorClient.cpp
+++ b/src/SIP/LoopbackAnchorClient.cpp
@@ -1,0 +1,279 @@
+// LoopbackAnchorClient — reference implementation of AnchorClient.
+//
+// This is not only useful for echo-testing: it shows exactly what any AnchorClient
+// implementation must do. Swap it for your own subclass to bridge active calls to a
+// SIP trunk, a recording server, an AI pipeline, or any system that can consume and
+// inject G.711/PCM-16 audio. The engine calls makeCall(), feeds audio via writeAudio(),
+// and receives audio from the external system through the AudioRxCallback. The loopback
+// simply returns whatever audio it receives — a useful smoke test that exercises the
+// full call-setup and audio-path without any external dependency.
+
+#include "LoopbackAnchorClient.hpp"
+#include <chrono>
+#include <atomic>
+
+namespace
+{
+	std::atomic<uint64_t> g_activeCallId{0};
+}
+
+LoopbackAnchorClient::LoopbackAnchorClient() = default;
+
+LoopbackAnchorClient::~LoopbackAnchorClient()
+{
+	shutdownImpl();   // non-virtual: never dispatch a virtual call from a destructor
+}
+
+bool LoopbackAnchorClient::init(const std::string& baseUrl,
+                               const std::string& clientId,
+                               const std::string& /*clientSecret*/,
+                               const std::string& sourceDn)
+{
+	_baseUrl = baseUrl;
+	_clientId = clientId;
+	_sourceDn = sourceDn;
+	return true;
+}
+
+bool LoopbackAnchorClient::start()
+{
+	_connected = true;
+	return true;
+}
+
+void LoopbackAnchorClient::stop()
+{
+	shutdownImpl();
+}
+
+void LoopbackAnchorClient::shutdownImpl()
+{
+	_connected = false;
+	_stopSimThread = true;
+	g_activeCallId++;
+	reapSimThreads();
+	std::lock_guard<std::mutex> lock(_mutex);
+	_eventCb = nullptr;
+	_audioCb = nullptr;
+}
+
+void LoopbackAnchorClient::reapSimThreads()
+{
+	// Join the previous call's simulation threads so _simThreads doesn't grow
+	// unboundedly on a long-running instance. Callers bump g_activeCallId first,
+	// so every outstanding thread exits at its next checkpoint (≤ ~40ms). Joins
+	// happen outside _mutex — the sim threads lock it in their callbacks.
+	std::vector<std::thread> threadsToJoin;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+		threadsToJoin = std::move(_simThreads);
+	}
+	for (auto& t : threadsToJoin)
+	{
+		if (t.joinable())
+		{
+			t.join();
+		}
+	}
+}
+
+bool LoopbackAnchorClient::isConnected() const
+{
+	return _connected;
+}
+
+bool LoopbackAnchorClient::makeCall(const std::string& /*destination*/, std::string* ownLegOut)
+{
+	if (!_connected)
+	{
+		return false;
+	}
+
+	// Resolve our own leg synchronously (fixed mock id) so the engine can bind the
+	// session immediately, before any Answered event arrives — keeping call correlation
+	// correct even when multiple calls are in flight.
+	if (ownLegOut) *ownLegOut = "mock-part-123";
+
+	_stopSimThread = true;
+	uint64_t myCallId = ++g_activeCallId;
+	reapSimThreads();
+	_stopSimThread = false;
+
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+		_simThreads.emplace_back([this, myCallId]() {
+			// Simulate network delay for ringing
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			if (myCallId != g_activeCallId.load()) return;
+
+			EventCallback evCb;
+			{
+				std::lock_guard<std::mutex> lock(_mutex);
+				evCb = _eventCb;
+				_activeParticipantId = "mock-part-123";
+			}
+
+			if (evCb)
+			{
+				CallEvent ringingEv{CallEvent::Ringing, _activeParticipantId, "", ""};
+				evCb(ringingEv);
+			}
+
+			// Simulate call answering
+			std::this_thread::sleep_for(std::chrono::milliseconds(30));
+			if (myCallId != g_activeCallId.load()) return;
+
+			if (evCb)
+			{
+				CallEvent answerEv{CallEvent::Answered, _activeParticipantId, "", ""};
+				evCb(answerEv);
+			}
+		});
+	}
+
+	return true;
+}
+
+bool LoopbackAnchorClient::answerCall(const std::string& participantId)
+{
+	if (!_connected)
+	{
+		return false;
+	}
+
+	std::string partId;
+	EventCallback evCb;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+		partId = participantId.empty() ? _activeParticipantId : participantId;
+		if (partId.empty())
+		{
+			return false;
+		}
+		_activeParticipantId = partId;
+		evCb = _eventCb;
+	}
+
+	// Answering the inbound participant connects the leg — fire the Answered event
+	// on a sim thread so the callback never runs under the caller's lock.
+	if (evCb)
+	{
+		std::thread answerThread([evCb, partId]() {
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			CallEvent answerEv{CallEvent::Answered, partId, "", ""};
+			evCb(answerEv);
+		});
+		std::lock_guard<std::mutex> lock(_mutex);
+		_simThreads.push_back(std::move(answerThread));
+	}
+	return true;
+}
+
+void LoopbackAnchorClient::simulateInboundCall(const std::string& callerId)
+{
+	if (!_connected)
+	{
+		return;
+	}
+
+	_stopSimThread = true;
+	uint64_t myCallId = ++g_activeCallId;
+	reapSimThreads();
+	_stopSimThread = false;
+
+	std::lock_guard<std::mutex> lock(_mutex);
+	_simThreads.emplace_back([this, myCallId, callerId]() {
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		if (myCallId != g_activeCallId.load()) return;
+
+		EventCallback evCb;
+		std::string partId = "mock-in-" + std::to_string(myCallId);
+		{
+			std::lock_guard<std::mutex> lock(_mutex);
+			evCb = _eventCb;
+			_activeParticipantId = partId;
+		}
+		if (evCb)
+		{
+			CallEvent inEv{CallEvent::Incoming, partId, "", callerId};
+			evCb(inEv);
+		}
+	});
+}
+
+bool LoopbackAnchorClient::dropCall(const std::string& participantId)
+{
+	if (!_connected)
+	{
+		return false;
+	}
+
+	std::string partId;
+	EventCallback evCb;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+		partId = participantId.empty() ? _activeParticipantId : participantId;
+		if (partId.empty())
+		{
+			return false;
+		}
+		_activeParticipantId.clear();
+		evCb = _eventCb;
+	}
+
+	_stopSimThread = true;
+	g_activeCallId++;
+	reapSimThreads();
+
+	if (evCb)
+	{
+		// Spawn the event callback thread outside the lock. emplace_back under
+		// _mutex risks vector reallocation while stop() is moving threads out,
+		// and mirrors the lock-free join pattern already used in stop().
+		std::thread dropThread([evCb, partId]() {
+			CallEvent dropEv{CallEvent::Dropped, partId, "", ""};
+			evCb(dropEv);
+		});
+		{
+			std::lock_guard<std::mutex> lock(_mutex);
+			_simThreads.push_back(std::move(dropThread));
+		}
+	}
+
+	return true;
+}
+
+void LoopbackAnchorClient::setEventCallback(EventCallback cb)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	_eventCb = cb;
+}
+
+bool LoopbackAnchorClient::writeAudio(const std::string& participantId, const int16_t* pcmSamples, size_t count)
+{
+	if (!_connected)
+	{
+		return false;
+	}
+
+	AudioRxCallback audioCb;
+	std::string partId;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+		audioCb = _audioCb;
+		partId = participantId.empty() ? _activeParticipantId : participantId;
+	}
+
+	if (audioCb && pcmSamples != nullptr && count > 0)
+	{
+		audioCb(partId, pcmSamples, count);   // loopback: echo this participant's audio back
+	}
+
+	return true;
+}
+
+void LoopbackAnchorClient::registerAudioRxCallback(AudioRxCallback cb)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	_audioCb = cb;
+}

--- a/src/SIP/LoopbackAnchorClient.hpp
+++ b/src/SIP/LoopbackAnchorClient.hpp
@@ -1,0 +1,61 @@
+#ifndef LOOPBACK_ANCHOR_CLIENT_HPP
+#define LOOPBACK_ANCHOR_CLIENT_HPP
+
+#include "AnchorClient.hpp"
+#include <mutex>
+#include <thread>
+#include <atomic>
+#include <string>
+#include <vector>
+
+class LoopbackAnchorClient : public AnchorClient
+{
+public:
+	LoopbackAnchorClient();
+	~LoopbackAnchorClient() override;
+
+	bool init(const std::string& baseUrl,
+	          const std::string& clientId,
+	          const std::string& clientSecret,
+	          const std::string& sourceDn) override;
+
+	bool start() override;
+	void stop() override;
+	bool isConnected() const override;
+	bool makeCall(const std::string& destination, std::string* ownLegOut = nullptr) override;
+	bool answerCall(const std::string& participantId) override;
+	bool dropCall(const std::string& participantId) override;
+	void setEventCallback(EventCallback cb) override;
+	bool writeAudio(const std::string& participantId, const int16_t* pcmSamples, size_t count) override;
+	void registerAudioRxCallback(AudioRxCallback cb) override;
+	void tick() override {}   // no periodic maintenance for the in-process loopback
+
+	// Test hook: pretend the upstream is delivering a PSTN call to the monitored DN.
+	// Fires a single CallEvent::Incoming (participant id "mock-in-<n>", the given
+	// callerId). The engine is expected to ring a local extension and then call
+	// answerCall(), which drives the participant to Answered — mirroring makeCall().
+	void simulateInboundCall(const std::string& callerId);
+
+private:
+	std::string _baseUrl;
+	std::string _clientId;
+	std::string _sourceDn;
+
+	std::atomic<bool> _connected{false};
+	std::string _activeParticipantId;
+
+	EventCallback   _eventCb;
+	AudioRxCallback _audioCb;
+
+	mutable std::mutex _mutex;
+
+	void reapSimThreads();
+	// Non-virtual teardown shared by stop() and the destructor so ~LoopbackAnchorClient()
+	// never makes a virtual call (cppcheck virtualCallInConstructor).
+	void shutdownImpl();
+
+	std::vector<std::thread> _simThreads;
+	std::atomic<bool> _stopSimThread{false};
+};
+
+#endif // LOOPBACK_ANCHOR_CLIENT_HPP

--- a/src/SIP/PbxConfig.hpp
+++ b/src/SIP/PbxConfig.hpp
@@ -135,6 +135,39 @@ namespace pbx
 		}
 		return out;
 	}
+
+	// ── Paging zones (the 980–989 virtual extensions) ─────────────────────────
+
+	// One paging zone: an unordered member set (stored as a deduped, capped list).
+	// A dial of the zone extension forks an intercom (auto-answer) INVITE to every
+	// registered member — exactly the 999 all-page machinery, scoped to the zone.
+	struct PageZone
+	{
+		std::vector<std::string> members;
+	};
+
+	// True iff `ext` is in the reserved paging-zone dial range 980–989. Pure, so
+	// the routing predicate is unit-testable without linking the registrar.
+	inline bool isPageZoneExt(const std::string& ext)
+	{
+		return ext.size() == 3 && ext[0] == '9' && ext[1] == '8' &&
+			std::isdigit(static_cast<unsigned char>(ext[2]));
+	}
+
+	// Split a zone member list (same CSV grammar as splitMembers), then dedupe
+	// (first occurrence wins, order preserved) and clamp to POCKETDIAL_ZONE_MEMBER_CAP.
+	inline std::vector<std::string> splitZoneMembers(const std::string& csv)
+	{
+		std::vector<std::string> out;
+		for (auto& m : splitMembers(csv))
+		{
+			if (out.size() >= static_cast<size_t>(POCKETDIAL_ZONE_MEMBER_CAP))
+				break;
+			if (std::find(out.begin(), out.end(), m) == out.end())
+				out.push_back(m);
+		}
+		return out;
+	}
 }
 
 #endif

--- a/src/SIP/PlayoutBuffer.cpp
+++ b/src/SIP/PlayoutBuffer.cpp
@@ -1,0 +1,129 @@
+#include "PlayoutBuffer.hpp"
+#include <cstring>
+#include <algorithm>
+
+PlayoutBuffer::PlayoutBuffer(size_t maxSamples)
+	: _maxSamples(maxSamples)
+{
+	_buffer.resize(_maxSamples, 0);
+}
+
+size_t PlayoutBuffer::write(const int16_t* samples, size_t count)
+{
+	if (samples == nullptr || count == 0)
+	{
+		return 0;
+	}
+
+	std::lock_guard<std::mutex> lock(_mutex);
+
+	// If count is larger than the total buffer capacity, clamp to max capacity
+	if (count > _maxSamples)
+	{
+		_overruns.fetch_add(1, std::memory_order_relaxed);
+		samples += (count - _maxSamples);
+		count = _maxSamples;
+	}
+
+	// Check if this write causes an overrun (requires dropping oldest samples)
+	if (_count + count > _maxSamples)
+	{
+		size_t overflow = (_count + count) - _maxSamples;
+		_overruns.fetch_add(1, std::memory_order_relaxed);
+
+		// Drop the oldest samples by advancing the read pointer
+		_readPtr = (_readPtr + overflow) % _maxSamples;
+		_count = _maxSamples - count;
+	}
+
+	// Write samples into the circular buffer
+	for (size_t i = 0; i < count; ++i)
+	{
+		_buffer[_writePtr] = samples[i];
+		_writePtr = (_writePtr + 1) % _maxSamples;
+	}
+	_count += count;
+
+	return count;
+}
+
+bool PlayoutBuffer::read(int16_t* out, size_t count)
+{
+	if (out == nullptr || count == 0)
+	{
+		return false;
+	}
+
+	std::lock_guard<std::mutex> lock(_mutex);
+
+	// Adaptive latency drain. The buffer used to be a pure FIFO: standing latency floated to
+	// wherever producer/consumer rates settled and then only ever GREW toward the ceiling —
+	// locking in 200-400 ms of mouth-to-ear delay for the whole call. Instead, keep the
+	// depth near _targetDepth: if it has drifted more than one read above target, drop the
+	// oldest excess so the delay walks back down. The drop is capped at one read (`count`) so
+	// it converges as ≤20 ms micro-skips (mostly in inter-word gaps) rather than one audible
+	// gap. This actively MINIMISES latency instead of letting it accumulate.
+	const size_t target = _targetDepth.load(std::memory_order_relaxed);
+	if (_count > target + 2 * count)
+	{
+		size_t excess = _count - (target + count);          // amount above the high-water mark
+		size_t drop   = (excess < count) ? excess : count;  // at most one frame per read
+		_readPtr = (_readPtr + drop) % _maxSamples;
+		_count  -= drop;
+	}
+
+	bool success = true;
+	size_t readCount = count;
+
+	if (_count < count)
+	{
+		_underruns.fetch_add(1, std::memory_order_relaxed);
+		readCount = _count;
+		success = false;
+	}
+
+	// Read available samples
+	for (size_t i = 0; i < readCount; ++i)
+	{
+		out[i] = _buffer[_readPtr];
+		_readPtr = (_readPtr + 1) % _maxSamples;
+	}
+	_count -= readCount;
+
+	// Fill any remaining samples with low-amplitude comfort noise
+	if (readCount < count)
+	{
+		for (size_t i = readCount; i < count; ++i)
+		{
+			// Low-overhead LCG pseudo-random noise generator (amplitude range -20 to 20)
+			static uint32_t seed = 123456789;
+			seed = seed * 1664525 + 1013904223;
+			int16_t noise = static_cast<int16_t>((seed % 41) - 20);
+			out[i] = noise;
+		}
+	}
+
+	return success;
+}
+
+size_t PlayoutBuffer::getLength() const
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	return _count;
+}
+
+void PlayoutBuffer::clear()
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	_readPtr = 0;
+	_writePtr = 0;
+	_count = 0;
+	std::fill(_buffer.begin(), _buffer.end(), 0);
+	_underruns.store(0, std::memory_order_relaxed);
+	_overruns.store(0, std::memory_order_relaxed);
+}
+
+void PlayoutBuffer::setTargetDepth(size_t samples)
+{
+	_targetDepth.store(samples, std::memory_order_relaxed);
+}

--- a/src/SIP/PlayoutBuffer.hpp
+++ b/src/SIP/PlayoutBuffer.hpp
@@ -1,0 +1,66 @@
+#ifndef PLAYOUT_BUFFER_HPP
+#define PLAYOUT_BUFFER_HPP
+
+#include <vector>
+#include <mutex>
+#include <cstdint>
+#include <cstddef>
+#include <atomic>
+
+class PlayoutBuffer
+{
+public:
+	// Default max samples 1600 (200 ms @ 8 kHz) — the HARD latency ceiling: a producer
+	// burst can never park more than 200 ms of audio here (overrun drops oldest). The old
+	// 8000 (1 s) let mouth-to-ear delay balloon. Steady-state is held far lower by the
+	// target-depth drain in read() (see _targetDepth).
+	explicit PlayoutBuffer(size_t maxSamples = 1600);
+	~PlayoutBuffer() = default;
+
+	// Write linear PCM16 samples to the buffer (called by the HTTP RX thread).
+	// If the buffer overflows, oldest samples are dropped to make room.
+	// Returns the number of samples successfully written.
+	size_t write(const int16_t* samples, size_t count);
+
+	// Read linear PCM16 samples from the buffer (called by the RTP TX thread every 20ms).
+	// Always fills 'out' with 'count' samples. If underrun, fills the rest with
+	// low-amplitude comfort noise.
+	// Returns true if all requested samples were read from the buffer,
+	// false if an underrun occurred.
+	bool read(int16_t* out, size_t count);
+
+	// Get current buffered sample count
+	size_t getLength() const;
+
+	// Reset buffer (clear all samples, reset stats)
+	void clear();
+
+	// Statistics queries
+	uint64_t getUnderruns() const { return _underruns.load(std::memory_order_relaxed); }
+	uint64_t getOverruns() const { return _overruns.load(std::memory_order_relaxed); }
+	size_t getTargetDepth() const { return _targetDepth.load(std::memory_order_relaxed); }
+
+	// Set/Get target playout delay (in samples)
+	void setTargetDepth(size_t samples);
+
+private:
+	std::vector<int16_t> _buffer;
+	size_t _maxSamples;
+	size_t _readPtr = 0;
+	size_t _writePtr = 0;
+	size_t _count = 0;
+
+	mutable std::mutex _mutex;
+
+	// Target playout depth = the standing jitter cushion read() drains toward (60 ms = 480
+	// samples @ 8 kHz). read() drops the oldest excess whenever the buffer drifts above
+	// target, so latency walks back DOWN instead of accumulating. Lower = less delay but
+	// more underrun risk on a bursty/lossy (TCP) trunk; tune against getUnderruns().
+	std::atomic<size_t> _targetDepth{480};
+
+	// Statistics
+	std::atomic<uint64_t> _underruns{0};
+	std::atomic<uint64_t> _overruns{0};
+};
+
+#endif // PLAYOUT_BUFFER_HPP

--- a/src/SIP/PoolConfig.hpp
+++ b/src/SIP/PoolConfig.hpp
@@ -18,8 +18,11 @@
 //
 //     cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-DPOCKETDIAL_MAX_CLIENTS=64 -DPOCKETDIAL_MAX_SESSIONS=16"
 //
-// The defaults reproduce the historical hardcoded values exactly (32 clients,
-// 8 sessions, 32 messages) so existing builds are bit-for-bit unchanged.
+// The client/session defaults reproduce the historical hardcoded values exactly
+// (32 clients, 8 sessions). The message-pool default was historically 32 (== client
+// count); it is now sized to cover the worst-case broadcast + BLF-NOTIFY burst
+// (MAX_CLIENTS + MAX_SUBSCRIPTIONS + headroom, Issue #54) so peak fan-out no longer
+// spills into the hot-path heap fallback.
 //
 // Trade-off in one line: raise these for capacity, lower them to claw back RAM
 // on a constrained SoftAP node. See docs/SCALING.md for per-tier recommendations,
@@ -40,14 +43,31 @@
 #define POCKETDIAL_MAX_SESSIONS 8
 #endif
 
-// Depth of the shared in-flight SipMessage scratch pool. Defaults to one slot per
-// potential client, which comfortably covers steady-state REGISTER/OPTIONS churn.
-// Broadcast/forking (the 999 all-page) transiently needs one message per target;
-// if the pool is momentarily drained, getMessageFromPool() falls back to a single
-// heap allocation rather than failing, so this value trades steady-state
-// allocation-free operation against static footprint.
+// Maximum number of concurrent BLF/presence dialog subscriptions (RFC 6665
+// SUBSCRIBE/NOTIFY with the RFC 4235 "dialog" event package). Each slot is a small
+// fixed record in a std::array — no heap. A SUBSCRIBE arriving with every slot in
+// use is answered 503 Service Unavailable (graceful degradation, never a crash).
+// Must stay ≤ POCKETDIAL_MSG_POOL: a single state change can fan one NOTIFY out to
+// every subscriber, and bounding subscriptions by the message-pool depth keeps that
+// burst allocation-free (it also caps the worst-case NOTIFY burst on the wire).
+// Defined BEFORE POCKETDIAL_MSG_POOL because the pool depth is sized from it.
+#ifndef POCKETDIAL_MAX_SUBSCRIPTIONS
+#define POCKETDIAL_MAX_SUBSCRIPTIONS 16
+#endif
+
+// Depth of the shared in-flight SipMessage scratch pool.
+//
+// The worst-case simultaneous draw happens when a 999 all-page builds one forked
+// INVITE per registered client AND refreshSubscriptions() queues one NOTIFY per
+// active BLF subscription into the SAME locked critical section before _outbox is
+// flushed. Those pooled refs all live at once, so the pool must cover MAX_CLIENTS
+// (fan-out) + MAX_SUBSCRIPTIONS (NOTIFY burst), plus a little headroom for the
+// inbound request being processed and its direct response(s). Sizing it this way
+// keeps the broadcast+NOTIFY peak allocation-free instead of spilling to the
+// hot-path heap fallback in getMessageFromPool(). Override to claw back RAM on a
+// constrained node.
 #ifndef POCKETDIAL_MSG_POOL
-#define POCKETDIAL_MSG_POOL POCKETDIAL_MAX_CLIENTS
+#define POCKETDIAL_MSG_POOL (POCKETDIAL_MAX_CLIENTS + POCKETDIAL_MAX_SUBSCRIPTIONS + 4)
 #endif
 
 // Maximum number of concurrent server-originated "register beep" dialogs. Each new
@@ -58,6 +78,61 @@
 // fixed record (no heap), so this stays cheap even on the constrained node.
 #ifndef POCKETDIAL_MAX_BEEPS
 #define POCKETDIAL_MAX_BEEPS 4
+#endif
+
+// Number of call-park orbit slots (virtual extensions 700, 701, ... 70(N-1), max
+// 10). The orbit table itself is a fixed std::array of small records — no heap in
+// the hot path, mirroring the pool discipline above. NOTE the real capacity cost
+// of a parked call is ONE Session slot out of POCKETDIAL_MAX_SESSIONS: the parked
+// dialog stays alive in the session pool for the whole time it sits on the orbit
+// (and a retrieve transiently holds a second slot for the retriever's leg). With
+// the default 8 sessions, parking more than a few calls will starve new INVITEs
+// into 503 — raise MAX_SESSIONS if you raise this.
+#ifndef POCKETDIAL_PARK_SLOTS
+#define POCKETDIAL_PARK_SLOTS 10
+#endif
+
+// Depth of the virtual-peer SipClient pool. The 777 echo, the 440 media-beachhead,
+// park (parked/retriever/ring-back legs) all need a transient SipClient that is NOT
+// a registered endpoint — historically each was make_shared'd inside the UDP packet
+// handler, breaking the zero-heap invariant. They are now drawn from this fixed pool
+// and recycled by use_count(). If the pool is momentarily drained the handler falls
+// back to a one-off heap SipClient (graceful, never a crash).
+#ifndef POCKETDIAL_VIRTUAL_PEERS
+#define POCKETDIAL_VIRTUAL_PEERS (POCKETDIAL_MAX_SESSIONS + POCKETDIAL_PARK_SLOTS)
+#endif
+
+// How long a call may sit parked before the orbit times out (seconds). On expiry
+// tick() rings back the parker (the Referred-By party of the parking INVITE) if
+// they are registered, or tears the parked leg down with a BYE otherwise.
+#ifndef POCKETDIAL_PARK_TIMEOUT_SEC
+#define POCKETDIAL_PARK_TIMEOUT_SEC 90
+#endif
+
+// Maximum number of configured paging zones (the 980–989 virtual extensions).
+// Bounds the _pageZones map exactly like _ringGroups is bounded; the 98x dial
+// range only has ten slots anyway, so this is also the semantic ceiling.
+#ifndef POCKETDIAL_MAX_PAGE_ZONES
+#define POCKETDIAL_MAX_PAGE_ZONES 10
+#endif
+
+// Maximum members per paging zone. A zone page forks one INVITE per registered
+// member through the shared message pool, so this cap bounds the transient
+// per-page message-pool pressure the same way the 999 all-page is bounded by
+// POCKETDIAL_MAX_CLIENTS. splitZoneMembers() clamps to this at config time,
+// so an oversized list degrades to the first N members — it never over-forks.
+#ifndef POCKETDIAL_ZONE_MEMBER_CAP
+#define POCKETDIAL_ZONE_MEMBER_CAP 8
+#endif
+
+// Maximum concurrent RFC 3261 §17 transaction records tracked for retransmit
+// timers.  Each InviteClient slot tracks one outgoing INVITE fork (Timer A/B):
+// retransmit interval doubles from T1 until a provisional stops it, or Timer B
+// (32 s) fires.  Sized to cover MAX_SESSIONS concurrent INVITE dialogs plus
+// headroom for forks to hunt-group members.  Pool exhaustion → message still
+// sent once (graceful degradation) — it never crashes or blocks.
+#ifndef POCKETDIAL_MAX_TRANSACTIONS
+#define POCKETDIAL_MAX_TRANSACTIONS (POCKETDIAL_MAX_SESSIONS * 2 + 8)
 #endif
 
 #endif

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -32,6 +32,11 @@
 
 std::vector<std::shared_ptr<SipMessage>> RequestsHandler::_messagePool;
 
+// File-scope static helpers defined later in this translation unit.
+static bool sameAddress(const sockaddr_in&, const sockaddr_in&);
+static std::string parkTagOf(std::string_view header);
+static std::string stripHeaderName(std::string_view fullLine);
+
 namespace
 {
 	// Default lease granted when a REGISTER does not request one (seconds).
@@ -80,6 +85,11 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 		{
 			_messagePool.push_back(std::make_shared<SipSdpMessage>("", sockaddr_in{}));
 		}
+	}
+	_virtualPeerPool.reserve(POCKETDIAL_VIRTUAL_PEERS);
+	for (int i = 0; i < POCKETDIAL_VIRTUAL_PEERS; ++i)
+	{
+		_virtualPeerPool.push_back(std::make_shared<SipClient>());
 	}
 
 	// Reload persisted PBX config (call-forward / ring groups) and the CDR ring from
@@ -130,7 +140,9 @@ void RequestsHandler::initHandlers()
 	_handlers.emplace(SipMessageTypes::BYE,               std::bind(&RequestsHandler::onBye,            this, std::placeholders::_1));
 	_handlers.emplace(SipMessageTypes::REQUEST_TERMINATED,std::bind(&RequestsHandler::onReqTerminated,  this, std::placeholders::_1));
 	_handlers.emplace(SipMessageTypes::REFER,             std::bind(&RequestsHandler::onRefer,          this, std::placeholders::_1));
+	_handlers.emplace(SipMessageTypes::UPDATE,            std::bind(&RequestsHandler::onUpdate,         this, std::placeholders::_1));
 	_handlers.emplace(SipMessageTypes::MESSAGE,           std::bind(&RequestsHandler::onMessage,        this, std::placeholders::_1));
+	_handlers.emplace(SipMessageTypes::SUBSCRIBE,         std::bind(&RequestsHandler::onSubscribe,      this, std::placeholders::_1));
 }
 
 void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
@@ -170,6 +182,11 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 		}
 
 		maybeSweep();
+
+		// RFC 3261 §17 transaction layer: advance the state machine for any tracked
+		// InviteClient transaction before the TU handler runs. A 1xx moves Calling →
+		// Proceeding (stops retransmitting); a 2xx/3xx-6xx → Accepted/Completed.
+		matchAndAdvanceTx(request);
 
 		// Route responses by parsed numeric status code so dispatch is immune to
 		// reason-phrase variation (e.g. "486 Busy" vs "486 Busy Here"). Requests and
@@ -258,6 +275,21 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 			{
 				it->second(std::move(request));
 			}
+		}
+
+		// BLF change detection: one pass after every handled packet covers
+		// registration appear/disappear, session create/transition/teardown.
+		// NOTIFYs land in _outbox and ride out with this pass (after unlock).
+		refreshSubscriptions();
+
+		// RFC 3261 §17: register any new outgoing INVITE in _outbox for retransmit.
+		// Scan after BLF NOTIFYs are added so the full outbox is covered; classifyTxType
+		// filters to INVITE requests only so NOTIFYs and responses are ignored.
+		for (const auto& [addr, msg] : _outbox)
+		{
+			auto txType = classifyTxType(msg);
+			if (txType != SipTransaction::Type::None)
+				registerTx(txType, addr, msg);
 		}
 
 		localOutbox = std::move(_outbox);
@@ -413,6 +445,19 @@ void RequestsHandler::onOptions(std::shared_ptr<SipMessage> data)
 void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 {
 	std::string destNumber(data->getToNumber());
+
+	// Issue #46: same off-path teardown guard as onBye(). A CANCEL whose Call-ID
+	// names an established two-leg dialog must come from a leg IP.
+	if (auto cancelSess = getSession(data->getCallID());
+		cancelSess.has_value() &&
+		!isDialogSourceAuthorized(cancelSess.value(), data->getSource()))
+	{
+		queueLog("CANCEL for Call-ID " + std::string(data->getCallID()) +
+			" rejected: source not a dialog leg (spoofed teardown)", true);
+		sendForbidden(data, "Forbidden");
+		return;
+	}
+
 	if (destNumber == "777")
 	{
 		endCall(data->getCallID(), data->getFromNumber(), "777");
@@ -427,7 +472,14 @@ void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
-	if (destNumber == "999")
+	if (parkOrbitIndex(destNumber) >= 0)
+	{
+		endCall(data->getCallID(), data->getFromNumber(), destNumber);
+		refreshParkSnapshot();
+		return;
+	}
+
+	if (destNumber == "999" || isPageZoneDialog(destNumber))
 	{
 		auto session = getSession(data->getCallID());
 		if (session.has_value())
@@ -456,7 +508,7 @@ void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 				_outbox.emplace_back(target->getAddress(), std::move(cancelMsg));
 			}
 		}
-		endCall(data->getCallID(), data->getFromNumber(), "999");
+		endCall(data->getCallID(), data->getFromNumber(), destNumber);
 		return;
 	}
 
@@ -482,12 +534,22 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// should retransmit that response; for 2xx, the ACK re-drive handles it. The
 	// simplest safe policy here is a silent drop so we never create a second session
 	// slot for the same dialog, which could exhaust the pool and trigger spurious 503.
-	if (auto existing = getSession(data->getCallID());
-		existing.has_value() &&
-		(existing.value()->getState() == Session::State::Invited ||
-		 existing.value()->getState() == Session::State::Connected))
+	if (auto existing = getSession(data->getCallID()); existing.has_value())
 	{
-		return; // silent drop per RFC 3261 §17.2.3
+		const auto st = existing.value()->getState();
+		// Mid-dialog re-INVITE (RFC 3261 §12.2): To-tag present = established dialog.
+		// This is the hold/resume path — route to onReinvite().
+		if ((st == Session::State::Connected || st == Session::State::Held) &&
+			std::string_view(data->getTo()).find("tag=") != std::string_view::npos)
+		{
+			onReinvite(data);
+			return;
+		}
+		if (st == Session::State::Invited || st == Session::State::Connected ||
+			st == Session::State::Held)
+		{
+			return; // silent drop per RFC 3261 §17.2.3
+		}
 	}
 
 	if (!isValidAor(data->getFromNumber()) || !isValidAor(data->getToNumber()))
@@ -580,11 +642,53 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
+	// Paging zones (980–989): a configured zone is a scoped 999 — fork an intercom
+	// INVITE to every registered zone member. An unconfigured 98x falls through to
+	// normal routing (and 404s, since 98x is not a real extension/group target).
+	if (pbx::isPageZoneExt(destNumber))
+	{
+		if (const pbx::PageZone* zone = findPageZone(destNumber))
+		{
+			std::vector<std::shared_ptr<SipClient>> targets;
+			for (const auto& m : zone->members)
+			{
+				if (m == caller.value()->getNumber()) continue;
+				auto mc = findClient(m);
+				if (mc.has_value())
+					targets.push_back(mc.value());
+			}
+
+			if (targets.empty())
+			{
+				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+				responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
+				responseObj->clearBody();
+				responseObj->setContact(buildContact(caller.value()->getNumber()));
+				_outbox.emplace_back(data->getSource(), std::move(responseObj));
+				return;
+			}
+
+			startBroadcastFork(data, caller.value(), std::move(targets), /*intercom=*/true);
+			return;
+		}
+	}
+
 	if (destNumber == "440")
 	{
 		// Media beachhead: the server answers and sources a one-way RTP tone stream.
 		onMediaInvite(data, caller.value());
 		return;
+	}
+
+	// Call parking (park-orbit, 700..70N): an INVITE to a FREE orbit parks the
+	// caller's leg there; an INVITE to an OCCUPIED orbit retrieves the parked call.
+	{
+		int orbitIdx = parkOrbitIndex(destNumber);
+		if (orbitIdx >= 0)
+		{
+			onParkInvite(data, caller.value(), orbitIdx);
+			return;
+		}
 	}
 
 	// Ring / hunt groups (Class A sweep): a configured group extension (e.g. 6xx)
@@ -1046,6 +1150,18 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 {
 	auto session = getSession(data->getCallID());
 	std::string destNumber(data->getToNumber());
+
+	// Issue #46: reject an off-path forged teardown. A BYE for an established
+	// two-phone dialog must originate from one of the call's leg IPs.
+	if (session.has_value() &&
+		!isDialogSourceAuthorized(session.value(), data->getSource()))
+	{
+		queueLog("BYE for Call-ID " + std::string(data->getCallID()) +
+			" rejected: source not a dialog leg (spoofed teardown)", true);
+		sendForbidden(data, "Forbidden");
+		return;
+	}
+
 	if (destNumber == "777")
 	{
 		auto response = getMessageFromPool(data->toString(), data->getSource());
@@ -1071,7 +1187,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
-	if (destNumber == "999")
+	if (destNumber == "999" || isPageZoneDialog(destNumber))
 	{
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader(SipMessageTypes::OK);
@@ -1147,6 +1263,13 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
+	// Park dialogs (server-originated re-INVITE ACKs + ring-back answers).
+	if (handleParkOk(data))
+		return;
+	// Attended-transfer re-INVITE ACKs.
+	if (handleTransferOk(data))
+		return;
+
 	auto session = getSession(data->getCallID());
 	if (session.has_value())
 	{
@@ -1156,8 +1279,39 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 			return;
 		}
 
-		if (data->getCSeq().find(SipMessageTypes::INVITE) != std::string::npos) 
+		if (data->getCSeq().find(SipMessageTypes::INVITE) != std::string::npos)
 		{
+			// Re-INVITE answer (hold/resume): relay 200 OK to the opposite leg and
+			// preserve the session state set by onReinvite() — do NOT re-run connect.
+			{
+				const auto st = session.value()->getState();
+				if ((st == Session::State::Connected || st == Session::State::Held) &&
+					!session.value()->isBroadcast())
+				{
+					auto legSrc  = session.value()->getSrc();
+					auto legDest = session.value()->getDest();
+					if (legSrc && legDest)
+					{
+						std::shared_ptr<SipClient> peer;
+						if (sameAddress(data->getSource(), legSrc->getAddress()))
+						{
+							peer = legDest;
+						}
+						else if (sameAddress(data->getSource(), legDest->getAddress()))
+						{
+							if (!data->getBody().empty())
+								session.value()->setRemoteSdp(std::string(data->getBody()));
+							peer = legSrc;
+						}
+						if (peer)
+						{
+							_outbox.emplace_back(peer->getAddress(), data);
+							return;
+						}
+					}
+				}
+			}
+
 			if (session.value()->isBroadcast())
 			{
 				if (session.value()->getState() != Session::State::Connected)
@@ -1257,6 +1411,12 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 			session->get()->setDest(client.value());
 			session->get()->setState(Session::State::Connected);
 			session->get()->clearRingTimer();   // answered: disarm any CFNA timeout
+			// Capture dialog From/To and callee SDP so attended transfer can
+			// cross-connect two live sessions without querying stored invite messages.
+			session->get()->setDialogHeaders(std::string(data->getFrom()),
+			                                std::string(data->getTo()));
+			session->get()->setRemoteSdp(std::string(data->getBody()));
+			armSessionTimer(session->get(), data);
 			auto response = getMessageFromPool(data->toString(), data->getSource());
 			response->setContact(buildContact(data->getToNumber()));
 			endHandle(data->getFromNumber(), std::move(response));
@@ -1673,13 +1833,15 @@ std::shared_ptr<SipMessage> RequestsHandler::buildCancel(const std::shared_ptr<S
 	return cancelMsg;
 }
 
-void RequestsHandler::setCallState(std::string_view callID, Session::State state)
+bool RequestsHandler::setCallState(std::string_view callID, Session::State state)
 {
 	auto session = getSession(callID);
 	if (session)
 	{
 		session->get()->setState(state);
+		return true;
 	}
+	return false;
 }
 
 void RequestsHandler::endCall(std::string_view callID, std::string_view srcNumber, std::string_view destNumber, std::string_view reason)
@@ -1687,6 +1849,11 @@ void RequestsHandler::endCall(std::string_view callID, std::string_view srcNumbe
 	// DTMF accumulators are keyed by Call-ID and share the dialog lifecycle; drop
 	// this dialog's entry so _dtmfState can't grow unbounded across calls (Fix #4).
 	_dtmfState.erase(std::string(callID));
+
+	// RFC 3261 §17: free any transaction slots tracking retransmits for this call.
+	freeTxsForCallId(callID);
+	// Free any park orbit slot holding this call's parked leg.
+	freeParkSlot(callID);
 
 	// Capture the session (for CDR start time / final state) BEFORE we erase it.
 	std::shared_ptr<Session> ending;
@@ -2712,6 +2879,15 @@ void RequestsHandler::tick()
 
 		sweepExpired();
 
+		// RFC 3261 §17: retransmit timed-out INVITE forks and free completed slots.
+		sweepTransactions(now);
+		// RFC 4028: BYE sessions that have exceeded their session-expires timer.
+		sweepSessionTimers(now);
+		// BLF subscription expiry.
+		sweepSubscriptions();
+		// Call-park timeout: ring back the parker or BYE the parked party.
+		parkSweep(now);
+
 		// Belt-and-suspenders (Fix #4): drop DTMF accumulators whose dialog is gone,
 		// in case a teardown path bypassed endCall(). Bounded by the small session pool.
 		for (auto dit = _dtmfState.begin(); dit != _dtmfState.end(); )
@@ -2896,6 +3072,18 @@ void RequestsHandler::tick()
 			nextSnapshot.ringGroups.emplace_back(ext,
 				g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall",
 				pbx::joinMembers(g.members));
+		}
+
+		// Parked calls view: {orbit, parkedExt, parker, secondsParked}.
+		nextSnapshot.parkedCalls.clear();
+		for (const auto& slot : _parkSlots)
+		{
+			if (slot.state == ParkState::Parked)
+			{
+				int sec = static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(
+					now - slot.parkedAt).count());
+				nextSnapshot.parkedCalls.emplace_back(slot.orbit, slot.parkedExt, slot.parker, sec);
+			}
 		}
 
 		{
@@ -3375,6 +3563,16 @@ void RequestsHandler::loadPbxConfig()
 		if (!g.members.empty()) _ringGroups[rec[0]] = std::move(g);
 	}
 
+	// Page zones: ext \t m1,m2,...
+	for (const auto& rec : deserializeBlob(readBlob("pzones")))
+	{
+		if (rec.size() < 2 || rec[0].empty()) continue;
+		if (_pageZones.size() >= static_cast<size_t>(POCKETDIAL_MAX_PAGE_ZONES)) break;
+		pbx::PageZone z;
+		z.members = pbx::splitZoneMembers(rec[1]);
+		if (!z.members.empty()) _pageZones[rec[0]] = std::move(z);
+	}
+
 	nvs_close(h);
 #endif
 }
@@ -3414,6 +3612,25 @@ void RequestsHandler::persistRingGroups()
 	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
 	{
 		nvs_set_str(h, "groups", blob.c_str());
+		nvs_commit(h);
+		nvs_close(h);
+	}
+#endif
+}
+
+void RequestsHandler::persistPageZones()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	std::string blob;
+	for (const auto& [ext, z] : _pageZones)
+	{
+		blob += ext; blob += '\t';
+		blob += pbx::joinMembers(z.members); blob += '\n';
+	}
+	nvs_handle_t h;
+	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
+	{
+		nvs_set_str(h, "pzones", blob.c_str());
 		nvs_commit(h);
 		nvs_close(h);
 	}
@@ -3930,4 +4147,1256 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 		}
 		// else: keep accumulating (target not yet 4 digits)
 	}
+}
+
+// ── File-scope static helpers ─────────────────────────────────────────────────
+
+static bool sameAddress(const sockaddr_in& a, const sockaddr_in& b)
+{
+	return a.sin_addr.s_addr == b.sin_addr.s_addr && a.sin_port == b.sin_port;
+}
+
+// Extract the ;tag= value from a From/To header line.
+static std::string parkTagOf(std::string_view header)
+{
+	size_t p = header.find(";tag=");
+	if (p == std::string_view::npos) return {};
+	p += 5;
+	size_t e = p;
+	while (e < header.size() && header[e] != ';' && header[e] != '>' &&
+		header[e] != ' ' && header[e] != '\r' && header[e] != '\n')
+	{
+		++e;
+	}
+	return std::string(header.substr(p, e - p));
+}
+
+// Strip a leading "HeaderName:" prefix (e.g. "From:", "To:", "Call-ID:") so
+// server-minted requests emit a clean value and never ship a doubled prefix.
+// Safe on bare values (the check is that the text before ':' contains only
+// letter/hyphen chars — so "<sip:...>" is left untouched). Idempotent.
+static std::string stripHeaderName(std::string_view h)
+{
+	size_t colon = h.find(':');
+	if (colon == std::string_view::npos || colon == 0 || colon > 15)
+		return std::string(h);
+	for (size_t i = 0; i < colon; ++i)
+	{
+		char c = h[i];
+		if (!(std::isalpha(static_cast<unsigned char>(c)) || c == '-'))
+			return std::string(h);
+	}
+	size_t v = colon + 1;
+	while (v < h.size() && (h[v] == ' ' || h[v] == '\t')) ++v;
+	size_t e = h.size();
+	while (e > v && (h[e - 1] == '\r' || h[e - 1] == '\n')) --e;
+	return std::string(h.substr(v, e - v));
+}
+
+// ── Mid-dialog re-INVITE (RFC 3261 §12.2 hold/resume) ────────────────────────
+
+void RequestsHandler::onReinvite(std::shared_ptr<SipMessage> data)
+{
+	auto sessionOpt = getSession(data->getCallID());
+	if (!sessionOpt.has_value())
+	{
+		return;
+	}
+	auto session = sessionOpt.value();
+	auto src = session->getSrc();
+	auto dest = session->getDest();
+
+	// Virtual-extension legs (777 echo) have no real peer to relay the offer to —
+	// decline the re-INVITE so the holding phone keeps the call on the original SDP.
+	const std::string destNum = dest ? dest->getNumber() : "";
+	if (destNum == "777" || !src || !dest)
+	{
+		auto response = getMessageFromPool(data->toString(), data->getSource());
+		response->setHeader("SIP/2.0 488 Not Acceptable Here");
+		response->clearBody();
+		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		_outbox.emplace_back(data->getSource(), std::move(response));
+		return;
+	}
+
+	// Identify the sending leg by source address; the relay target is the peer.
+	std::shared_ptr<SipClient> peer;
+	if (sameAddress(data->getSource(), src->getAddress()))
+	{
+		peer = dest;
+	}
+	else if (sameAddress(data->getSource(), dest->getAddress()))
+	{
+		peer = src;
+	}
+	if (!peer)
+	{
+		return; // not from either leg of this dialog: ignore
+	}
+
+	// Relay UNTOUCHED — no clearBody()/enforceG711() — so the hold SDP
+	// (a=sendonly/inactive) and its Content-Length reach the peer intact.
+	_outbox.emplace_back(peer->getAddress(), data);
+
+	// A re-INVITE from either leg is evidence the endpoint is alive — it counts
+	// as a session-timer refresh.
+	if (session->getSessionExpiresSeconds() > 0)
+	{
+		session->armSessionTimer(session->getSessionExpiresSeconds(),
+		                         session->isRefresher(),
+		                         std::chrono::steady_clock::now());
+	}
+
+	// Track hold state from the offered SDP direction. RFC 3264: an absent
+	// direction attribute implies sendrecv (an active call).
+	const auto dir = data->getSdpDirection();
+	if (dir == SipMessage::SdpDirection::SendOnly ||
+		dir == SipMessage::SdpDirection::RecvOnly ||
+		dir == SipMessage::SdpDirection::Inactive)
+	{
+		session->setState(Session::State::Held);
+		queueLog("Hold: " + std::string(data->getFromNumber()) + " held call " + std::string(data->getCallID()));
+	}
+	else
+	{
+		session->setState(Session::State::Connected);
+		queueLog("Hold: call " + std::string(data->getCallID()) + " resumed");
+	}
+}
+
+// ── Mid-dialog UPDATE (RFC 3311 hold/resume / session-timer keep-alive) ──────
+
+void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
+{
+	auto sessionOpt = getSession(data->getCallID());
+	if (!sessionOpt.has_value())
+	{
+		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		resp->setHeader("SIP/2.0 481 Call/Transaction Does Not Exist");
+		resp->clearBody();
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+		return;
+	}
+	auto session = sessionOpt.value();
+	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+
+	if (!data->hasSdp())
+	{
+		// Bodiless UPDATE: session-timer refresh — 200 OK and reset expiry.
+		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		resp->setHeader(SipMessageTypes::OK);
+		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		resp->clearBody();
+		resp->syncContentLength();
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+
+		if (session->getSessionExpiresSeconds() > 0)
+		{
+			session->armSessionTimer(session->getSessionExpiresSeconds(),
+			                         session->isRefresher(),
+			                         std::chrono::steady_clock::now());
+		}
+		return;
+	}
+
+	// SDP-bearing UPDATE: relay to the peer leg (same logic as onReinvite).
+	auto src  = session->getSrc();
+	auto dest = session->getDest();
+	const std::string destNum = dest ? dest->getNumber() : "";
+
+	if (destNum == "777" || !src || !dest)
+	{
+		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		resp->setHeader("SIP/2.0 488 Not Acceptable Here");
+		resp->clearBody();
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+		return;
+	}
+
+	std::shared_ptr<SipClient> peer;
+	if (sameAddress(data->getSource(), src->getAddress()))
+		peer = dest;
+	else if (sameAddress(data->getSource(), dest->getAddress()))
+		peer = src;
+
+	if (!peer) return;
+
+	_outbox.emplace_back(peer->getAddress(), data);
+
+	if (session->getSessionExpiresSeconds() > 0)
+	{
+		session->armSessionTimer(session->getSessionExpiresSeconds(),
+		                         session->isRefresher(),
+		                         std::chrono::steady_clock::now());
+	}
+
+	const auto dir = data->getSdpDirection();
+	if (dir == SipMessage::SdpDirection::SendOnly ||
+	    dir == SipMessage::SdpDirection::RecvOnly ||
+	    dir == SipMessage::SdpDirection::Inactive)
+	{
+		session->setState(Session::State::Held);
+		queueLog("Update/Hold: " + std::string(data->getFromNumber()) +
+		         " held call " + std::string(data->getCallID()));
+	}
+	else
+	{
+		session->setState(Session::State::Connected);
+		queueLog("Update/Resume: call " + std::string(data->getCallID()) + " resumed");
+	}
+}
+
+// ── BYE source authorization ──────────────────────────────────────────────────
+
+bool RequestsHandler::isDialogSourceAuthorized(const std::shared_ptr<Session>& session,
+	const sockaddr_in& source) const
+{
+	if (!session)
+	{
+		// Out-of-dialog BYE on a non-existent Call-ID: harmless — nothing to tear down.
+		return true;
+	}
+
+	auto src  = session->getSrc();
+	auto dest = session->getDest();
+
+	// Fail-open for any dialog with a missing leg (half-set-up session).
+	if (!src || !dest)
+	{
+		return true;
+	}
+
+	// Compare source IP only (port-agnostic): a phone may send the BYE from the same
+	// contact IP but a different ephemeral UDP port than the original INVITE.
+	const uint32_t fromIp = source.sin_addr.s_addr;
+	return fromIp == src->getAddress().sin_addr.s_addr ||
+	       fromIp == dest->getAddress().sin_addr.s_addr;
+}
+
+// ── BLF presence (RFC 6665 SUBSCRIBE / RFC 4235 dialog-event NOTIFY) ─────────
+
+std::string RequestsHandler::parseEventPackage(const std::string& raw)
+{
+	size_t pos = 0;
+	while (pos < raw.size())
+	{
+		size_t nl = raw.find('\n', pos);
+		size_t lineEnd = (nl == std::string::npos) ? raw.size() : nl;
+		size_t next = (nl == std::string::npos) ? raw.size() : nl + 1;
+		if (raw[pos] == '\r' || raw[pos] == '\n') break;
+
+		size_t colon = raw.find(':', pos);
+		if (colon != std::string::npos && colon < lineEnd)
+		{
+			std::string name = raw.substr(pos, colon - pos);
+			std::transform(name.begin(), name.end(), name.begin(),
+				[](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+			if (name == "event" || name == "o")
+			{
+				size_t vBegin = colon + 1;
+				size_t vEnd = lineEnd;
+				std::string val = raw.substr(vBegin, vEnd - vBegin);
+				size_t semi = val.find(';');
+				if (semi != std::string::npos) val.erase(semi);
+				size_t b = val.find_first_not_of(" \t\r");
+				size_t e = val.find_last_not_of(" \t\r");
+				if (b == std::string::npos) return "";
+				return val.substr(b, e - b + 1);
+			}
+		}
+		pos = next;
+	}
+	return "";
+}
+
+std::string RequestsHandler::buildDialogInfoXml(const std::string& entity, unsigned version,
+	const std::string& dialogId, const std::string& state, const std::string& direction)
+{
+	// Minimal RFC 4235 document, always state="full": each NOTIFY carries the
+	// complete (zero-or-one element) dialog set, so watchers never need to merge
+	// partials. An empty `state` omits the <dialog> element — the canonical
+	// "idle lamp" body that Yealink/Grandstream BLF keys expect.
+	std::ostringstream xml;
+	xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
+	    << "<dialog-info xmlns=\"urn:ietf:params:xml:ns:dialog-info\" version=\""
+	    << version << "\" state=\"full\" entity=\"" << entity << "\">\r\n";
+	if (!state.empty())
+	{
+		xml << "<dialog id=\"" << dialogId << "\"";
+		if (!direction.empty()) xml << " direction=\"" << direction << "\"";
+		xml << "><state>" << state << "</state></dialog>\r\n";
+	}
+	xml << "</dialog-info>\r\n";
+	return xml.str();
+}
+
+std::string RequestsHandler::computeDialogState(const std::string& targetAor,
+	std::string& outDirection, std::string& outDialogId) const
+{
+	std::string best;
+	auto rank = [](const std::string& s) -> int {
+		if (s == "confirmed") return 3;
+		if (s == "early")     return 2;
+		if (s == "trying")    return 1;
+		return 0;
+	};
+	for (const auto& [callID, session] : _sessions)
+	{
+		bool isSrc  = session->getSrc()  && session->getSrc()->getNumber()  == targetAor;
+		bool isDest = session->getDest() && session->getDest()->getNumber() == targetAor;
+		if (!isSrc && !isDest) continue;
+
+		std::string state, dir;
+		switch (session->getState())
+		{
+			case Session::State::Invited:
+				state = isDest ? "early" : "trying";
+				dir   = isDest ? "recipient" : "initiator";
+				break;
+			case Session::State::Connected:
+			case Session::State::Held:
+				// RFC 4235 §4: a held call is an established dialog; state stays
+				// "confirmed" so the watcher's BLF lamp remains lit (#53).
+				state = "confirmed";
+				dir   = isSrc ? "initiator" : "recipient";
+				break;
+			default:
+				continue;
+		}
+		if (rank(state) > rank(best))
+		{
+			best = state;
+			outDirection = dir;
+			outDialogId  = callID;
+		}
+	}
+	if (best.empty()) { outDirection.clear(); outDialogId.clear(); }
+	return best;
+}
+
+std::shared_ptr<SipMessage> RequestsHandler::buildDialogNotify(DialogSubscription& sub,
+	const std::string& state, const std::string& direction, const std::string& dialogId,
+	bool terminated, const char* termReason)
+{
+	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+	char ipBuf[INET_ADDRSTRLEN]{};
+	inet_ntop(AF_INET, &sub.addr.sin_addr, ipBuf, sizeof(ipBuf));
+	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(sub.addr.sin_port));
+	std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
+
+	std::string entity = "sip:" + sub.targetAor + "@" + srcIpPort;
+	std::string body = buildDialogInfoXml(entity, sub.version, dialogId, state, direction);
+
+	int remaining = 0;
+	if (!terminated)
+	{
+		auto now = std::chrono::steady_clock::now();
+		remaining = static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(
+			sub.deadline - now).count());
+		if (remaining < 0) remaining = 0;
+	}
+	std::string subState = terminated
+		? ("terminated;reason=" + std::string(termReason))
+		: ("active;expires=" + std::to_string(remaining));
+
+	// NOTIFY runs inside the subscription dialog: our To-tag becomes the From,
+	// the watcher's From becomes the To (RFC 6665 §4.4.1 — roles swap).
+	std::string fromHdr = sub.subTo;
+	std::string toHdr   = sub.watcherFrom;
+	auto stripName = [](const std::string& h) {
+		size_t c = h.find(':');
+		return (c == std::string::npos) ? h : h.substr(c + 1);
+	};
+
+	std::ostringstream ss;
+	ss << "NOTIFY sip:" << destIpPort << " SIP/2.0\r\n"
+	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
+	   << "From:" << stripName(fromHdr) << "\r\n"
+	   << "To:" << stripName(toHdr) << "\r\n"
+	   << "Call-ID: " << sub.callId << "\r\n"
+	   << "CSeq: " << sub.cseq++ << " NOTIFY\r\n"
+	   << "Max-Forwards: 70\r\n"
+	   << "Event: dialog\r\n"
+	   << "Subscription-State: " << subState << "\r\n"
+	   << "Contact: <sip:" << sub.targetAor << "@" << srcIpPort << ">\r\n"
+	   << "User-Agent: pocket-dial\r\n"
+	   << "Content-Type: application/dialog-info+xml\r\n"
+	   << "Content-Length: " << body.size() << "\r\n\r\n"
+	   << body;
+
+	return getMessageFromPool(ss.str(), sub.addr);
+}
+
+void RequestsHandler::onSubscribe(std::shared_ptr<SipMessage> data)
+{
+	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+
+	// 1. Event-package gate: only the RFC 4235 "dialog" package is implemented.
+	std::string pkg = parseEventPackage(data->toString());
+	if (pkg != "dialog")
+	{
+		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		resp->setHeader(SipMessageTypes::BAD_EVENT);
+		resp->clearBody();
+		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		resp->addHeader("Allow-Events", "dialog");
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+		return;
+	}
+
+	// 2. Watched-target validation.
+	std::string target(data->getToNumber());
+	if (!isValidAor(target))
+	{
+		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		resp->setHeader(SipMessageTypes::BAD_REQUEST);
+		resp->clearBody();
+		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+		return;
+	}
+
+	const int expires = parseRequestedExpires(data);
+	std::string callId(data->getCallID());
+	{
+		size_t c = callId.find(':');
+		if (c != std::string::npos) callId.erase(0, c + 1);
+		size_t b = callId.find_first_not_of(" \t");
+		size_t e = callId.find_last_not_of(" \t\r");
+		callId = (b == std::string::npos) ? "" : callId.substr(b, e - b + 1);
+	}
+
+	// 3. Refresh / unsubscribe: match existing subscription by Call-ID.
+	DialogSubscription* sub = nullptr;
+	for (auto& s : _subscriptions)
+	{
+		if (s.used && s.callId == callId) { sub = &s; break; }
+	}
+
+	if (sub == nullptr && expires > 0)
+	{
+		for (auto& s : _subscriptions)
+		{
+			if (!s.used) { sub = &s; break; }
+		}
+		if (sub == nullptr)
+		{
+			auto resp = getMessageFromPool(data->toString(), data->getSource());
+			resp->setHeader("SIP/2.0 503 Service Unavailable");
+			resp->clearBody();
+			resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+			_outbox.emplace_back(data->getSource(), std::move(resp));
+			queueLog("BLF: subscription pool exhausted, 503 to watcher of " + target, true);
+			return;
+		}
+		*sub = DialogSubscription{};
+		sub->used        = true;
+		sub->callId      = callId;
+		sub->watcherFrom = std::string(data->getFrom());
+		sub->subTo       = std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9);
+		sub->targetAor   = target;
+		queueLog("BLF: new subscription, watcher " + std::string(data->getFromNumber())
+			+ " -> target " + target);
+	}
+
+	// 4. 202 Accepted (RFC 6665 §4.2.1).
+	{
+		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		resp->setHeader(SipMessageTypes::ACCEPTED);
+		resp->clearBody();
+		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		if (sub) resp->setTo(sub->subTo);
+		else     resp->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
+		resp->setContact(buildContact(target));
+		resp->addHeader("Expires", std::to_string(expires));
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+	}
+
+	if (sub == nullptr) return;
+
+	sub->addr       = data->getSource();
+	sub->expiresSec = expires;
+	sub->deadline   = std::chrono::steady_clock::now() + std::chrono::seconds(expires);
+
+	// 5. Immediate NOTIFY (RFC 6665 §4.2.1.4).
+	std::string dir, dialogId;
+	std::string state = computeDialogState(target, dir, dialogId);
+	const bool terminating = (expires == 0);
+	auto notify = buildDialogNotify(*sub, state, dir, dialogId, terminating, "noresource");
+	_outbox.emplace_back(sub->addr, std::move(notify));
+	sub->lastState = state + "|" + dir + "|" + dialogId;
+	sub->version++;
+
+	if (terminating)
+	{
+		queueLog("BLF: unsubscribe, watcher of " + target + " released");
+		*sub = DialogSubscription{};
+	}
+}
+
+void RequestsHandler::refreshSubscriptions()
+{
+	for (auto& sub : _subscriptions)
+	{
+		if (!sub.used) continue;
+		std::string dir, dialogId;
+		std::string state = computeDialogState(sub.targetAor, dir, dialogId);
+		std::string token = state + "|" + dir + "|" + dialogId;
+		if (token == sub.lastState) continue;
+		auto notify = buildDialogNotify(sub, state, dir, dialogId, false, "");
+		_outbox.emplace_back(sub.addr, std::move(notify));
+		sub.lastState = token;
+		sub.version++;
+	}
+}
+
+void RequestsHandler::sweepSubscriptions()
+{
+	auto now = std::chrono::steady_clock::now();
+	for (auto& sub : _subscriptions)
+	{
+		if (!sub.used || now < sub.deadline) continue;
+		std::string dir, dialogId;
+		std::string state = computeDialogState(sub.targetAor, dir, dialogId);
+		auto notify = buildDialogNotify(sub, state, dir, dialogId, true, "timeout");
+		_outbox.emplace_back(sub.addr, std::move(notify));
+		queueLog("BLF: subscription to " + sub.targetAor + " expired");
+		sub = DialogSubscription{};
+	}
+}
+
+// ── RFC 3261 §17 INVITE-client transaction (Timer A retransmit / Timer B timeout)
+
+RequestsHandler::SipTransaction::Type
+RequestsHandler::classifyTxType(const std::shared_ptr<SipMessage>& msg)
+{
+	if (!msg || msg->getStatusInfo().has_value()) return SipTransaction::Type::None;
+	if (msg->getType() == "INVITE") return SipTransaction::Type::InviteClient;
+	return SipTransaction::Type::None;
+}
+
+void RequestsHandler::registerTx(SipTransaction::Type type,
+                                  const sockaddr_in& peer,
+                                  const std::shared_ptr<SipMessage>& msg)
+{
+	SipTransaction* slot = nullptr;
+	for (auto& tx : _txPool)
+	{
+		if (tx.type == SipTransaction::Type::None) { slot = &tx; break; }
+	}
+	if (!slot)
+	{
+		queueLog("[tx] pool exhausted — INVITE sent without retransmit tracking", true);
+		return;
+	}
+
+	auto raw = msg->toString();
+	auto now = std::chrono::steady_clock::now();
+	constexpr uint32_t kT1ms     = 500;
+	constexpr uint32_t kTimerBms = 64 * kT1ms; // 32 s
+
+	slot->type          = type;
+	slot->state         = SipTransaction::State::Calling;
+	slot->peer          = peer;
+	slot->msgTruncated  = (raw.size() >= sizeof(slot->msg));
+	slot->msgLen        = raw.size() < sizeof(slot->msg) ? raw.size() : sizeof(slot->msg) - 1;
+	std::memcpy(slot->msg, raw.data(), slot->msgLen);
+	slot->msg[slot->msgLen] = '\0';
+
+	auto branch = msg->getViaBranch();
+	auto bLen   = branch.size() < sizeof(slot->viaBranch) ? branch.size() : sizeof(slot->viaBranch) - 1;
+	std::memcpy(slot->viaBranch, branch.data(), bLen);
+	slot->viaBranch[bLen] = '\0';
+
+	auto method = msg->getCSeqMethod();
+	auto mLen   = method.size() < sizeof(slot->cseqMethod) ? method.size() : sizeof(slot->cseqMethod) - 1;
+	std::memcpy(slot->cseqMethod, method.data(), mLen);
+	slot->cseqMethod[mLen] = '\0';
+
+	auto callId = msg->getCallID();
+	auto cLen   = callId.size() < sizeof(slot->callId) ? callId.size() : sizeof(slot->callId) - 1;
+	std::memcpy(slot->callId, callId.data(), cLen);
+	slot->callId[cLen] = '\0';
+
+	slot->nextRetransmit     = now + std::chrono::milliseconds(kT1ms);
+	slot->transactionTimeout = now + std::chrono::milliseconds(kTimerBms);
+	slot->absorbDeadline     = {};
+	slot->retransmitCount    = 0;
+	slot->currentIntervalMs  = kT1ms;
+}
+
+bool RequestsHandler::matchAndAdvanceTx(const std::shared_ptr<SipMessage>& msg)
+{
+	if (!msg) return false;
+	auto viaBranch = msg->getViaBranch();
+	if (viaBranch.empty()) return false;
+	auto cseqMethod = msg->getCSeqMethod();
+
+	bool matched = false;
+	auto now = std::chrono::steady_clock::now();
+	constexpr uint32_t kTimerLms = 64 * 500; // RFC 6026: 32 s absorb after 2xx
+
+	for (auto& tx : _txPool)
+	{
+		if (tx.type == SipTransaction::Type::None) continue;
+		if (viaBranch != std::string_view(tx.viaBranch)) continue;
+		if (!cseqMethod.empty() && cseqMethod != std::string_view(tx.cseqMethod)) continue;
+
+		matched = true;
+		auto si = msg->getStatusInfo();
+		if (!si.has_value()) continue;
+
+		using Cls = PocketDial::SipStatusClass;
+		switch (si->klass)
+		{
+			case Cls::Provisional:
+				if (tx.state == SipTransaction::State::Calling)
+					tx.state = SipTransaction::State::Proceeding;
+				break;
+			case Cls::Success:
+				tx.state = SipTransaction::State::Accepted;
+				tx.absorbDeadline = now + std::chrono::milliseconds(kTimerLms);
+				break;
+			default:
+				tx.state = SipTransaction::State::Completed;
+				tx.absorbDeadline = now + std::chrono::milliseconds(kTimerLms);
+				break;
+		}
+	}
+	return matched;
+}
+
+void RequestsHandler::sweepTransactions(std::chrono::steady_clock::time_point now)
+{
+	for (auto& tx : _txPool)
+	{
+		if (tx.type == SipTransaction::Type::None) continue;
+
+		if (tx.state == SipTransaction::State::Completed ||
+		    tx.state == SipTransaction::State::Accepted)
+		{
+			if (now >= tx.absorbDeadline)
+				tx.type = SipTransaction::Type::None;
+			continue;
+		}
+
+		if (tx.state == SipTransaction::State::Calling &&
+		    now >= tx.transactionTimeout)
+		{
+			queueLog(std::string("[tx] Timer B expired — INVITE for ") + tx.callId
+				+ " timed out (no provisional response)", true);
+			tx.type = SipTransaction::Type::None;
+			continue;
+		}
+
+		if (tx.state == SipTransaction::State::Calling &&
+		    now >= tx.nextRetransmit)
+		{
+			if (tx.msgLen > 0 && !tx.msgTruncated)
+			{
+				std::string retxStr(tx.msg, tx.msgLen);
+				auto retx = getMessageFromPool(retxStr, tx.peer);
+				if (retx) _outbox.emplace_back(tx.peer, std::move(retx));
+			}
+			tx.currentIntervalMs *= 2;
+			tx.nextRetransmit     = now + std::chrono::milliseconds(tx.currentIntervalMs);
+			tx.retransmitCount++;
+		}
+	}
+}
+
+void RequestsHandler::freeTxsForCallId(std::string_view callId)
+{
+	for (auto& tx : _txPool)
+	{
+		if (tx.type != SipTransaction::Type::None &&
+		    std::string_view(tx.callId) == callId)
+		{
+			tx.type = SipTransaction::Type::None;
+		}
+	}
+}
+
+// ── RFC 4028 session timers ───────────────────────────────────────────────────
+
+void RequestsHandler::armSessionTimer(Session* session,
+                                       const std::shared_ptr<SipMessage>& ok200)
+{
+	uint32_t secs = ok200->getSessionExpiresSecs();
+	if (secs == 0) return;
+	auto ref = ok200->getSessionExpiresRefresher();
+	bool weRefresh = (ref == "uas");
+	session->armSessionTimer(secs, weRefresh, std::chrono::steady_clock::now());
+	session->setDialogHeaders(std::string(ok200->getFrom()), std::string(ok200->getTo()));
+}
+
+void RequestsHandler::sweepSessionTimers(std::chrono::steady_clock::time_point now)
+{
+	std::vector<std::string> toExpire;
+	for (const auto& [callID, session] : _sessions)
+	{
+		if (session->getSessionExpiresSeconds() == 0) continue;
+		const auto st = session->getState();
+		if (st != Session::State::Connected && st != Session::State::Held) continue;
+
+		if (now >= session->getSessionExpiry())
+		{
+			toExpire.push_back(callID);
+		}
+	}
+
+	for (const auto& callID : toExpire)
+	{
+		auto it = _sessions.find(callID);
+		if (it == _sessions.end()) continue;
+		auto session = it->second;
+		auto src  = session->getSrc();
+		auto dest = session->getDest();
+		const std::string& dFrom = session->getDialogFrom();
+		const std::string& dTo   = session->getDialogTo();
+
+		if (src && !dFrom.empty())
+		{
+			auto b = buildServerBye(src->getNumber(), src->getAddress(), callID, dTo, dFrom);
+			if (b) _outbox.emplace_back(src->getAddress(), std::move(b));
+		}
+		if (dest && !dFrom.empty())
+		{
+			auto b = buildServerBye(dest->getNumber(), dest->getAddress(), callID, dFrom, dTo);
+			if (b) _outbox.emplace_back(dest->getAddress(), std::move(b));
+		}
+		queueLog("[session timer] expired — BYE sent for " + callID, true);
+		endCall(callID,
+		        src  ? src->getNumber()  : "",
+		        dest ? dest->getNumber() : "",
+		        "session timer expired");
+	}
+}
+
+// ── Paging zones (980–989) ────────────────────────────────────────────────────
+
+const pbx::PageZone* RequestsHandler::findPageZone(const std::string& extension) const
+{
+	auto it = _pageZones.find(extension);
+	return (it == _pageZones.end()) ? nullptr : &it->second;
+}
+
+bool RequestsHandler::isPageZoneDialog(const std::string& extension) const
+{
+	return pbx::isPageZoneExt(extension) && _pageZones.find(extension) != _pageZones.end();
+}
+
+void RequestsHandler::setPageZone(const std::string& zoneExt, const std::string& members)
+{
+	std::vector<std::pair<bool, std::string>> localLogs;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+
+		if (!pbx::isPageZoneExt(zoneExt))
+		{
+			queueLog("Page zone ignored for non-zone extension " + zoneExt +
+				" (zones are 980-989)", true);
+		}
+		else
+		{
+			std::vector<std::string> list = pbx::splitZoneMembers(members);
+			if (list.empty())
+			{
+				_pageZones.erase(zoneExt);
+				queueLog("Page zone " + zoneExt + " deleted");
+				persistPageZones();
+			}
+			else
+			{
+				bool isNew = (_pageZones.find(zoneExt) == _pageZones.end());
+				if (isNew && _pageZones.size() >= static_cast<size_t>(POCKETDIAL_MAX_PAGE_ZONES))
+				{
+					queueLog("Page zone ignored (table full) for " + zoneExt, true);
+				}
+				else
+				{
+					pbx::PageZone& z = _pageZones[zoneExt];
+					z.members = std::move(list);
+					queueLog("Page zone " + zoneExt + " = " + pbx::joinMembers(z.members));
+					persistPageZones();
+				}
+			}
+		}
+
+		{
+			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+			_snapshot.pageZones.clear();
+			_snapshot.pageZones.reserve(_pageZones.size());
+			for (const auto& [ext, z] : _pageZones)
+			{
+				_snapshot.pageZones.emplace_back(ext, pbx::joinMembers(z.members));
+			}
+		}
+
+		localLogs = std::move(_logQueue);
+		_logQueue.clear();
+	}
+
+	for (const auto& log : localLogs)
+	{
+		if (log.first) std::cerr << log.second << std::endl;
+		else std::cout << log.second << std::endl;
+	}
+}
+
+std::vector<std::pair<std::string, std::string>> RequestsHandler::getPageZones()
+{
+	std::lock_guard<std::mutex> lock(_snapshotMutex);
+	return _snapshot.pageZones;
+}
+
+// ── Call parking (orbits 700–709) ─────────────────────────────────────────────
+
+int RequestsHandler::parkOrbitIndex(std::string_view ext) const
+{
+	if (ext.size() != 3 || ext[0] != '7' || ext[1] != '0') return -1;
+	if (ext[2] < '0' || ext[2] > '9') return -1;
+	int idx = ext[2] - '0';
+	return (idx < static_cast<int>(_parkSlots.size())) ? idx : -1;
+}
+
+void RequestsHandler::onParkInvite(std::shared_ptr<SipMessage> data,
+	const std::shared_ptr<SipClient>& caller, int orbitIdx)
+{
+	if (orbitIdx < 0 || orbitIdx >= static_cast<int>(_parkSlots.size()) || !caller)
+	{
+		return;
+	}
+	ParkSlot& slot = _parkSlots[orbitIdx];
+	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string orbit = "70" + std::to_string(orbitIdx);
+	const std::string toTag = IDGen::GenerateID(9);
+
+	if (slot.state == ParkState::Free)
+	{
+		// ── PARK ── answer with an a=inactive hold SDP so the parked party is held.
+		const std::string holdSdp =
+			"v=0\r\n"
+			"o=- 0 0 IN IP4 " + activeIp + "\r\n"
+			"s=pocket-dial\r\n"
+			"c=IN IP4 " + activeIp + "\r\n"
+			"t=0 0\r\n"
+			"m=audio 9 RTP/AVP 0\r\n"
+			"a=inactive\r\n";
+		auto ok = getMessageFromPool(data->toString(), data->getSource());
+		ok->setHeader(SipMessageTypes::OK);
+		ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+		ok->setTo(std::string(data->getTo()) + ";tag=" + toTag);
+		ok->setContact(buildContact(orbit));
+		ok->setBody(holdSdp);
+		ok->syncContentLength();
+		_outbox.emplace_back(data->getSource(), ok);
+
+		slot = ParkSlot{};
+		slot.state      = ParkState::Parked;
+		slot.orbit      = orbit;
+		slot.callID     = std::string(data->getCallID());
+		slot.parkedExt  = caller->getNumber();
+		slot.parkedAddr = data->getSource();
+		slot.parked        = true;
+		slot.parkedSdp     = std::string(data->getBody());
+		slot.parkedFromTag = parkTagOf(data->getFrom());
+		slot.localTag   = toTag;
+		slot.parker     = caller->getNumber();
+		slot.parkedAt   = std::chrono::steady_clock::now();
+
+		auto virt = allocateVirtualPeer(orbit, data->getSource());
+		if (auto session = allocateSession(std::string(data->getCallID()), caller))
+		{
+			session->setDest(virt);
+			session->setLocalTag(toTag);
+			session->setInviteMessage(data);
+			_sessions.emplace(std::string(data->getCallID()), session);
+			session->setState(Session::State::Connected);
+		}
+		queueLog("Park: " + caller->getNumber() + " parked on " + orbit);
+		refreshParkSnapshot();
+		return;
+	}
+
+	// ── RETRIEVE ── the orbit is occupied: SDP-swap retrieve.
+	const std::string parkedSdp(slot.parkedSdp);
+	const std::string retrieverSdp(data->getBody());
+
+	auto ok = getMessageFromPool(data->toString(), data->getSource());
+	ok->setHeader(SipMessageTypes::OK);
+	ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+	ok->setTo(std::string(data->getTo()) + ";tag=" + toTag);
+	ok->setContact(buildContact(orbit));
+	if (!parkedSdp.empty()) ok->setBody(parkedSdp);
+	ok->enforceG711();
+	ok->syncContentLength();
+	_outbox.emplace_back(data->getSource(), ok);
+
+	sendParkReinvite(slot, retrieverSdp);
+
+	auto virt = allocateVirtualPeer(slot.parkedExt, slot.parkedAddr);
+	if (auto rsession = allocateSession(std::string(data->getCallID()), caller))
+	{
+		rsession->setDest(virt);
+		rsession->setPeerCallID(slot.callID);
+		rsession->setLocalTag(toTag);
+		rsession->setInviteMessage(data);
+		_sessions.emplace(std::string(data->getCallID()), rsession);
+		rsession->setState(Session::State::Connected);
+	}
+	if (auto parked = getSession(slot.callID); parked.has_value())
+	{
+		parked.value()->setPeerCallID(std::string(data->getCallID()));
+	}
+	queueLog("Park: " + caller->getNumber() + " retrieved " + slot.parkedExt + " from " + orbit);
+
+	slot = ParkSlot{};
+	refreshParkSnapshot();
+}
+
+void RequestsHandler::sendParkReinvite(ParkSlot& slot, const std::string& sdp)
+{
+	if (slot.callID.empty() || !slot.parked) return;
+	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+
+	char ipBuf[INET_ADDRSTRLEN]{};
+	inet_ntop(AF_INET, &slot.parkedAddr.sin_addr, ipBuf, sizeof(ipBuf));
+	const std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(slot.parkedAddr.sin_port));
+
+	const std::string theirTag = slot.parkedFromTag;
+	const std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
+	const std::string body = sdp;
+
+	std::ostringstream ss;
+	ss << "INVITE sip:" << slot.parkedExt << "@" << destIpPort << " SIP/2.0\r\n"
+	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
+	   << "From: <sip:" << slot.orbit << "@" << srcIpPort << ">;tag=" << slot.localTag << "\r\n"
+	   << "To: <sip:" << slot.parkedExt << "@" << activeIp << ">;tag=" << theirTag << "\r\n"
+	   << slot.callID << "\r\n"
+	   << "CSeq: 2 INVITE\r\n"
+	   << "Max-Forwards: 70\r\n"
+	   << "Contact: <sip:" << slot.orbit << "@" << srcIpPort << ";transport=UDP>\r\n"
+	   << "User-Agent: pocket-dial\r\n"
+	   << "Content-Type: application/sdp\r\n"
+	   << "Content-Length: " << body.size() << "\r\n\r\n"
+	   << body;
+
+	auto inv = getMessageFromPool(ss.str(), slot.parkedAddr);
+	inv->enforceG711();
+	inv->syncContentLength();
+	_outbox.emplace_back(slot.parkedAddr, std::move(inv));
+	_parkPendingAcks.push_back(slot.callID);
+	queueLog("Park: re-INVITE -> parked party " + slot.parkedExt);
+}
+
+void RequestsHandler::byeParkedParty(const ParkSlot& slot)
+{
+	if (slot.callID.empty()) return;
+	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+	const std::string fromHeader = "<sip:" + slot.orbit + "@" + srcIpPort + ">;tag=" + slot.localTag;
+	const std::string toHeader = "<sip:" + slot.parkedExt + "@" + activeIp + ">;tag=" + slot.parkedFromTag;
+	auto bye = buildServerBye(slot.parkedExt, slot.parkedAddr,
+		stripHeaderName(slot.callID), fromHeader, toHeader);
+	if (bye) _outbox.emplace_back(slot.parkedAddr, std::move(bye));
+}
+
+void RequestsHandler::startParkRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& parker,
+	std::chrono::steady_clock::time_point now)
+{
+	if (!parker) { byeParkedParty(slot); freeParkSlot(slot.callID); return; }
+	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+	const sockaddr_in& addr = parker->getAddress();
+
+	char ipBuf[INET_ADDRSTRLEN]{};
+	inet_ntop(AF_INET, &addr.sin_addr, ipBuf, sizeof(ipBuf));
+	const std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(addr.sin_port));
+
+	slot.rbCallID  = "Call-ID: " + IDGen::GenerateID(16) + "@" + activeIp;
+	slot.rbFromTag = IDGen::GenerateID(9);
+	slot.rbBranch  = "z9hG4bK" + IDGen::GenerateID(12);
+	slot.rbAddr    = addr;
+	slot.state     = ParkState::RingingBack;
+	slot.deadline  = now + std::chrono::seconds(30);
+
+	const std::string body = slot.parkedSdp;
+	std::ostringstream ss;
+	ss << "INVITE sip:" << parker->getNumber() << "@" << destIpPort << " SIP/2.0\r\n"
+	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << slot.rbBranch << "\r\n"
+	   << "From: \"PocketDial Park\" <sip:" << slot.orbit << "@" << srcIpPort << ">;tag=" << slot.rbFromTag << "\r\n"
+	   << "To: <sip:" << parker->getNumber() << "@" << activeIp << ">\r\n"
+	   << slot.rbCallID << "\r\n"
+	   << "CSeq: 1 INVITE\r\n"
+	   << "Max-Forwards: 70\r\n"
+	   << "Contact: <sip:" << slot.orbit << "@" << srcIpPort << ";transport=UDP>\r\n"
+	   << "User-Agent: pocket-dial\r\n"
+	   << "Content-Type: application/sdp\r\n"
+	   << "Content-Length: " << body.size() << "\r\n\r\n"
+	   << body;
+
+	auto inv = getMessageFromPool(ss.str(), addr);
+	inv->enforceG711();
+	inv->syncContentLength();
+	_outbox.emplace_back(addr, std::move(inv));
+	queueLog("Park: timeout on " + slot.orbit + " — ringing back parker " + parker->getNumber());
+}
+
+bool RequestsHandler::handleParkOk(const std::shared_ptr<SipMessage>& data)
+{
+	const std::string cseq(data->getCSeq());
+	const std::string callID(data->getCallID());
+	const bool isInviteOk = cseq.find(SipMessageTypes::INVITE) != std::string::npos;
+	if (!isInviteOk) return false;
+
+	// (a) 200 OK to a park re-INVITE sent to the parked party: ACK and free tracking entry.
+	if (auto it = std::find(_parkPendingAcks.begin(), _parkPendingAcks.end(), callID);
+		it != _parkPendingAcks.end())
+	{
+		const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+		const sockaddr_in srcAddr = data->getSource();
+		char ipBuf[INET_ADDRSTRLEN]{};
+		inet_ntop(AF_INET, &srcAddr.sin_addr, ipBuf, sizeof(ipBuf));
+		const std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(srcAddr.sin_port));
+		std::ostringstream ss;
+		ss << "ACK sip:" << data->getToNumber() << "@" << destIpPort << " SIP/2.0\r\n"
+		   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=z9hG4bK" << IDGen::GenerateID(12) << "\r\n"
+		   << "From: " << stripHeaderName(data->getFrom()) << "\r\n"
+		   << "To: " << stripHeaderName(data->getTo()) << "\r\n"
+		   << callID << "\r\n"
+		   << "CSeq: 2 ACK\r\n"
+		   << "Max-Forwards: 70\r\n"
+		   << "Content-Length: 0\r\n\r\n";
+		_outbox.emplace_back(data->getSource(), getMessageFromPool(ss.str(), data->getSource()));
+		_parkPendingAcks.erase(it);
+		return true;
+	}
+
+	// (b) 200 OK to a ring-back INVITE sent to the parker: ACK parker, bridge both legs.
+	for (auto& slot : _parkSlots)
+	{
+		if (slot.state == ParkState::RingingBack && slot.rbCallID == callID)
+		{
+			const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+			const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+			char ipBuf[INET_ADDRSTRLEN]{};
+			inet_ntop(AF_INET, &slot.rbAddr.sin_addr, ipBuf, sizeof(ipBuf));
+			const std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(slot.rbAddr.sin_port));
+			std::ostringstream ss;
+			ss << "ACK sip:" << data->getToNumber() << "@" << destIpPort << " SIP/2.0\r\n"
+			   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << slot.rbBranch << "\r\n"
+			   << "From: \"PocketDial Park\" <sip:" << slot.orbit << "@" << srcIpPort << ">;tag=" << slot.rbFromTag << "\r\n"
+			   << "To: " << stripHeaderName(data->getTo()) << "\r\n"
+			   << slot.rbCallID << "\r\n"
+			   << "CSeq: 1 ACK\r\n"
+			   << "Max-Forwards: 70\r\n"
+			   << "Content-Length: 0\r\n\r\n";
+			_outbox.emplace_back(slot.rbAddr, getMessageFromPool(ss.str(), slot.rbAddr));
+
+			sendParkReinvite(slot, std::string(data->getBody()));
+
+			if (auto parker = findClient(slot.parker); parker.has_value())
+			{
+				auto virt = allocateVirtualPeer(slot.parkedExt, slot.parkedAddr);
+				if (auto rb = allocateSession(slot.rbCallID, parker.value()))
+				{
+					rb->setDest(virt);
+					rb->setPeerCallID(slot.callID);
+					rb->setLocalTag(slot.rbFromTag);
+					rb->setParkUac(true);
+					rb->setInviteMessage(data);
+					_sessions.emplace(slot.rbCallID, rb);
+					rb->setState(Session::State::Connected);
+				}
+				if (auto parked = getSession(slot.callID); parked.has_value())
+				{
+					parked.value()->setPeerCallID(slot.rbCallID);
+				}
+			}
+
+			queueLog("Park: parker answered ring-back on " + slot.orbit + " — bridging");
+			slot = ParkSlot{};
+			refreshParkSnapshot();
+			return true;
+		}
+	}
+	return false;
+}
+
+bool RequestsHandler::handleTransferOk(const std::shared_ptr<SipMessage>& data)
+{
+	const std::string cseq(data->getCSeq());
+	const std::string callID(data->getCallID());
+	if (cseq.find(SipMessageTypes::INVITE) == std::string::npos) return false;
+
+	auto it = std::find(_transferPendingAcks.begin(), _transferPendingAcks.end(), callID);
+	if (it == _transferPendingAcks.end()) return false;
+
+	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+	const sockaddr_in src = data->getSource();
+	char ipBuf[INET_ADDRSTRLEN]{};
+	inet_ntop(AF_INET, &src.sin_addr, ipBuf, sizeof(ipBuf));
+	const std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(src.sin_port));
+
+	std::ostringstream ss;
+	ss << "ACK sip:" << data->getToNumber() << "@" << destIpPort << " SIP/2.0\r\n"
+	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=z9hG4bK" << IDGen::GenerateID(12) << "\r\n"
+	   << "From: " << stripHeaderName(data->getFrom()) << "\r\n"
+	   << "To: " << stripHeaderName(data->getTo()) << "\r\n"
+	   << callID << "\r\n"
+	   << "CSeq: 100 ACK\r\n"
+	   << "Max-Forwards: 70\r\n"
+	   << "Content-Length: 0\r\n\r\n";
+	_outbox.emplace_back(data->getSource(), getMessageFromPool(ss.str(), data->getSource()));
+	_transferPendingAcks.erase(it);
+	return true;
+}
+
+void RequestsHandler::parkSweep(std::chrono::steady_clock::time_point now)
+{
+	for (auto& slot : _parkSlots)
+	{
+		if (slot.state == ParkState::Parked &&
+			(now - slot.parkedAt) >= _parkTimeout)
+		{
+			auto parker = findClient(slot.parker);
+			if (parker.has_value())
+			{
+				startParkRingback(slot, parker.value(), now);
+			}
+			else
+			{
+				queueLog("Park: timeout on " + slot.orbit + " — parker " + slot.parker +
+					" gone, tearing down");
+				byeParkedParty(slot);
+				freeParkSlot(slot.callID);
+			}
+		}
+		else if (slot.state == ParkState::RingingBack && now >= slot.deadline)
+		{
+			queueLog("Park: ring-back on " + slot.orbit + " not answered — tearing down");
+			byeParkedParty(slot);
+			freeParkSlot(slot.callID);
+		}
+	}
+	refreshParkSnapshot();
+}
+
+void RequestsHandler::freeParkSlot(std::string_view callID)
+{
+	for (auto& slot : _parkSlots)
+	{
+		if (slot.state != ParkState::Free && slot.callID == callID)
+		{
+			slot = ParkSlot{};
+		}
+	}
+	_parkPendingAcks.erase(
+		std::remove(_parkPendingAcks.begin(), _parkPendingAcks.end(), std::string(callID)),
+		_parkPendingAcks.end());
+}
+
+void RequestsHandler::refreshParkSnapshot()
+{
+	const auto now = std::chrono::steady_clock::now();
+	std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+	_snapshot.parkedCalls.clear();
+	for (const auto& slot : _parkSlots)
+	{
+		if (slot.state == ParkState::Free) continue;
+		int secs = static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(
+			now - slot.parkedAt).count());
+		_snapshot.parkedCalls.emplace_back(slot.orbit, slot.parkedExt, slot.parker, secs);
+	}
+}
+
+std::vector<std::tuple<std::string, std::string, std::string, int>> RequestsHandler::getParkedCalls()
+{
+	std::lock_guard<std::mutex> lock(_snapshotMutex);
+	return _snapshot.parkedCalls;
+}
+
+// ── Build helpers ─────────────────────────────────────────────────────────────
+
+std::shared_ptr<SipMessage> RequestsHandler::buildOkWithSdp(
+	const std::shared_ptr<SipMessage>& inviteMsg,
+	const std::string& activeIp,
+	const std::string& toTag,
+	const std::string& sdpBody)
+{
+	auto ok = getMessageFromPool(inviteMsg->toString(), inviteMsg->getSource());
+	ok->setHeader(SipMessageTypes::OK);
+	ok->setVia(std::string(inviteMsg->getVia()) + ";received=" + activeIp);
+	ok->setTo(std::string(inviteMsg->getTo()) + ";tag=" + toTag);
+	ok->setContact(buildContact(inviteMsg->getToNumber()));
+	ok->clearBody();
+	{
+		std::string raw = ok->toString();
+		size_t sep = raw.find("\r\n\r\n");
+		if (sep != std::string::npos)
+		{
+			std::string_view headerView(raw.data(), sep);
+			if (headerView.find("application/sdp") == std::string_view::npos)
+			{
+				raw.insert(sep, "\r\nContent-Type: application/sdp");
+				sep = raw.find("\r\n\r\n");
+			}
+			raw.erase(sep + 4);
+			raw += sdpBody;
+		}
+		ok->reset(std::move(raw), inviteMsg->getSource());
+	}
+	ok->enforceG711();
+	ok->syncContentLength();
+	return ok;
+}
+
+std::shared_ptr<SipMessage> RequestsHandler::buildServerBye(
+	const std::string& destExt,
+	const sockaddr_in& destAddr,
+	const std::string& callId,
+	const std::string& fromHeader,
+	const std::string& toHeader)
+{
+	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+	char ipBuf[INET_ADDRSTRLEN]{};
+	inet_ntop(AF_INET, &destAddr.sin_addr, ipBuf, sizeof(ipBuf));
+	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(destAddr.sin_port));
+	std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
+
+	std::ostringstream ss;
+	ss << "BYE sip:" << destExt << "@" << destIpPort << " SIP/2.0\r\n"
+	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
+	   << "From: " << stripHeaderName(fromHeader) << "\r\n"
+	   << "To: " << stripHeaderName(toHeader) << "\r\n"
+	   << "Call-ID: " << stripHeaderName(callId) << "\r\n"
+	   << "CSeq: 2 BYE\r\n"
+	   << "Max-Forwards: 70\r\n"
+	   << "Content-Length: 0\r\n\r\n";
+
+	return getMessageFromPool(ss.str(), destAddr);
+}
+
+std::shared_ptr<SipClient> RequestsHandler::allocateVirtualPeer(std::string number, sockaddr_in address, int expiresSeconds)
+{
+	// A virtual peer is owned solely by the Session._dest it backs, so a pool slot is
+	// free precisely when only the pool itself still references it (use_count()==1).
+	for (auto& peer : _virtualPeerPool)
+	{
+		if (peer.use_count() == 1)
+		{
+			peer->reset(std::move(number), address, expiresSeconds);
+			return peer;
+		}
+	}
+	// Pool drained: fall back to a one-off heap SipClient rather than failing the call.
+	std::cerr << "[WARNING] Virtual-peer pool exhausted! Fallback to heap allocation.\n";
+	return std::make_shared<SipClient>(std::move(number), address, expiresSeconds);
 }

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -63,6 +63,7 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 	OnHandledEvent onHandledEvent) :
 	_onHandled(onHandledEvent),
 	_serverIp(std::move(serverIp)),
+	_localIp(_serverIp == "0.0.0.0" ? getPrimaryLocalIP() : _serverIp),
 	_serverPort(serverPort)
 {
 	initHandlers();
@@ -259,7 +260,7 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 			{
 				auto infoOk = getMessageFromPool(request->toString(), request->getSource());
 				infoOk->setHeader(SipMessageTypes::OK);
-				std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+				std::string activeIp = _localIp;
 				infoOk->setVia(std::string(request->getVia()) + ";received=" + activeIp);
 				_outbox.emplace_back(request->getSource(), std::move(infoOk));
 			}
@@ -334,7 +335,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader("SIP/2.0 400 Bad Request");
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		return;
@@ -414,7 +415,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 			auto response = getMessageFromPool(data->toString(), data->getSource());
 			response->setHeader("SIP/2.0 503 Service Unavailable");
 			response->clearBody();
-			std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+			std::string activeIp = _localIp;
 			response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 			_outbox.emplace_back(data->getSource(), std::move(response));
 			return;
@@ -423,7 +424,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 
 	auto response = getMessageFromPool(data->toString(), data->getSource());
 	response->setHeader(SipMessageTypes::OK);
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	response->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
 	// Echo the granted lease back in the Contact so the client knows when to refresh.
@@ -435,7 +436,7 @@ void RequestsHandler::onOptions(std::shared_ptr<SipMessage> data)
 {
 	auto response = getMessageFromPool(data->toString(), data->getSource());
 	response->setHeader(SipMessageTypes::OK);
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	response->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
 	response->setContact(buildContact(data->getFromNumber()));
@@ -484,7 +485,7 @@ void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 		auto session = getSession(data->getCallID());
 		if (session.has_value())
 		{
-			std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+			std::string activeIp = _localIp;
 			std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 			std::string originalCSeq(data->getCSeq());
 			size_t invitePos = originalCSeq.find("INVITE");
@@ -557,7 +558,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader("SIP/2.0 400 Bad Request");
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		return;
@@ -570,7 +571,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		return;
@@ -583,7 +584,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		auto ringing = getMessageFromPool(data->toString(), data->getSource());
 		ringing->setHeader("SIP/2.0 180 Ringing");
 		ringing->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		ringing->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		std::string toTag = IDGen::GenerateID(9);
 		ringing->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -751,7 +752,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		auto ringing = getMessageFromPool(data->toString(), data->getSource());
 		ringing->setHeader("SIP/2.0 180 Ringing");
 		ringing->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		ringing->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		ringing->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
 		ringing->setContact(buildContact(destNumber));
@@ -785,7 +786,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader("SIP/2.0 480 Temporarily Unavailable");
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		response->setContact(buildContact(caller.value()->getNumber()));
 		endHandle(data->getFromNumber(), response);
@@ -923,7 +924,7 @@ bool RequestsHandler::parseCallerRtp(const std::shared_ptr<SipMessage>& invite,
 void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	const std::shared_ptr<SipClient>& caller)
 {
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 
 	// Single-stream cap: a 2nd dial of 440 while a stream is live is rejected so the
 	// one media slot/socket/task is never double-booked (degrade gracefully).
@@ -1166,7 +1167,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 	{
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader(SipMessageTypes::OK);
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		endCall(data->getCallID(), data->getFromNumber(), destNumber);
@@ -1180,7 +1181,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		_rtpSender.stop(std::string(data->getCallID()));
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader(SipMessageTypes::OK);
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		endCall(data->getCallID(), data->getFromNumber(), destNumber);
@@ -1191,7 +1192,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 	{
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader(SipMessageTypes::OK);
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 
@@ -1314,7 +1315,13 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 
 			if (session.value()->isBroadcast())
 			{
-				if (session.value()->getState() != Session::State::Connected)
+				// Only the first answer from a pending fork (Invited state) should run
+				// the connect path. A re-INVITE 200 OK from an already-connected or held
+				// broadcast call (Held / Connected state) falls through to a silent drop
+				// below — the peer relay above was already skipped by !isBroadcast(), so
+				// the hold/resume path for broadcast calls is currently unsupported and
+				// the 200 OK is discarded (the hold stays in place). (#69)
+				if (session.value()->getState() == Session::State::Invited)
 				{
 					auto clientOpt = findClientByAddress(data->getSource());
 					if (!clientOpt.has_value())
@@ -1451,7 +1458,7 @@ void RequestsHandler::onAck(std::shared_ptr<SipMessage> data)
 		if (answeringClient)
 		{
 			auto ackFork = getMessageFromPool(data->toString(), data->getSource());
-			std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+			std::string activeIp = _localIp;
 			std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 			char ipBuf[INET_ADDRSTRLEN]{};
@@ -1515,7 +1522,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		return;
@@ -1558,7 +1565,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader(SipMessageTypes::BAD_REQUEST);
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		return;
@@ -1569,7 +1576,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 		auto accepted = getMessageFromPool(data->toString(), data->getSource());
 		accepted->setHeader(SipMessageTypes::ACCEPTED);
 		accepted->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		accepted->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		accepted->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
 		_outbox.emplace_back(data->getSource(), std::move(accepted));
@@ -1615,7 +1622,7 @@ void RequestsHandler::onMessage(std::shared_ptr<SipMessage> data)
 	auto response = getMessageFromPool(data->toString(), data->getSource());
 	response->setHeader(SipMessageTypes::OK);
 	response->clearBody();
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	response->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
 	_outbox.emplace_back(data->getSource(), std::move(response));
@@ -1629,7 +1636,7 @@ void RequestsHandler::buildInviteFork(const std::shared_ptr<SipMessage>& invite,
 	auto inviteFork = getMessageFromPool(invite->toString(), invite->getSource());
 	inviteFork->setContact(buildContact(caller->getNumber()));
 
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	char ipBuf[INET_ADDRSTRLEN]{};
 	inet_ntop(AF_INET, &target->getAddress().sin_addr, ipBuf, sizeof(ipBuf));
 	std::string targetIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(target->getAddress().sin_port));
@@ -1681,7 +1688,7 @@ void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
 	auto ringing = getMessageFromPool(invite->toString(), invite->getSource());
 	ringing->setHeader("SIP/2.0 180 Ringing");
 	ringing->clearBody();
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	ringing->setVia(std::string(invite->getVia()) + ";received=" + activeIp);
 	ringing->setTo(std::string(invite->getTo()) + ";tag=" + IDGen::GenerateID(9));
 	ringing->setContact(buildContact(contactExt));
@@ -1775,7 +1782,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildReferNotify(const std::shared_
 {
 	// RFC 3515 §2.4.5 NOTIFY: Event: refer + message/sipfrag body reporting the
 	// transfer result. Sent within the REFER's dialog back to the transferor.
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	char ipBuf[INET_ADDRSTRLEN]{};
 	inet_ntop(AF_INET, &transferor->getAddress().sin_addr, ipBuf, sizeof(ipBuf));
 	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(transferor->getAddress().sin_port));
@@ -1810,7 +1817,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildCancel(const std::shared_ptr<S
 	// Build a CANCEL for an outstanding forked INVITE leg toward `target`, derived
 	// from the original INVITE (same Call-ID / branch). Mirrors the inline CANCEL
 	// construction used by onCancel()/onOk() for the 999 path.
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 	auto cancelMsg = getMessageFromPool(invite->toString(), invite->getSource());
@@ -1928,6 +1935,7 @@ void RequestsHandler::recordCdr(const std::shared_ptr<Session>& session,
 			// the later Bye transition does NOT touch it, so getStartTime() still marks
 			// the answer instant in both cases — talk time is now - startTime.
 			case Session::State::Connected:
+			case Session::State::Held:   // call torn down mid-hold → still Answered (#73)
 			case Session::State::Bye:
 				result = CdrResult::Answered;
 				{
@@ -2137,7 +2145,7 @@ void RequestsHandler::endHandle(std::string_view destNumber, std::shared_ptr<Sip
 
 std::string RequestsHandler::buildContact(std::string_view number) const
 {
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	return "Contact: <sip:" + std::string(number) + "@" + activeIp + ":" + std::to_string(_serverPort) + ";transport=UDP>";
 }
 
@@ -2652,7 +2660,7 @@ void RequestsHandler::sendChallenge(const std::shared_ptr<SipMessage>& data, boo
 	auto response = getMessageFromPool(data->toString(), data->getSource());
 	response->setHeader("SIP/2.0 401 Unauthorized");
 	response->clearBody();
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	response->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
 	// Fresh stateless nonce per challenge; realm MUST match SipSecretStore::kRealm.
@@ -2668,7 +2676,7 @@ void RequestsHandler::sendForbidden(const std::shared_ptr<SipMessage>& data, con
 	auto response = getMessageFromPool(data->toString(), data->getSource());
 	response->setHeader("SIP/2.0 403 " + reason);
 	response->clearBody();
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	response->syncContentLength();
 	_outbox.emplace_back(data->getSource(), std::move(response));
@@ -2809,7 +2817,7 @@ bool RequestsHandler::sendMessageTo(const std::string& ext, const std::string& t
 		inet_ntop(AF_INET, &addr.sin_addr, ipBuf, sizeof(ipBuf));
 		std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(addr.sin_port));
 
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 		std::string callId  = IDGen::GenerateID(16) + "@" + activeIp;
@@ -3091,6 +3099,16 @@ void RequestsHandler::tick()
 			_snapshot = std::move(nextSnapshot);
 		}
 
+		// RFC 3261 §17: register any new outgoing INVITEs for retransmit (mirrors
+		// the same scan in handle()). tick()-originated INVITE forks (park ring-back,
+		// hunt-group next-ring, CFNA redirect) need Timer A/B coverage too. (#70)
+		for (const auto& [addr, msg] : _outbox)
+		{
+			auto txType = classifyTxType(msg);
+			if (txType != SipTransaction::Type::None)
+				registerTx(txType, addr, msg);
+		}
+
 		localOutbox = std::move(_outbox);
 		_outbox.clear();
 
@@ -3132,7 +3150,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildOptionsPing(const std::shared_
 	inet_ntop(AF_INET, &client->getAddress().sin_addr, ipBuf, sizeof(ipBuf));
 	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(client->getAddress().sin_port));
 
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 	std::string callId = IDGen::GenerateID(16) + "@" + activeIp;
@@ -3202,7 +3220,7 @@ void RequestsHandler::sendRegisterBeep(const std::shared_ptr<SipClient>& phone)
 	inet_ntop(AF_INET, &addr.sin_addr, ipBuf, sizeof(ipBuf));
 	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(addr.sin_port));
 
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 	std::string callId  = IDGen::GenerateID(16) + "@" + activeIp;
@@ -3274,7 +3292,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildBeepAck(const std::shared_ptr<
 	inet_ntop(AF_INET, &bd->addr.sin_addr, ipBuf, sizeof(ipBuf));
 	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(bd->addr.sin_port));
 
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 	std::ostringstream ss;
@@ -3304,7 +3322,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildBeepBye(const std::shared_ptr<
 	inet_ntop(AF_INET, &bd->addr.sin_addr, ipBuf, sizeof(ipBuf));
 	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(bd->addr.sin_port));
 
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 	std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
 
@@ -3336,7 +3354,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildBeepCancel(std::size_t slot)
 	inet_ntop(AF_INET, &bd.addr.sin_addr, ipBuf, sizeof(ipBuf));
 	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(bd.addr.sin_port));
 
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 	std::ostringstream ss;
@@ -4014,7 +4032,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		accum.digits.clear();
@@ -4214,7 +4232,7 @@ void RequestsHandler::onReinvite(std::shared_ptr<SipMessage> data)
 		auto response = getMessageFromPool(data->toString(), data->getSource());
 		response->setHeader("SIP/2.0 488 Not Acceptable Here");
 		response->clearBody();
-		std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		_outbox.emplace_back(data->getSource(), std::move(response));
 		return;
@@ -4279,7 +4297,7 @@ void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
 		return;
 	}
 	auto session = sessionOpt.value();
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 
 	if (!data->hasSdp())
 	{
@@ -4479,7 +4497,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildDialogNotify(DialogSubscriptio
 	const std::string& state, const std::string& direction, const std::string& dialogId,
 	bool terminated, const char* termReason)
 {
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 	char ipBuf[INET_ADDRSTRLEN]{};
 	inet_ntop(AF_INET, &sub.addr.sin_addr, ipBuf, sizeof(ipBuf));
@@ -4531,7 +4549,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildDialogNotify(DialogSubscriptio
 
 void RequestsHandler::onSubscribe(std::shared_ptr<SipMessage> data)
 {
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 
 	// 1. Event-package gate: only the RFC 4235 "dialog" package is implemented.
 	std::string pkg = parseEventPackage(data->toString());
@@ -4857,12 +4875,16 @@ void RequestsHandler::sweepSessionTimers(std::chrono::steady_clock::time_point n
 		const std::string& dFrom = session->getDialogFrom();
 		const std::string& dTo   = session->getDialogTo();
 
-		if (src && !dFrom.empty())
+		// Guard on both dialog headers: a BYE with an empty From or To is malformed
+		// and phones will drop it, leaving the session alive and re-firing every sweep
+		// tick. dTo can be empty if armSessionTimer was invoked before the 200 OK set
+		// dialog headers (e.g. a partial onReinvite path). (#72)
+		if (src && !dFrom.empty() && !dTo.empty())
 		{
 			auto b = buildServerBye(src->getNumber(), src->getAddress(), callID, dTo, dFrom);
 			if (b) _outbox.emplace_back(src->getAddress(), std::move(b));
 		}
-		if (dest && !dFrom.empty())
+		if (dest && !dFrom.empty() && !dTo.empty())
 		{
 			auto b = buildServerBye(dest->getNumber(), dest->getAddress(), callID, dFrom, dTo);
 			if (b) _outbox.emplace_back(dest->getAddress(), std::move(b));
@@ -4970,7 +4992,7 @@ void RequestsHandler::onParkInvite(std::shared_ptr<SipMessage> data,
 		return;
 	}
 	ParkSlot& slot = _parkSlots[orbitIdx];
-	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string activeIp = _localIp;
 	const std::string orbit = "70" + std::to_string(orbitIdx);
 	const std::string toTag = IDGen::GenerateID(9);
 
@@ -5022,8 +5044,24 @@ void RequestsHandler::onParkInvite(std::shared_ptr<SipMessage> data,
 	}
 
 	// ── RETRIEVE ── the orbit is occupied: SDP-swap retrieve.
+	// Allocate the retriever session FIRST (#71): if the pool is exhausted we 503
+	// the retriever and leave the slot intact rather than sending a re-INVITE to
+	// the parked party and then having no session to track the bridge.
 	const std::string parkedSdp(slot.parkedSdp);
 	const std::string retrieverSdp(data->getBody());
+
+	auto virt = allocateVirtualPeer(slot.parkedExt, slot.parkedAddr);
+	auto rsession = allocateSession(std::string(data->getCallID()), caller);
+	if (!rsession)
+	{
+		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		resp->setHeader("SIP/2.0 503 Service Unavailable");
+		resp->clearBody();
+		resp->syncContentLength();
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+		queueLog("Park: retrieve rejected — session pool exhausted", true);
+		return;
+	}
 
 	auto ok = getMessageFromPool(data->toString(), data->getSource());
 	ok->setHeader(SipMessageTypes::OK);
@@ -5035,22 +5073,18 @@ void RequestsHandler::onParkInvite(std::shared_ptr<SipMessage> data,
 	ok->syncContentLength();
 	_outbox.emplace_back(data->getSource(), ok);
 
-	sendParkReinvite(slot, retrieverSdp);
+	rsession->setDest(virt);
+	rsession->setPeerCallID(slot.callID);
+	rsession->setLocalTag(toTag);
+	rsession->setInviteMessage(data);
+	_sessions.emplace(std::string(data->getCallID()), rsession);
+	rsession->setState(Session::State::Connected);
 
-	auto virt = allocateVirtualPeer(slot.parkedExt, slot.parkedAddr);
-	if (auto rsession = allocateSession(std::string(data->getCallID()), caller))
-	{
-		rsession->setDest(virt);
-		rsession->setPeerCallID(slot.callID);
-		rsession->setLocalTag(toTag);
-		rsession->setInviteMessage(data);
-		_sessions.emplace(std::string(data->getCallID()), rsession);
-		rsession->setState(Session::State::Connected);
-	}
 	if (auto parked = getSession(slot.callID); parked.has_value())
 	{
 		parked.value()->setPeerCallID(std::string(data->getCallID()));
 	}
+	sendParkReinvite(slot, retrieverSdp);
 	queueLog("Park: " + caller->getNumber() + " retrieved " + slot.parkedExt + " from " + orbit);
 
 	slot = ParkSlot{};
@@ -5060,7 +5094,7 @@ void RequestsHandler::onParkInvite(std::shared_ptr<SipMessage> data,
 void RequestsHandler::sendParkReinvite(ParkSlot& slot, const std::string& sdp)
 {
 	if (slot.callID.empty() || !slot.parked) return;
-	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string activeIp = _localIp;
 	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 	char ipBuf[INET_ADDRSTRLEN]{};
@@ -5076,7 +5110,7 @@ void RequestsHandler::sendParkReinvite(ParkSlot& slot, const std::string& sdp)
 	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
 	   << "From: <sip:" << slot.orbit << "@" << srcIpPort << ">;tag=" << slot.localTag << "\r\n"
 	   << "To: <sip:" << slot.parkedExt << "@" << activeIp << ">;tag=" << theirTag << "\r\n"
-	   << slot.callID << "\r\n"
+	   << "Call-ID: " << slot.callID << "\r\n"
 	   << "CSeq: 2 INVITE\r\n"
 	   << "Max-Forwards: 70\r\n"
 	   << "Contact: <sip:" << slot.orbit << "@" << srcIpPort << ";transport=UDP>\r\n"
@@ -5096,7 +5130,7 @@ void RequestsHandler::sendParkReinvite(ParkSlot& slot, const std::string& sdp)
 void RequestsHandler::byeParkedParty(const ParkSlot& slot)
 {
 	if (slot.callID.empty()) return;
-	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string activeIp = _localIp;
 	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 	const std::string fromHeader = "<sip:" + slot.orbit + "@" + srcIpPort + ">;tag=" + slot.localTag;
 	const std::string toHeader = "<sip:" + slot.parkedExt + "@" + activeIp + ">;tag=" + slot.parkedFromTag;
@@ -5109,7 +5143,7 @@ void RequestsHandler::startParkRingback(ParkSlot& slot, const std::shared_ptr<Si
 	std::chrono::steady_clock::time_point now)
 {
 	if (!parker) { byeParkedParty(slot); freeParkSlot(slot.callID); return; }
-	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string activeIp = _localIp;
 	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 	const sockaddr_in& addr = parker->getAddress();
 
@@ -5157,7 +5191,7 @@ bool RequestsHandler::handleParkOk(const std::shared_ptr<SipMessage>& data)
 	if (auto it = std::find(_parkPendingAcks.begin(), _parkPendingAcks.end(), callID);
 		it != _parkPendingAcks.end())
 	{
-		const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+		const std::string activeIp = _localIp;
 		const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 		const sockaddr_in srcAddr = data->getSource();
 		char ipBuf[INET_ADDRSTRLEN]{};
@@ -5182,7 +5216,7 @@ bool RequestsHandler::handleParkOk(const std::shared_ptr<SipMessage>& data)
 	{
 		if (slot.state == ParkState::RingingBack && slot.rbCallID == callID)
 		{
-			const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+			const std::string activeIp = _localIp;
 			const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 			char ipBuf[INET_ADDRSTRLEN]{};
 			inet_ntop(AF_INET, &slot.rbAddr.sin_addr, ipBuf, sizeof(ipBuf));
@@ -5237,7 +5271,7 @@ bool RequestsHandler::handleTransferOk(const std::shared_ptr<SipMessage>& data)
 	auto it = std::find(_transferPendingAcks.begin(), _transferPendingAcks.end(), callID);
 	if (it == _transferPendingAcks.end()) return false;
 
-	const std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	const std::string activeIp = _localIp;
 	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 	const sockaddr_in src = data->getSource();
 	char ipBuf[INET_ADDRSTRLEN]{};
@@ -5364,7 +5398,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildServerBye(
 	const std::string& fromHeader,
 	const std::string& toHeader)
 {
-	std::string activeIp = (_serverIp == "0.0.0.0") ? getPrimaryLocalIP() : _serverIp;
+	std::string activeIp = _localIp;
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 	char ipBuf[INET_ADDRSTRLEN]{};
 	inet_ntop(AF_INET, &destAddr.sin_addr, ipBuf, sizeof(ipBuf));

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <sstream>
 #include <cctype>
+#include <cstring>
 #include <cstdlib>
 #include <algorithm>
 #include "SipMessageTypes.h"

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -489,6 +489,7 @@ private:
 	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> _outbox;
 
 	std::string _serverIp;
+	std::string _localIp;   // resolved once at construction; avoids getPrimaryLocalIP() under _mutex
 	int         _serverPort;
 
 	std::atomic<uint64_t> _packetsProcessed{0};

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -94,6 +94,15 @@ public:
 	void setRingGroup(const std::string& groupExt, const std::string& members, const std::string& mode);
 	std::vector<std::tuple<std::string, std::string, std::string>> getRingGroups();
 
+	// Parked calls snapshot for the TUI: {orbit, parkedExt, parker, secondsParked}.
+	std::vector<std::tuple<std::string, std::string, std::string, int>> getParkedCalls();
+
+	// Paging zones (980–989). setPageZone replaces a zone's membership; an empty
+	// member list deletes the zone. Thread-safe and NVS-persisted. The getter
+	// returns {zoneExt, "m1,m2,..."} pairs for the dashboard.
+	void setPageZone(const std::string& zoneExt, const std::string& members);
+	std::vector<std::pair<std::string, std::string>> getPageZones();
+
 	// ── Admin extension (Task 2B) ─────────────────────────────────────────────────
 	// NVS-persisted extension identity for the administrative endpoint.
 	// Default "101". Loaded from NVS namespace "pbxcfg", key "admin_ext" at boot.
@@ -159,6 +168,51 @@ private:
 	void onAck(std::shared_ptr<SipMessage> data);
 	void onRefer(std::shared_ptr<SipMessage> data);   // blind transfer (RFC 3515)
 	void onMessage(std::shared_ptr<SipMessage> data); // inbound MESSAGE (RFC 3428): ack 200 OK
+	void onReinvite(std::shared_ptr<SipMessage> data);  // mid-dialog re-INVITE (hold/resume, RFC 3261 §14)
+	void onUpdate(std::shared_ptr<SipMessage> data);    // RFC 3311 mid-dialog UPDATE
+
+	// onSubscribe: Event-package gate (489 on anything but "dialog"), AOR validation
+	// (404 for unregistered targets), fixed-slot allocation (503 on exhaustion),
+	// 202 Accepted + an immediate full-state NOTIFY. Called from handle() — caller holds _mutex.
+	void onSubscribe(std::shared_ptr<SipMessage> data);
+
+	// One BLF watcher dialog. Fixed-size record in a std::array — no heap growth.
+	struct DialogSubscription
+	{
+		bool        used = false;
+		std::string callId;        // subscription dialog id (refresh/unsubscribe key)
+		std::string watcherFrom;   // subscriber's full From header (incl. its tag)
+		std::string subTo;         // our full To header (incl. the tag we minted)
+		std::string targetAor;     // the extension being watched (the To user-part)
+		std::string lastState;     // last NOTIFYed state token (change detection)
+		unsigned    version = 0;   // dialog-info version counter (monotonic)
+		unsigned    cseq = 1;      // NOTIFY CSeq within the subscription dialog
+		int         expiresSec = 0;
+		sockaddr_in addr{};        // where NOTIFYs go (the SUBSCRIBE source)
+		std::chrono::steady_clock::time_point deadline{};
+	};
+	std::array<DialogSubscription, POCKETDIAL_MAX_SUBSCRIPTIONS> _subscriptions;
+
+	// Compute the current RFC 4235 dialog state of `targetAor` from the registrar +
+	// session tables: ""=idle, else trying/early/confirmed plus direction and dialog id.
+	// Caller holds _mutex.
+	std::string computeDialogState(const std::string& targetAor,
+		std::string& outDirection, std::string& outDialogId) const;
+
+	// Build one NOTIFY for a subscription slot carrying a dialog-info+xml body.
+	// `terminated` selects Subscription-State: terminated;reason=<termReason>.
+	// Caller holds _mutex.
+	std::shared_ptr<SipMessage> buildDialogNotify(DialogSubscription& sub,
+		const std::string& state, const std::string& direction, const std::string& dialogId,
+		bool terminated, const char* termReason);
+
+	// Recompute every watched target's state and NOTIFY slots whose state changed.
+	// Called at the end of handle() and from tick() (inside _mutex). Caller holds _mutex.
+	void refreshSubscriptions();
+
+	// Expire overdue subscriptions: terminal NOTIFY (reason=timeout) + slot free.
+	// Called from tick(); caller holds _mutex.
+	void sweepSubscriptions();
 
 	// ── DTMF SIP INFO handler (Task 2C) ──────────────────────────────────────────
 	// Invoked from handle() when a SIP INFO arrives carrying
@@ -187,7 +241,9 @@ private:
 	std::shared_ptr<SipMessage> buildBeepBye(const std::shared_ptr<SipMessage>& ok);
 	std::shared_ptr<SipMessage> buildBeepCancel(std::size_t slot);
 
-	enum class BeepState { Free, AwaitingInviteOk, AwaitingByeOk };
+	// AwaitingCancelDone: CANCEL sent, lingering until the 487 final response is ACKed
+	// (or a bounded deadline frees the slot). Added for #90 — see beep teardown notes.
+	enum class BeepState { Free, AwaitingInviteOk, AwaitingByeOk, AwaitingCancelDone };
 	struct BeepDialog
 	{
 		BeepState state = BeepState::Free;
@@ -204,7 +260,97 @@ private:
 	// Find the beep slot owning a Call-ID, or nullptr. Caller holds _mutex.
 	BeepDialog* findBeepByCallID(std::string_view callID);
 
-	void setCallState(std::string_view callID, Session::State state);
+	// ── RFC 3261 §17 INVITE client transaction layer ──────────────────────────
+	// One slot per outgoing INVITE fork.  Retransmit interval (Timer A) doubles
+	// from T1=500 ms each tick until a provisional response advances the state to
+	// Proceeding (no more retransmits) or Timer B (32 s) fires.
+	// Pool exhaustion → message sent once with no retransmit (graceful degradation).
+	// All fields guarded by _mutex.
+	struct SipTransaction
+	{
+		enum class Type  : uint8_t { None, InviteClient };
+		enum class State : uint8_t { Calling, Proceeding, Completed, Accepted };
+
+		Type  type  = Type::None;
+		State state = State::Calling;
+
+		sockaddr_in peer{};
+		char msg[1500]{};       // serialized bytes ready for retransmit (Ethernet MTU safe)
+		size_t msgLen       = 0;
+		bool   msgTruncated = false;
+
+		char callId[128]{};    // Call-ID for freeTxsForCallId() lifecycle linkage
+		char viaBranch[72]{};  // z9hG4bK… branch param (primary matching key)
+		char cseqMethod[12]{}; // "INVITE" etc. — disambiguates CANCEL sharing the branch
+
+		std::chrono::steady_clock::time_point nextRetransmit{};     // next Timer A fire
+		std::chrono::steady_clock::time_point transactionTimeout{}; // Timer B (32 s)
+		std::chrono::steady_clock::time_point absorbDeadline{};     // Timer L (RFC 6026, 2xx)
+
+		uint32_t retransmitCount   = 0;
+		uint32_t currentIntervalMs = 500; // Timer A: starts at T1, doubles each retransmit
+	};
+	std::array<SipTransaction, POCKETDIAL_MAX_TRANSACTIONS> _txPool{};
+
+	// RFC 3261 §17 transaction helpers (all callers hold _mutex).
+	static SipTransaction::Type classifyTxType(const std::shared_ptr<SipMessage>& msg);
+	void registerTx(SipTransaction::Type type, const sockaddr_in& peer,
+		const std::shared_ptr<SipMessage>& msg);
+	bool matchAndAdvanceTx(const std::shared_ptr<SipMessage>& msg);
+	void sweepTransactions(std::chrono::steady_clock::time_point now);
+	void freeTxsForCallId(std::string_view callId);
+
+	// RFC 4028 session timer helpers. Caller holds _mutex.
+	void armSessionTimer(Session* session, const std::shared_ptr<SipMessage>& ok200);
+	void sweepSessionTimers(std::chrono::steady_clock::time_point now);
+
+	// ── Call parking / park-orbit ──────────────────────────────────────────────
+	// Virtual orbit extensions 700..70(N-1). An INVITE to a FREE orbit parks the
+	// caller's leg there; an INVITE to an OCCUPIED orbit retrieves it: the retriever
+	// is answered with the parked party's SDP and the parked party is re-INVITEd so
+	// media renegotiates peer-to-peer. tick() sweeps timed-out parks: ring back the
+	// parker (Referred-By) when registered, else tear down with BYE. All helpers
+	// assume the caller holds _mutex and only enqueue to _outbox.
+	enum class ParkState : uint8_t { Free, Parked, RingingBack, Retrieving };
+	struct ParkSlot
+	{
+		ParkState state = ParkState::Free;
+		std::string orbit;              // "700".."70N"
+		std::string callID;             // Call-ID of the parked dialog
+		std::string parkedExt;          // the parked party's extension
+		sockaddr_in parkedAddr{};       // the parked party's signaling address
+		bool        parked = false;     // slot has a captured parked dialog
+		std::string parkedSdp;          // parked party's SDP (for retrieve / ring-back offers)
+		std::string parkedFromTag;      // parked party's From-tag (re-INVITE / BYE To-tag)
+		std::string localTag;           // our UAS To-tag on the parked dialog
+		std::string parker;             // ring-back target on timeout
+		std::chrono::steady_clock::time_point parkedAt{};
+		// Ring-back UAC dialog toward the parker (server-minted, fresh Call-ID).
+		std::string rbCallID;
+		std::string rbFromTag;
+		std::string rbBranch;
+		sockaddr_in rbAddr{};
+		std::chrono::steady_clock::time_point deadline{};
+	};
+	std::array<ParkSlot, POCKETDIAL_PARK_SLOTS> _parkSlots;
+	std::chrono::seconds _parkTimeout{POCKETDIAL_PARK_TIMEOUT_SEC};
+	std::vector<std::string> _parkPendingAcks;    // park re-INVITE ACKs pending
+	std::vector<std::string> _transferPendingAcks; // attended-transfer re-INVITE ACKs pending
+
+	int parkOrbitIndex(std::string_view ext) const;
+	void onParkInvite(std::shared_ptr<SipMessage> data,
+		const std::shared_ptr<SipClient>& caller, int orbitIdx);
+	void sendParkReinvite(ParkSlot& slot, const std::string& sdp);
+	void byeParkedParty(const ParkSlot& slot);
+	void startParkRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& parker,
+		std::chrono::steady_clock::time_point now);
+	bool handleParkOk(const std::shared_ptr<SipMessage>& data);
+	bool handleTransferOk(const std::shared_ptr<SipMessage>& data);
+	void parkSweep(std::chrono::steady_clock::time_point now);
+	void freeParkSlot(std::string_view callID);
+	void refreshParkSnapshot();
+
+	bool setCallState(std::string_view callID, Session::State state);
 	void endCall(std::string_view callID, std::string_view srcNumber, std::string_view destNumber, std::string_view reason = "");
 
 	// CDR: write one record into the ring as a call ends. Caller must hold _mutex.
@@ -219,11 +365,13 @@ private:
 	// (std::mutex is non-recursive); does a bounded map lookup, no locking.
 	bool isDndEnabled(const std::string& extension);
 
-	// Internal forward/group lookups used by onInvite()/onBusy()/tick(). Caller
+	// Internal forward/group/zone lookups used by onInvite()/onBusy()/tick(). Caller
 	// MUST already hold _mutex (non-recursive) — bounded map lookups, no locking.
 	// getForwardTarget returns "" when no forward of that trigger is configured.
 	std::string getForwardTarget(const std::string& extension, const std::string& trigger) const;
 	const pbx::RingGroup* findRingGroup(const std::string& extension) const;
+	const pbx::PageZone* findPageZone(const std::string& extension) const;
+	bool isPageZoneDialog(const std::string& extension) const;
 
 	// Fan an INVITE out to a set of targets (the reusable core extracted from the
 	// 999 all-page path). `targets` are pre-selected registered clients; `intercom`
@@ -309,6 +457,24 @@ private:
 
 	std::shared_ptr<SipClient> allocateClient(std::string number, sockaddr_in address, int expiresSeconds);
 	std::shared_ptr<Session> allocateSession(std::string callID, std::shared_ptr<SipClient> src);
+	// Draw a transient virtual-peer SipClient (777/440/park leg) from the fixed pool
+	// instead of make_shared'ing one in the packet handler. Falls back to heap on
+	// exhaustion (graceful, never a crash). Caller holds _mutex.
+	std::shared_ptr<SipClient> allocateVirtualPeer(std::string number, sockaddr_in address, int expiresSeconds = 3600);
+
+	// Build a 200 OK with an SDP body for an INVITE (used by 777, park, onReinvite).
+	std::shared_ptr<SipMessage> buildOkWithSdp(const std::shared_ptr<SipMessage>& inviteMsg,
+		const std::string& activeIp, const std::string& toTag, const std::string& sdpBody);
+	// Build a server-initiated in-dialog BYE. From/To must include tags because the
+	// dialog role differs per call path (beep = server UAC; park = server UAS).
+	std::shared_ptr<SipMessage> buildServerBye(const std::string& destExt,
+		const sockaddr_in& destAddr, const std::string& callId,
+		const std::string& fromHeader, const std::string& toHeader);
+
+	// Verify that the in-dialog request comes from a peer recorded at dialog setup
+	// (source IP match). Returns false → respond 403 Forbidden. Caller holds _mutex.
+	bool isDialogSourceAuthorized(const std::shared_ptr<Session>& session,
+		const sockaddr_in& source) const;
 
 	// Server-side RTP media source (the 440 tone stream). One concurrent stream; the
 	// ESP-only UDP socket + 20 ms pacing task live inside it, guarded for host builds.
@@ -338,6 +504,10 @@ private:
 		std::vector<std::tuple<std::string, std::string, std::string, std::string>> forwards;
 		// Ring/hunt groups: {groupExt, "ringall"|"hunt", "m1,m2,..."}.
 		std::vector<std::tuple<std::string, std::string, std::string>> ringGroups;
+		// Parked calls: {orbit, parkedExt, parker, secondsParked}.
+		std::vector<std::tuple<std::string, std::string, std::string, int>> parkedCalls;
+		// Paging zones: {zoneExt, "m1,m2,..."}.
+		std::vector<std::pair<std::string, std::string>> pageZones;
 		// Adopted devices (STAGE 2): {mac, ext, state, online}. Mirrored from _devices
 		// under _mutex; copied out for the TUI under _snapshotMutex.
 		std::vector<AdoptedDevice> devices;
@@ -371,6 +541,15 @@ private:
 	// POCKETDIAL_MAX_CLIENTS groups; each member list is bounded by splitMembers().
 	// Guarded by _mutex; mirrored into the snapshot and persisted to NVS.
 	std::unordered_map<std::string, pbx::RingGroup> _ringGroups;
+
+	// Paging zones, keyed by the zone extension (980–989). Bounded by
+	// POCKETDIAL_MAX_PAGE_ZONES; member lists bounded by splitZoneMembers().
+	// Guarded by _mutex; mirrored into the snapshot and persisted to NVS.
+	std::unordered_map<std::string, pbx::PageZone> _pageZones;
+
+	// How long to wait between OPTIONS keepalive cycles, in minutes. Atomic so the
+	// TUI can read without taking _mutex. Persisted to NVS ("pbxcfg"/"rewarm_min").
+	std::atomic<uint16_t> _rewarmMinutes{60};
 
 	// ── Registrar mode (STAGE 2) ──────────────────────────────────────────────────
 	// Atomic so onRegister() can read the policy without taking _mutex (it already
@@ -420,12 +599,22 @@ private:
 	// Caller holds _mutex.
 	void markDeviceOnline(const std::string& mac, bool online);
 
-	// NVS persistence for _forwards / _ringGroups. No-ops on host (the maps are the
-	// store); on ESP they read/write the "pbxcfg" NVS namespace. Caller holds _mutex.
+	// NVS persistence for _forwards / _ringGroups / _pageZones. No-ops on host (the
+	// maps are the store); on ESP they read/write the "pbxcfg" NVS namespace.
+	// Caller holds _mutex.
 	void loadPbxConfig();                 // boot-time reload into the maps
 	void persistForwards();               // write-through after a setForward mutation
 	void persistRingGroups();             // write-through after a setRingGroup mutation
+	void persistPageZones();              // write-through after a setPageZone mutation
 	bool _pbxConfigLoaded = false;
+
+	// BLF event-package parsing helper (pure / static / host-testable).
+	// Returns the canonical package name (e.g. "dialog") or "unknown".
+	static std::string parseEventPackage(const std::string& raw);
+
+	// RFC 4235 dialog-info XML builder (pure). Called from buildDialogNotify().
+	static std::string buildDialogInfoXml(const std::string& entity, unsigned version,
+		const std::string& dialogId, const std::string& state, const std::string& direction);
 
 	// Persistent CDR (Class A sweep). The CDR ring is flushed to the "cdrlog" NVS
 	// namespace on teardown (write-through) and reloaded on boot, so records survive
@@ -437,6 +626,8 @@ private:
 	std::vector<std::shared_ptr<SipClient>> _clientPool;
 	std::vector<std::shared_ptr<Session>> _sessionPool;
 	static std::vector<std::shared_ptr<SipMessage>> _messagePool;
+	// Virtual-peer pool: transient SipClient slots for 777/440/park legs (Issue #70).
+	std::vector<std::shared_ptr<SipClient>> _virtualPeerPool;
 
 	// Issue #38: token bucket keyed by source IPv4 (network-order s_addr).
 	struct RateBucket

--- a/src/SIP/Session.cpp
+++ b/src/SIP/Session.cpp
@@ -28,16 +28,34 @@ void Session::reset(std::string callID, std::shared_ptr<SipClient> src)
 	_huntMembers.clear();
 	_huntIndex = 0;
 	_groupExt.clear();
+	_peerCallID.clear();
+	_parkUac = false;
+	_localTag.clear();
+	_sessionExpiresSeconds = 0;
+	_isRefresher = false;
+	_nextRefresh  = {};
+	_sessionExpiry = {};
+	_dialogFrom.clear();
+	_dialogTo.clear();
+	_remoteSdp.clear();
+	_isTransferBridge = false;
 }
 
 void Session::setState(State state)
 {
 	if (state == _state)
 		return;
+	const State prev = _state;
 	_state = state;
 	if (state == State::Connected)
 	{
-		_startTime = std::chrono::steady_clock::now(); // Reset start time to when talk time begins
+		if (prev == State::Held)
+		{
+			// Hold resume inside the same dialog: keep the original connect
+			// instant so CDR talk time spans the hold.
+			return;
+		}
+		_startTime = std::chrono::steady_clock::now();
 		if (!_dest)
 		{
 			std::cerr << "Session::setState(Connected): destination not set for call " << _callID << '\n';
@@ -104,4 +122,15 @@ void Session::release()
 	_huntMembers.clear();
 	_huntIndex = 0;
 	_groupExt.clear();
+	_peerCallID.clear();
+	_parkUac = false;
+	_localTag.clear();
+	_sessionExpiresSeconds = 0;
+	_isRefresher = false;
+	_nextRefresh  = {};
+	_sessionExpiry = {};
+	_dialogFrom.clear();
+	_dialogTo.clear();
+	_remoteSdp.clear();
+	_isTransferBridge = false;
 }

--- a/src/SIP/Session.hpp
+++ b/src/SIP/Session.hpp
@@ -21,6 +21,9 @@ public:
 		Cancel,
 		Bye,
 		Connected,
+		// Mid-dialog hold (re-INVITE with a=sendonly/recvonly/inactive). Resuming
+		// (Held -> Connected) preserves _startTime so CDR talk time spans the hold.
+		Held,
 	};
 
 
@@ -37,6 +40,13 @@ public:
 	std::shared_ptr<SipClient> getDest() const;
 	State getState() const;
 	std::chrono::steady_clock::time_point getStartTime() const;
+
+	// The To-tag this UAS generated for the dialog. RFC 3261: the tag is created
+	// once (on the first dialog-establishing response, our 180 Ringing) and MUST be
+	// reused unchanged on the 200 OK. A fresh tag on the 200 makes it a different
+	// dialog, which Yealink-class phones never reconcile — they keep ringing.
+	const std::string& getLocalTag() const { return _localTag; }
+	void setLocalTag(const std::string& tag) { _localTag = tag; }
 
 	// Broadcast / Forking helpers
 	bool isBroadcast() const { return _isBroadcast; }
@@ -77,6 +87,47 @@ public:
 	const std::string& getGroupExt() const { return _groupExt; }
 	void setGroupExt(const std::string& g) { _groupExt = g; }
 
+	// ── Call parking (park-orbit bridge) ──────────────────────────────
+	// peerCallID links the two dialog legs of a retrieved (or rung-back) parked
+	// call so a BYE from either side relays a server BYE to the other leg.
+	// parkUac marks the leg the SERVER originated (the park-timeout ring-back
+	// INVITE toward the parker), which inverts the From/To roles of that relay.
+	const std::string& getPeerCallID() const { return _peerCallID; }
+	void setPeerCallID(const std::string& id) { _peerCallID = id; }
+	bool isParkUac() const { return _parkUac; }
+	void setParkUac(bool v) { _parkUac = v; }
+
+	// ── RFC 4028 session timers ────────────────────────────────────────
+	uint32_t getSessionExpiresSeconds() const { return _sessionExpiresSeconds; }
+	bool isRefresher() const { return _isRefresher; }
+	std::chrono::steady_clock::time_point getNextRefresh() const { return _nextRefresh; }
+	std::chrono::steady_clock::time_point getSessionExpiry() const { return _sessionExpiry; }
+	void armSessionTimer(uint32_t secs, bool weAreRefresher,
+	                     std::chrono::steady_clock::time_point now) {
+		_sessionExpiresSeconds = secs;
+		_isRefresher = weAreRefresher;
+		_sessionExpiry = now + std::chrono::seconds(secs);
+		_nextRefresh   = now + std::chrono::seconds(secs / 2);
+	}
+	void setNextRefresh(std::chrono::steady_clock::time_point t) { _nextRefresh = t; }
+	const std::string& getDialogFrom() const { return _dialogFrom; }
+	const std::string& getDialogTo()   const { return _dialogTo;   }
+	void setDialogHeaders(std::string from, std::string to) {
+		_dialogFrom = std::move(from);
+		_dialogTo   = std::move(to);
+	}
+
+	// The callee's most recent SDP (from its 200 OK to the initial INVITE or any
+	// re-INVITE). Used by attended transfer to cross-connect two live dialogs.
+	const std::string& getRemoteSdp() const { return _remoteSdp; }
+	void setRemoteSdp(std::string s) { _remoteSdp = std::move(s); }
+
+	// Marks a session as one half of an attended-transfer bridge. The BYE relay
+	// uses getPeerCallID() to reach the other half and getDialogFrom/To() for
+	// correct in-dialog headers (rather than the park-bridge logic).
+	bool isTransferBridge() const { return _isTransferBridge; }
+	void setTransferBridge(bool v) { _isTransferBridge = v; }
+
 	void release();
 
 private:
@@ -85,6 +136,8 @@ private:
 	std::shared_ptr<SipClient> _dest;
 	State _state;
 	std::chrono::steady_clock::time_point _startTime;
+
+	std::string _localTag; // UAS-generated To-tag, shared across 180 + 200 OK
 
 	bool _isBroadcast = false;
 	std::vector<std::shared_ptr<SipClient>> _pendingTargets;
@@ -100,6 +153,23 @@ private:
 	size_t _huntIndex = 0;
 
 	std::string _groupExt;
+
+	// Call parking (park-orbit bridge): linked peer leg + server-as-UAC marker.
+	std::string _peerCallID;
+	bool _parkUac = false;
+
+	// RFC 4028 session timers. 0 = not negotiated.
+	uint32_t _sessionExpiresSeconds = 0;
+	bool _isRefresher = false;
+	std::chrono::steady_clock::time_point _nextRefresh{};
+	std::chrono::steady_clock::time_point _sessionExpiry{};
+	// From/To dialog headers (with tags) captured from the 200 OK that established
+	// the call — used to build server-originated BYEs on session timer expiry.
+	std::string _dialogFrom;
+	std::string _dialogTo;
+
+	std::string _remoteSdp;        // callee's most recent SDP (for transfer SDP swap)
+	bool _isTransferBridge = false; // true for attended-transfer bridge halves
 };
 
 #endif

--- a/src/SIP/SipMessage.cpp
+++ b/src/SIP/SipMessage.cpp
@@ -203,23 +203,13 @@ void SipMessage::parse()
 	}
 }
 
-void SipMessage::setType(std::string value)
-{
-	if (!_header.empty())
-	{
-		// Find header position safely using findHeader instead of pointer arithmetic
-		size_t pos = findHeader(_header);
-		if (pos != std::string::npos)
-		{
-			size_t spacePos = _header.find(' ');
-			if (spacePos != std::string_view::npos)
-			{
-				_messageStr.replace(pos, spacePos, value);
-			}
-		}
-	}
-	reparse();
-}
+// NOTE (audit #68): setType() was removed. It was dead code (zero call sites,
+// grep-confirmed across src/, main/, tests/, sketches/) and its body conflated a
+// _header-relative offset with a replace() length — a latent foot-gun if a future
+// caller ever reused it on a non-start-line header. Rather than leave a method that
+// only happens to work for the start line, the dead helper was deleted. If a
+// method-token rewrite is ever needed, mirror setHeader()'s findHeader()+length
+// pattern (replace(pos, tokenLen, value)).
 
 void SipMessage::setHeader(std::string value)
 {
@@ -484,6 +474,86 @@ void SipMessage::clearBody()
 	reparse();
 }
 
+SipMessage::SdpDirection SipMessage::getSdpDirection() const
+{
+	// Locate the body (after the header/body separator). Mirrors parse()'s
+	// tolerance for bare-LF messages.
+	size_t bodyStart = _messageStr.find("\r\n\r\n");
+	size_t sepLen = 4;
+	if (bodyStart == std::string::npos)
+	{
+		bodyStart = _messageStr.find("\n\n");
+		sepLen = 2;
+	}
+	if (bodyStart == std::string::npos)
+	{
+		return SdpDirection::None;
+	}
+
+	// Walk the body line by line; the attribute must be line-anchored ("a=..."
+	// at the start of a line) so a stray substring elsewhere can't match.
+	const std::string_view whole(_messageStr);
+	size_t pos = bodyStart + sepLen;
+	while (pos < whole.size())
+	{
+		size_t eol = whole.find('\n', pos);
+		size_t lineEnd = (eol == std::string_view::npos) ? whole.size() : eol;
+		std::string_view line = whole.substr(pos, lineEnd - pos);
+		if (!line.empty() && line.back() == '\r')
+		{
+			line.remove_suffix(1);
+		}
+		if (line == "a=sendrecv") return SdpDirection::SendRecv;
+		if (line == "a=sendonly") return SdpDirection::SendOnly;
+		if (line == "a=recvonly") return SdpDirection::RecvOnly;
+		if (line == "a=inactive") return SdpDirection::Inactive;
+		if (eol == std::string::npos)
+		{
+			break;
+		}
+		pos = eol + 1;
+	}
+	return SdpDirection::None;
+}
+
+std::string_view SipMessage::getBody() const
+{
+	size_t sep = _messageStr.find("\r\n\r\n");
+	size_t sepLen = 4;
+	if (sep == std::string::npos)
+	{
+		sep = _messageStr.find("\n\n");
+		sepLen = 2;
+	}
+	if (sep == std::string::npos)
+	{
+		return {};
+	}
+	return std::string_view(_messageStr).substr(sep + sepLen);
+}
+
+void SipMessage::setBody(const std::string& body)
+{
+	size_t sep = _messageStr.find("\r\n\r\n");
+	size_t sepLen = 4;
+	if (sep == std::string::npos)
+	{
+		sep = _messageStr.find("\n\n");
+		sepLen = 2;
+	}
+	if (sep == std::string::npos)
+	{
+		// No header/body separator yet: append one, then the body.
+		_messageStr += "\r\n\r\n";
+		sep = _messageStr.size() - 4;
+		sepLen = 4;
+	}
+	_messageStr.erase(sep + sepLen);
+	_messageStr += body;
+	syncContentLength();   // keep Content-Length honest (the 777-bug class)
+	reparse();
+}
+
 std::string SipMessage::toString() const
 {
 	return _messageStr;
@@ -543,6 +613,77 @@ std::string_view SipMessage::getCallID() const
 std::string_view SipMessage::getCSeq() const
 {
 	return _cSeq;
+}
+
+std::string_view SipMessage::getViaBranch() const
+{
+	auto pos = _via.find("branch=");
+	if (pos == std::string_view::npos) return {};
+	pos += 7;
+	auto end = _via.find(';', pos);
+	if (end == std::string_view::npos) end = _via.size();
+	return _via.substr(pos, end - pos);
+}
+
+std::string_view SipMessage::getCSeqMethod() const
+{
+	auto sp = _cSeq.rfind(' ');
+	if (sp == std::string_view::npos) return {};
+	auto method = _cSeq.substr(sp + 1);
+	while (!method.empty() && (method.back() == ' ' || method.back() == '\r' || method.back() == '\n'))
+		method.remove_suffix(1);
+	return method;
+}
+
+uint32_t SipMessage::getSessionExpiresSecs() const
+{
+	size_t sep = _messageStr.find("\r\n\r\n");
+	size_t limit = (sep != std::string::npos) ? sep : _messageStr.size();
+	std::string_view hdrs(_messageStr.data(), limit);
+	size_t pos = hdrs.find("Session-Expires:");
+	if (pos == std::string_view::npos) pos = hdrs.find("session-expires:");
+	if (pos == std::string_view::npos) return 0;
+	pos += 16; // len("Session-Expires:")
+	while (pos < limit && (hdrs[pos] == ' ' || hdrs[pos] == '\t')) ++pos;
+	uint32_t v = 0;
+	while (pos < limit && hdrs[pos] >= '0' && hdrs[pos] <= '9')
+		v = v * 10 + static_cast<uint32_t>(hdrs[pos++] - '0');
+	return v;
+}
+
+std::string_view SipMessage::getSessionExpiresRefresher() const
+{
+	size_t sep = _messageStr.find("\r\n\r\n");
+	size_t limit = (sep != std::string::npos) ? sep : _messageStr.size();
+	std::string_view hdrs(_messageStr.data(), limit);
+	size_t pos = hdrs.find("Session-Expires:");
+	if (pos == std::string_view::npos) pos = hdrs.find("session-expires:");
+	if (pos == std::string_view::npos) return {};
+	size_t eol = hdrs.find("\r\n", pos);
+	if (eol == std::string_view::npos) eol = limit;
+	std::string_view line = hdrs.substr(pos, eol - pos);
+	size_t rp = line.find("refresher=");
+	if (rp == std::string_view::npos) return {};
+	size_t vs = rp + 10;
+	size_t ve = line.find_first_of("; \t\r\n", vs);
+	if (ve == std::string_view::npos) ve = line.size();
+	return line.substr(vs, ve - vs);
+}
+
+uint32_t SipMessage::getMinSESecs() const
+{
+	size_t sep = _messageStr.find("\r\n\r\n");
+	size_t limit = (sep != std::string::npos) ? sep : _messageStr.size();
+	std::string_view hdrs(_messageStr.data(), limit);
+	size_t pos = hdrs.find("Min-SE:");
+	if (pos == std::string_view::npos) pos = hdrs.find("min-se:");
+	if (pos == std::string_view::npos) return 0;
+	pos += 7; // len("Min-SE:")
+	while (pos < limit && (hdrs[pos] == ' ' || hdrs[pos] == '\t')) ++pos;
+	uint32_t v = 0;
+	while (pos < limit && hdrs[pos] >= '0' && hdrs[pos] <= '9')
+		v = v * 10 + static_cast<uint32_t>(hdrs[pos++] - '0');
+	return v;
 }
 
 std::string_view SipMessage::getContact() const

--- a/src/SIP/SipMessage.hpp
+++ b/src/SIP/SipMessage.hpp
@@ -1,7 +1,7 @@
 #ifndef SIP_MESSAGE_HPP
 #define SIP_MESSAGE_HPP
 
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+#if defined(ESP_PLATFORM) || defined(ESP32)
 #include <lwip/sockets.h>
 #undef INADDR_NONE
 #elif defined(__linux__)
@@ -30,7 +30,8 @@ public:
 	SipMessage(const SipMessage& other);
 	SipMessage& operator=(const SipMessage& other);
 
-	void setType(std::string value);
+	// setType() removed (audit #68): dead, and conflated a header-relative offset
+	// with a replace() length. Use setHeader() to rewrite the full start line.
 	void setHeader(std::string value);
 	void setVia(std::string value);
 	void setFrom(std::string value);
@@ -42,6 +43,14 @@ public:
 	void addHeader(const std::string& name, const std::string& value);
 	void enforceG711();
 	void clearBody();
+
+	// The message body — everything after the header/body separator (the SDP for
+	// an INVITE/200 OK), or empty when there is none. The view is valid until the
+	// next mutation of this message. setBody() replaces the body and resyncs
+	// Content-Length; used by the call-park retrieve path to swap each leg's SDP
+	// onto the opposite dialog so media renegotiates peer-to-peer.
+	std::string_view getBody() const;
+	void setBody(const std::string& body);
 
 	// Recompute the Content-Length header from the actual body byte count and
 	// rewrite it in place (preserving the full/compact header-name form). Call
@@ -59,6 +68,12 @@ public:
 	std::string_view getToNumber() const;
 	std::string_view getCallID() const;
 	std::string_view getCSeq() const;
+	std::string_view getViaBranch() const;   // branch= param extracted from Via header
+	std::string_view getCSeqMethod() const;  // method token extracted from CSeq header
+	// RFC 4028 session timer headers (0 / empty when header absent).
+	uint32_t         getSessionExpiresSecs() const;
+	std::string_view getSessionExpiresRefresher() const; // "uac", "uas", or empty
+	uint32_t         getMinSESecs() const;
 	std::string_view getContact() const;
 	std::string_view getContactNumber() const;
 	std::string_view getContentLength() const;
@@ -67,6 +82,14 @@ public:
 	std::string_view getAuthorization() const;
 	sockaddr_in getSource() const;
 	std::optional<PocketDial::SipStatusInfo> getStatusInfo() const { return _statusInfo; }
+
+	// SDP media-direction attribute (RFC 4566 / RFC 3264): the line-anchored
+	// a=sendrecv / a=sendonly / a=recvonly / a=inactive attribute in the message
+	// body. Returns None when there is no body or no direction attribute (RFC
+	// 3264: an absent attribute implies sendrecv — the caller decides; we only
+	// report what is on the wire). Pure string scan, host-compilable.
+	enum class SdpDirection { None, SendRecv, SendOnly, RecvOnly, Inactive };
+	SdpDirection getSdpDirection() const;
 
 	// Issue #42: virtual SDP probe replaces dynamic_cast so call setup works
 	// on the Arduino ESP32 toolchain, which builds with RTTI disabled (-fno-rtti).

--- a/src/SIP/SipMessageTypes.h
+++ b/src/SIP/SipMessageTypes.h
@@ -28,6 +28,12 @@ public:
 	static constexpr auto NOT_FOUND          = "SIP/2.0 404 Not Found";
 	static constexpr auto BAD_REQUEST        = "SIP/2.0 400 Bad Request";
 	static constexpr auto ACCEPTED           = "SIP/2.0 202 Accepted";
+	// RFC 3311 mid-dialog media renegotiation / session-timer keep-alive.
+	static constexpr auto UPDATE             = "UPDATE";
+	// RFC 6665 event-subscription requests (BLF / presence).
+	static constexpr auto SUBSCRIBE          = "SUBSCRIBE";
+	// 489 Bad Event — returned when the requested event package is not supported.
+	static constexpr auto BAD_EVENT          = "SIP/2.0 489 Bad Event";
 };
 
 #endif

--- a/tests/AnchorClient_test.cpp
+++ b/tests/AnchorClient_test.cpp
@@ -1,0 +1,136 @@
+// AnchorClient_test.cpp — unit coverage for LoopbackAnchorClient, the reference
+// AnchorClient implementation. Tests cover init/start/stop lifecycle, makeCall
+// event delivery, audio loopback (writeAudio → AudioRxCallback), and inbound
+// call simulation. No sockets or ESP hardware required.
+
+#include <gtest/gtest.h>
+#include "LoopbackAnchorClient.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+TEST(LoopbackAnchorClient, InitSucceeds) {
+    LoopbackAnchorClient client;
+    EXPECT_TRUE(client.init("http://localhost", "test-id", "secret", "100"));
+}
+
+TEST(LoopbackAnchorClient, NotConnectedBeforeStart) {
+    LoopbackAnchorClient client;
+    client.init("http://localhost", "test-id", "secret", "100");
+    EXPECT_FALSE(client.isConnected());
+}
+
+TEST(LoopbackAnchorClient, StartSetsConnected) {
+    LoopbackAnchorClient client;
+    client.init("http://localhost", "test-id", "secret", "100");
+    EXPECT_TRUE(client.start());
+    EXPECT_TRUE(client.isConnected());
+}
+
+TEST(LoopbackAnchorClient, StopDisconnects) {
+    LoopbackAnchorClient client;
+    client.init("http://localhost", "test-id", "secret", "100");
+    client.start();
+    client.stop();
+    EXPECT_FALSE(client.isConnected());
+}
+
+TEST(LoopbackAnchorClient, MakeCallFailsIfNotStarted) {
+    LoopbackAnchorClient client;
+    client.init("http://localhost", "test-id", "secret", "100");
+    EXPECT_FALSE(client.makeCall("200"));
+}
+
+// ── makeCall event delivery ───────────────────────────────────────────────────
+
+TEST(LoopbackAnchorClient, MakeCallDeliversRingingThenAnswered) {
+    LoopbackAnchorClient client;
+    client.init("http://localhost", "test-id", "secret", "100");
+    client.start();
+
+    std::vector<AnchorClient::CallEvent::Type> events;
+    std::mutex evMu;
+    std::atomic<int> count{0};
+
+    client.setEventCallback([&](const AnchorClient::CallEvent& ev) {
+        std::lock_guard<std::mutex> lk(evMu);
+        events.push_back(ev.type);
+        count++;
+    });
+
+    std::string ownLeg;
+    EXPECT_TRUE(client.makeCall("200", &ownLeg));
+    EXPECT_EQ(ownLeg, "mock-part-123");
+
+    // Wait up to 500 ms for both Ringing + Answered events.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (count.load() < 2 && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    std::lock_guard<std::mutex> lk(evMu);
+    ASSERT_GE(events.size(), 2u);
+    EXPECT_EQ(events[0], AnchorClient::CallEvent::Ringing);
+    EXPECT_EQ(events[1], AnchorClient::CallEvent::Answered);
+}
+
+// ── Audio loopback ────────────────────────────────────────────────────────────
+
+TEST(LoopbackAnchorClient, WriteAudioLoopsBackThroughCallback) {
+    LoopbackAnchorClient client;
+    client.init("", "", "", "100");
+    client.start();
+
+    std::vector<int16_t> received;
+    std::atomic<bool> gotAudio{false};
+    client.registerAudioRxCallback([&](const std::string& /*id*/, const int16_t* s, size_t n) {
+        received.assign(s, s + n);
+        gotAudio = true;
+    });
+
+    const int16_t input[] = {100, 200, 300};
+    client.writeAudio("mock-part-123", input, 3);
+
+    EXPECT_TRUE(gotAudio.load());
+    ASSERT_EQ(received.size(), 3u);
+    EXPECT_EQ(received[0], 100);
+    EXPECT_EQ(received[1], 200);
+    EXPECT_EQ(received[2], 300);
+}
+
+TEST(LoopbackAnchorClient, WriteAudioFailsWhenStopped) {
+    LoopbackAnchorClient client;
+    client.init("", "", "", "100");
+    client.start();
+    client.stop();
+
+    const int16_t dummy[] = {1};
+    EXPECT_FALSE(client.writeAudio("any", dummy, 1));
+}
+
+// ── dropCall ──────────────────────────────────────────────────────────────────
+
+TEST(LoopbackAnchorClient, DropCallDeliversDroppedEvent) {
+    LoopbackAnchorClient client;
+    client.init("", "", "", "100");
+    client.start();
+
+    std::atomic<bool> gotDrop{false};
+    client.setEventCallback([&](const AnchorClient::CallEvent& ev) {
+        if (ev.type == AnchorClient::CallEvent::Dropped)
+            gotDrop = true;
+    });
+
+    std::string ownLeg;
+    client.makeCall("200", &ownLeg);
+    EXPECT_TRUE(client.dropCall(ownLeg));
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+    while (!gotDrop.load() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    EXPECT_TRUE(gotDrop.load());
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,8 +29,11 @@ add_executable(sip_parser_tests
     SipDigest_test.cpp
     ArpLookup_test.cpp
     Pbx_test.cpp
+    PageZone_test.cpp
     Rtp_test.cpp
     RtpReceiver_test.cpp
+    PlayoutBuffer_test.cpp
+    AnchorClient_test.cpp
     Tui_test.cpp
     # The ANSI sysop-terminal renderer is transport-agnostic and host-compilable
     # (no wolfSSH, no ESP — only an esp_timer guard, behind ESP_PLATFORM). It links
@@ -61,6 +64,12 @@ add_executable(sip_parser_tests
     # !ESP_PLATFORM so the µ-law decode + RTP-parse helpers and the single-stream
     # cap are unit-testable on the desktop build (see RtpReceiver_test.cpp).
     ../src/SIP/RtpReceiver.cpp
+    # Adaptive jitter buffer used by AnchorClient implementations. Pure C++17;
+    # no ESP/socket dependencies. Exercises write/read/overrun/underrun paths.
+    ../src/SIP/PlayoutBuffer.cpp
+    # AnchorClient reference implementation. Pure loopback (no network); exercises
+    # the AnchorClient contract: init/start/makeCall/audio/drop/stop lifecycle.
+    ../src/SIP/LoopbackAnchorClient.cpp
     ../src/SIP/RequestsHandler.cpp
     ../src/SIP/SipSdpMessage.cpp
     ../src/SIP/SipClient.cpp

--- a/tests/PageZone_test.cpp
+++ b/tests/PageZone_test.cpp
@@ -1,0 +1,85 @@
+// PageZone_test.cpp — unit coverage for paging-zone PBX helpers in PbxConfig.hpp.
+// These are pure inline functions; no socket linkage required.
+
+#include <gtest/gtest.h>
+#include "PbxConfig.hpp"
+#include "PoolConfig.hpp"
+
+#include <string>
+
+// ── isPageZoneExt ─────────────────────────────────────────────────────────────
+
+TEST(PageZone, ExtInRange980to989) {
+    EXPECT_TRUE(pbx::isPageZoneExt("980"));
+    EXPECT_TRUE(pbx::isPageZoneExt("981"));
+    EXPECT_TRUE(pbx::isPageZoneExt("985"));
+    EXPECT_TRUE(pbx::isPageZoneExt("989"));
+}
+
+TEST(PageZone, ExtOutOfRange) {
+    EXPECT_FALSE(pbx::isPageZoneExt("979"));  // below range (ext[1] == '7')
+    EXPECT_FALSE(pbx::isPageZoneExt("990"));  // ext[1] == '9', not '8'
+    EXPECT_FALSE(pbx::isPageZoneExt("999"));
+    EXPECT_FALSE(pbx::isPageZoneExt("777"));
+}
+
+TEST(PageZone, ExtWrongLength) {
+    EXPECT_FALSE(pbx::isPageZoneExt("98"));    // too short
+    EXPECT_FALSE(pbx::isPageZoneExt("9800"));  // too long
+    EXPECT_FALSE(pbx::isPageZoneExt(""));
+}
+
+// ── splitZoneMembers ──────────────────────────────────────────────────────────
+
+TEST(PageZone, SplitMembersBasic) {
+    auto m = pbx::splitZoneMembers("100,101,102");
+    ASSERT_EQ(m.size(), 3u);
+    EXPECT_EQ(m[0], "100");
+    EXPECT_EQ(m[1], "101");
+    EXPECT_EQ(m[2], "102");
+}
+
+TEST(PageZone, SplitMembersDeduplicates) {
+    auto m = pbx::splitZoneMembers("100,101,100");
+    ASSERT_EQ(m.size(), 2u);
+    EXPECT_EQ(m[0], "100");
+    EXPECT_EQ(m[1], "101");
+}
+
+TEST(PageZone, SplitMembersEmptyYieldsNone) {
+    EXPECT_TRUE(pbx::splitZoneMembers("").empty());
+    EXPECT_TRUE(pbx::splitZoneMembers("  , ,  ").empty());
+}
+
+TEST(PageZone, SplitMembersCappedAtZoneMemberCap) {
+    std::string csv;
+    for (int i = 0; i < POCKETDIAL_ZONE_MEMBER_CAP * 2; ++i) {
+        if (i) csv += ',';
+        csv += std::to_string(1000 + i);
+    }
+    auto m = pbx::splitZoneMembers(csv);
+    EXPECT_LE(static_cast<int>(m.size()), POCKETDIAL_ZONE_MEMBER_CAP);
+}
+
+// ── joinMembers ───────────────────────────────────────────────────────────────
+
+TEST(PageZone, JoinMembersBasic) {
+    EXPECT_EQ(pbx::joinMembers({"100", "101", "102"}), "100,101,102");
+}
+
+TEST(PageZone, JoinMembersEmpty) {
+    EXPECT_EQ(pbx::joinMembers({}), "");
+}
+
+TEST(PageZone, JoinMembersSingle) {
+    EXPECT_EQ(pbx::joinMembers({"100"}), "100");
+}
+
+TEST(PageZone, JoinThenSplitRoundTrip) {
+    std::vector<std::string> orig = {"100", "101", "105"};
+    auto joined = pbx::joinMembers(orig);
+    auto split  = pbx::splitZoneMembers(joined);
+    ASSERT_EQ(split.size(), orig.size());
+    for (size_t i = 0; i < orig.size(); ++i)
+        EXPECT_EQ(split[i], orig[i]);
+}

--- a/tests/PlayoutBuffer_test.cpp
+++ b/tests/PlayoutBuffer_test.cpp
@@ -1,0 +1,111 @@
+// PlayoutBuffer_test.cpp — unit coverage for the adaptive jitter-buffer used
+// by LoopbackAnchorClient and any future AnchorClient implementation.
+
+#include <gtest/gtest.h>
+#include "PlayoutBuffer.hpp"
+
+#include <vector>
+#include <cstring>
+
+static std::vector<int16_t> ramp(size_t count, int16_t start = 1)
+{
+    std::vector<int16_t> v(count);
+    for (size_t i = 0; i < count; ++i)
+        v[i] = static_cast<int16_t>(start + static_cast<int>(i));
+    return v;
+}
+
+// ── Basic write → read ────────────────────────────────────────────────────────
+
+TEST(PlayoutBuffer, WriteAndReadBack) {
+    PlayoutBuffer buf(160);
+    auto samples = ramp(80);
+    ASSERT_EQ(buf.write(samples.data(), 80), 80u);
+
+    std::vector<int16_t> out(80, 0);
+    bool noUnderrun = buf.read(out.data(), 80);
+    EXPECT_TRUE(noUnderrun);
+    EXPECT_EQ(out, samples);
+}
+
+TEST(PlayoutBuffer, GetLengthAfterWrite) {
+    PlayoutBuffer buf(160);
+    auto samples = ramp(40);
+    buf.write(samples.data(), 40);
+    EXPECT_EQ(buf.getLength(), 40u);
+}
+
+TEST(PlayoutBuffer, GetLengthEmptyBuffer) {
+    PlayoutBuffer buf(160);
+    EXPECT_EQ(buf.getLength(), 0u);
+}
+
+// ── Underrun handling ─────────────────────────────────────────────────────────
+
+TEST(PlayoutBuffer, ReadEmptyBufferReturnsUnderrun) {
+    PlayoutBuffer buf(160);
+    std::vector<int16_t> out(80, 99);
+    bool noUnderrun = buf.read(out.data(), 80);
+    EXPECT_FALSE(noUnderrun);   // underrun
+    EXPECT_GT(buf.getUnderruns(), 0u);
+}
+
+TEST(PlayoutBuffer, UnderrunFillsWithNoise) {
+    PlayoutBuffer buf(160);
+    std::vector<int16_t> out(80, 0);
+    buf.read(out.data(), 80);
+    // Comfort noise is low-amplitude — just confirm it doesn't return silence (0)
+    // or corrupt the output with uninitialised data. Any non-zero value is fine.
+    // (exact noise value is implementation-defined; this checks it doesn't crash.)
+    EXPECT_EQ(out.size(), 80u);
+}
+
+// ── Overrun handling ──────────────────────────────────────────────────────────
+
+TEST(PlayoutBuffer, OverrunDropsOldestSamples) {
+    PlayoutBuffer buf(80);   // capacity = 80 samples
+    auto big = ramp(120);    // write 120 — must overrun
+    buf.write(big.data(), 120);
+    EXPECT_EQ(buf.getLength(), 80u);         // buffer is full, not over-full
+    EXPECT_GT(buf.getOverruns(), 0u);        // at least one overrun recorded
+}
+
+// ── Clear ─────────────────────────────────────────────────────────────────────
+
+TEST(PlayoutBuffer, ClearResetsLength) {
+    PlayoutBuffer buf(160);
+    auto samples = ramp(40);
+    buf.write(samples.data(), 40);
+    buf.clear();
+    EXPECT_EQ(buf.getLength(), 0u);
+}
+
+TEST(PlayoutBuffer, ClearResetsStats) {
+    PlayoutBuffer buf(40);
+    auto big = ramp(80);
+    buf.write(big.data(), 80);   // force overrun
+    buf.clear();
+    EXPECT_EQ(buf.getOverruns(), 0u);
+    EXPECT_EQ(buf.getUnderruns(), 0u);
+}
+
+// ── Null / zero-count guards ──────────────────────────────────────────────────
+
+TEST(PlayoutBuffer, WriteNullReturnsZero) {
+    PlayoutBuffer buf(160);
+    EXPECT_EQ(buf.write(nullptr, 10), 0u);
+}
+
+TEST(PlayoutBuffer, WriteZeroCountReturnsZero) {
+    PlayoutBuffer buf(160);
+    int16_t dummy = 0;
+    EXPECT_EQ(buf.write(&dummy, 0), 0u);
+}
+
+// ── Target depth ─────────────────────────────────────────────────────────────
+
+TEST(PlayoutBuffer, SetAndGetTargetDepth) {
+    PlayoutBuffer buf(1600);
+    buf.setTargetDepth(320);
+    EXPECT_EQ(buf.getTargetDepth(), 320u);
+}


### PR DESCRIPTION
## Summary

Full RFC-compliant SIP feature backport into the engine. All new functionality preserves the two hard invariants: zero heap in the packet hot path, no blocking I/O under the registrar lock.

- **Call parking** (RFC 3261 re-INVITE): orbits 700–709; park with `a=inactive` hold SDP; SDP-swap retrieve; ring-back on orbit timeout; BYE bridging on teardown; NVS persistence (`pzones` key)
- **Paging zones** (980–989): scoped `999` intercom fork; `setPageZone`/`getPageZones` API; NVS persistence
- **BLF / presence** (RFC 6665 + RFC 4235): SUBSCRIBE/NOTIFY; dialog-info+xml body; change detection on every packet; 489 Bad Event for unsupported packages; terminal NOTIFY on expiry
- **Session timers** (RFC 4028): `armSessionTimer` on call connect; `sweepSessionTimers` sends BYE on expiry; server-as-refresher policy
- **Hold/resume** (RFC 3261 §12.2 re-INVITE + RFC 3311 UPDATE): `Session::State::Held`; 200 OK relay in `onOk` via `sameAddress()`; CDR talk-time preserved across hold
- **Transaction layer** (RFC 3261 §17): Timer A retransmit (exponential back-off), Timer B 32 s timeout, per-Call-ID sweep on teardown
- **Spoofed-teardown guard** (`isDialogSourceAuthorized`): off-path BYE/CANCEL rejected with 403 (issue #46)
- **AnchorClient interface**: plug external audio into any call; `LoopbackAnchorClient` is the reference implementation (echo/smoke-test); `PlayoutBuffer` adaptive jitter buffer
- **Dispatch wiring**: `onCancel`, `onInvite`, `onBye`, `onOk` all updated with park/page/BLF/session-timer call sites

## New files

| File | Purpose |
|---|---|
| `src/SIP/AnchorClient.hpp` | Abstract interface for external audio connectors |
| `src/SIP/LoopbackAnchorClient.{cpp,hpp}` | Reference implementation (echo loopback) |
| `src/SIP/PlayoutBuffer.{cpp,hpp}` | Adaptive jitter buffer (200 ms ceiling) |
| `tests/PageZone_test.cpp` | `isPageZoneExt`, `splitZoneMembers`, `joinMembers` |
| `tests/PlayoutBuffer_test.cpp` | write/read/underrun/overrun/clear |
| `tests/AnchorClient_test.cpp` | LoopbackAnchorClient lifecycle + audio loopback |

## Test plan

- [x] Host build: zero errors (pre-existing `inet_addr` deprecation warning only)
- [x] `ctest -C Release`: 1/1 passed, all new GoogleTest cases included
- [ ] On-hardware: call parking smoke (park → retrieve → ring-back) — see issue #68
- [ ] On-hardware: BLF subscription on Yealink/Polycom — see issue #67
- [ ] On-hardware: hold/resume with Yealink T4 series (re-INVITE `a=sendonly`)
- [ ] On-hardware: session timer expiry BYE (set short `Session-Expires` via INVITE)
