### PR TITLE
fix(sip): malformed headers on server-minted requests + decomposition follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## Unreleased (sip-decomposition-followups) - 2026-08-03
+
+Review follow-ups on the SIP engine decomposition. Host-verified (142/142
+GoogleTest, up from 131 — the park, register-beep and BLF machines had no host
+coverage at all, which is how the wire defects below survived a green suite).
+
+### Fixed — malformed headers on server-minted requests
+
+`SipMessage::getCallID()` / `getTo()` / `getFrom()` return the **full header
+line**, not the bare value. Four hand-built request paths treated them as bare
+values and re-stamped the header name on top. All predate the decomposition
+(they came in with the `b3cf191` protocol backport) and were carried through it
+untouched:
+
+- **Park retrieve re-INVITE** shipped `Call-ID: Call-ID: x@host`, so the parked
+  phone could not match the request to its dialog and media never renegotiated.
+- **Register beep** matched dialogs by comparing the bare Call-ID it generated
+  against the full header line — a comparison that could never succeed. An
+  answered beep was therefore never ACKed and never BYEd, and five seconds later
+  `sweep()` sent a CANCEL for an INVITE that already had a final response
+  (illegal per RFC 3261 §9.1). Its ACK also emitted `To: To: <...>`.
+- **REFER progress NOTIFY** (RFC 3515 §2.4.5) emitted `From: To: ...`,
+  `To: From: ...` and `Call-ID: Call-ID: ...`.
+
+### Changed — shared plumbing instead of per-machine copies
+
+- `SipWireUtil.hpp` owns `addrToIpPort()` and the `a=inactive` hold offer, which
+  had been pasted into ParkOrbit, RegisterBeeper and BlfSubscriptions (each with
+  its own socket-include block, none with a Windows branch — `inet_ntop` needs
+  `ws2tcpip.h`, so those files could not build on MSVC).
+- `BlfSubscriptions` drops its three private header parsers for the shared
+  `siphdr::stripHeaderName` and a new `SipMessage::getEvent()` accessor. The old
+  event-package scanner re-serialised the whole message and matched any line
+  named `o` — which is also the SDP origin line's name.
+- `ParkOrbit::consumeParkChanged()` mirrors `Registrar::consumeDevicesChanged()`,
+  so the dashboard mirror is polled once per packet instead of being a duty each
+  mutating call site had to remember. Paths that never signalled at all
+  (`sweep()`, `freeForCallId()` via `endCall`) now do.
+- `PbxEnv::sessionsView()` (a reference to `RequestsHandler`'s whole `_sessions`
+  map) is replaced by `forEachSessionInvolving()`, keeping the session table's
+  representation private.
+- `RequestsHandler::drainOutbox()` is the single point messages leave the outbox
+  by, so RFC 3261 §17 retransmit registration is structural rather than a scan
+  duplicated at each flush site.
+- Registrar registry changes are now classified: an online-flag flip patches the
+  snapshot rows in place instead of rebuilding the vector and two strings per
+  device, which is what a post-reboot registration storm would otherwise cost.
+
+### Removed
+
+- `handleTransferOk()` and `_transferPendingAcks` — unreachable since they were
+  introduced; no commit ever added an entry to the list, so the lookup always
+  failed and `onOk()` paid a wasted call on every 200 OK.
+
 ## Unreleased (sip-engine-decomposition) - 2026-08-03
 
 Structural refactor, behavior-neutral by design. Host-verified (131/131 GoogleTest).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased (sip-decomposition-followups) - 2026-08-03
 
-Review follow-ups on the SIP engine decomposition. Host-verified (142/142
+Review follow-ups on the SIP engine decomposition. Host-verified (145/145
 GoogleTest, up from 131 — the park, register-beep and BLF machines had no host
 coverage at all, which is how the wire defects below survived a green suite).
 

--- a/src/SIP/BlfSubscriptions.cpp
+++ b/src/SIP/BlfSubscriptions.cpp
@@ -7,41 +7,24 @@
 #include "IDGen.hpp"
 #include "Session.hpp"
 #include "SipClient.hpp"
+#include "SipHeaderUtil.hpp"
 #include "SipMessageTypes.h"
 #include "SipWireUtil.hpp"
 
-std::string BlfSubscriptions::parseEventPackage(const std::string& raw)
+std::string BlfSubscriptions::parseEventPackage(const std::shared_ptr<SipMessage>& data)
 {
-	size_t pos = 0;
-	while (pos < raw.size())
-	{
-		size_t nl = raw.find('\n', pos);
-		size_t lineEnd = (nl == std::string::npos) ? raw.size() : nl;
-		size_t next = (nl == std::string::npos) ? raw.size() : nl + 1;
-		if (raw[pos] == '\r' || raw[pos] == '\n') break;
-
-		size_t colon = raw.find(':', pos);
-		if (colon != std::string::npos && colon < lineEnd)
-		{
-			std::string name = raw.substr(pos, colon - pos);
-			std::transform(name.begin(), name.end(), name.begin(),
-				[](unsigned char c){ return static_cast<char>(std::tolower(c)); });
-			if (name == "event" || name == "o")
-			{
-				size_t vBegin = colon + 1;
-				size_t vEnd = lineEnd;
-				std::string val = raw.substr(vBegin, vEnd - vBegin);
-				size_t semi = val.find(';');
-				if (semi != std::string::npos) val.erase(semi);
-				size_t b = val.find_first_not_of(" \t\r");
-				size_t e = val.find_last_not_of(" \t\r");
-				if (b == std::string::npos) return "";
-				return val.substr(b, e - b + 1);
-			}
-		}
-		pos = next;
-	}
-	return "";
+	// SipMessage already parsed the header block (full name + compact form), so
+	// ask it for the Event line instead of re-serialising the whole message and
+	// running a second, weaker header scan over it — the old one also matched any
+	// line named "o", which is the SDP origin line's name too.
+	if (!data) return "";
+	std::string pkg = siphdr::stripHeaderName(data->getEvent());
+	size_t semi = pkg.find(';');            // drop ;id=... and friends
+	if (semi != std::string::npos) pkg.erase(semi);
+	size_t e = pkg.find_last_not_of(" \t\r\n");
+	if (e == std::string::npos) return "";
+	pkg.erase(e + 1);
+	return pkg;
 }
 
 std::string BlfSubscriptions::buildDialogInfoXml(const std::string& entity, unsigned version,
@@ -135,18 +118,15 @@ std::shared_ptr<SipMessage> BlfSubscriptions::buildDialogNotify(DialogSubscripti
 
 	// NOTIFY runs inside the subscription dialog: our To-tag becomes the From,
 	// the watcher's From becomes the To (RFC 6665 §4.4.1 — roles swap).
-	std::string fromHdr = sub.subTo;
-	std::string toHdr   = sub.watcherFrom;
-	auto stripName = [](const std::string& h) {
-		size_t c = h.find(':');
-		return (c == std::string::npos) ? h : h.substr(c + 1);
-	};
-
+	// subTo / watcherFrom hold FULL header lines ("To: <sip:...>;tag=x"), so the
+	// value has to be unwrapped before it is re-stamped under the swapped name.
+	// Uses the shared, guarded helper rather than a local "cut at the first colon"
+	// lambda, which would mangle any value that is not prefixed with its name.
 	std::ostringstream ss;
 	ss << "NOTIFY sip:" << destIpPort << " SIP/2.0\r\n"
 	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
-	   << "From:" << stripName(fromHdr) << "\r\n"
-	   << "To:" << stripName(toHdr) << "\r\n"
+	   << "From: " << siphdr::stripHeaderName(sub.subTo) << "\r\n"
+	   << "To: " << siphdr::stripHeaderName(sub.watcherFrom) << "\r\n"
 	   << "Call-ID: " << sub.callId << "\r\n"
 	   << "CSeq: " << sub.cseq++ << " NOTIFY\r\n"
 	   << "Max-Forwards: 70\r\n"
@@ -166,7 +146,7 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 	const std::string& activeIp = _env.localIp();
 
 	// 1. Event-package gate: only the RFC 4235 "dialog" package is implemented.
-	std::string pkg = parseEventPackage(data->toString());
+	std::string pkg = parseEventPackage(data);
 	if (pkg != "dialog")
 	{
 		auto resp = _env.messageFromPool(data->toString(), data->getSource());
@@ -191,14 +171,9 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 	}
 
 	const int expires = _env.requestedExpires(data);
-	std::string callId(data->getCallID());
-	{
-		size_t c = callId.find(':');
-		if (c != std::string::npos) callId.erase(0, c + 1);
-		size_t b = callId.find_first_not_of(" \t");
-		size_t e = callId.find_last_not_of(" \t\r");
-		callId = (b == std::string::npos) ? "" : callId.substr(b, e - b + 1);
-	}
+	// Subscriptions are keyed by the bare Call-ID value (getCallID() hands back
+	// the whole header line). Same guarded helper as everywhere else.
+	const std::string callId = siphdr::stripHeaderName(data->getCallID());
 
 	// 3. Refresh / unsubscribe: match existing subscription by Call-ID.
 	DialogSubscription* sub = nullptr;

--- a/src/SIP/BlfSubscriptions.cpp
+++ b/src/SIP/BlfSubscriptions.cpp
@@ -58,14 +58,14 @@ std::string BlfSubscriptions::computeDialogState(const std::string& targetAor,
 		if (s == "trying")    return 1;
 		return 0;
 	};
-	for (const auto& [callID, session] : _env.sessionsView())
+	_env.forEachSessionInvolving(targetAor,
+		[&](const std::string& callID, const Session& session)
 	{
-		bool isSrc  = session->getSrc()  && session->getSrc()->getNumber()  == targetAor;
-		bool isDest = session->getDest() && session->getDest()->getNumber() == targetAor;
-		if (!isSrc && !isDest) continue;
+		const bool isSrc  = session.getSrc()  && session.getSrc()->getNumber()  == targetAor;
+		const bool isDest = session.getDest() && session.getDest()->getNumber() == targetAor;
 
 		std::string state, dir;
-		switch (session->getState())
+		switch (session.getState())
 		{
 			case Session::State::Invited:
 				state = isDest ? "early" : "trying";
@@ -79,7 +79,7 @@ std::string BlfSubscriptions::computeDialogState(const std::string& targetAor,
 				dir   = isSrc ? "initiator" : "recipient";
 				break;
 			default:
-				continue;
+				return;
 		}
 		if (rank(state) > rank(best))
 		{
@@ -87,7 +87,7 @@ std::string BlfSubscriptions::computeDialogState(const std::string& targetAor,
 			outDirection = dir;
 			outDialogId  = callID;
 		}
-	}
+	});
 	if (best.empty()) { outDirection.clear(); outDialogId.clear(); }
 	return best;
 }

--- a/src/SIP/BlfSubscriptions.cpp
+++ b/src/SIP/BlfSubscriptions.cpp
@@ -11,14 +11,13 @@
 #include "SipMessageTypes.h"
 #include "SipWireUtil.hpp"
 
-std::string BlfSubscriptions::parseEventPackage(const std::shared_ptr<SipMessage>& data)
+std::string BlfSubscriptions::parseEventPackage(std::string_view eventHeader)
 {
-	// SipMessage already parsed the header block (full name + compact form), so
-	// ask it for the Event line instead of re-serialising the whole message and
-	// running a second, weaker header scan over it — the old one also matched any
-	// line named "o", which is the SDP origin line's name too.
-	if (!data) return "";
-	std::string pkg = siphdr::stripHeaderName(data->getEvent());
+	// Takes the already-parsed Event header line (SipMessage::getEvent), rather
+	// than re-serialising the whole message and running a second, weaker header
+	// scan over it — the old scanner also matched any line named "o", which is
+	// the SDP origin line's name too.
+	std::string pkg = siphdr::stripHeaderName(eventHeader);
 	size_t semi = pkg.find(';');            // drop ;id=... and friends
 	if (semi != std::string::npos) pkg.erase(semi);
 	size_t e = pkg.find_last_not_of(" \t\r\n");
@@ -59,10 +58,10 @@ std::string BlfSubscriptions::computeDialogState(const std::string& targetAor,
 		return 0;
 	};
 	_env.forEachSessionInvolving(targetAor,
-		[&](const std::string& callID, const Session& session)
+		[&](const std::string& callID, const Session& session, PbxEnv::DialogRole role)
 	{
-		const bool isSrc  = session.getSrc()  && session.getSrc()->getNumber()  == targetAor;
-		const bool isDest = session.getDest() && session.getDest()->getNumber() == targetAor;
+		const bool isSrc  = (role == PbxEnv::DialogRole::Caller);
+		const bool isDest = !isSrc;
 
 		std::string state, dir;
 		switch (session.getState())
@@ -146,7 +145,7 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 	const std::string& activeIp = _env.localIp();
 
 	// 1. Event-package gate: only the RFC 4235 "dialog" package is implemented.
-	std::string pkg = parseEventPackage(data);
+	std::string pkg = parseEventPackage(data->getEvent());
 	if (pkg != "dialog")
 	{
 		auto resp = _env.messageFromPool(data->toString(), data->getSource());

--- a/src/SIP/BlfSubscriptions.cpp
+++ b/src/SIP/BlfSubscriptions.cpp
@@ -8,12 +8,7 @@
 #include "Session.hpp"
 #include "SipClient.hpp"
 #include "SipMessageTypes.h"
-
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-#include <lwip/sockets.h>
-#elif defined(__linux__)
-#include <arpa/inet.h>
-#endif
+#include "SipWireUtil.hpp"
 
 std::string BlfSubscriptions::parseEventPackage(const std::string& raw)
 {
@@ -118,12 +113,10 @@ std::shared_ptr<SipMessage> BlfSubscriptions::buildDialogNotify(DialogSubscripti
 	const std::string& state, const std::string& direction, const std::string& dialogId,
 	bool terminated, const char* termReason)
 {
-	std::string activeIp = _env.localIp();
-	std::string srcIpPort = activeIp + ":" + std::to_string(_env.serverPort());
-	char ipBuf[INET_ADDRSTRLEN]{};
-	inet_ntop(AF_INET, &sub.addr.sin_addr, ipBuf, sizeof(ipBuf));
-	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(sub.addr.sin_port));
-	std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
+	const std::string& activeIp = _env.localIp();
+	const std::string srcIpPort = activeIp + ":" + std::to_string(_env.serverPort());
+	const std::string destIpPort = sipwire::addrToIpPort(sub.addr);
+	const std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
 
 	std::string entity = "sip:" + sub.targetAor + "@" + srcIpPort;
 	std::string body = buildDialogInfoXml(entity, sub.version, dialogId, state, direction);

--- a/src/SIP/BlfSubscriptions.hpp
+++ b/src/SIP/BlfSubscriptions.hpp
@@ -53,7 +53,7 @@ private:
 
 	// Event-package parsing helper (pure / static / host-testable). Returns the
 	// canonical package name (e.g. "dialog") or "".
-	static std::string parseEventPackage(const std::shared_ptr<SipMessage>& data);
+	static std::string parseEventPackage(std::string_view eventHeader);
 
 	// RFC 4235 dialog-info XML builder (pure).
 	static std::string buildDialogInfoXml(const std::string& entity, unsigned version,

--- a/src/SIP/BlfSubscriptions.hpp
+++ b/src/SIP/BlfSubscriptions.hpp
@@ -53,7 +53,7 @@ private:
 
 	// Event-package parsing helper (pure / static / host-testable). Returns the
 	// canonical package name (e.g. "dialog") or "".
-	static std::string parseEventPackage(const std::string& raw);
+	static std::string parseEventPackage(const std::shared_ptr<SipMessage>& data);
 
 	// RFC 4235 dialog-info XML builder (pure).
 	static std::string buildDialogInfoXml(const std::string& entity, unsigned version,

--- a/src/SIP/ParkOrbit.cpp
+++ b/src/SIP/ParkOrbit.cpp
@@ -7,22 +7,9 @@
 #include "Session.hpp"
 #include "SipHeaderUtil.hpp"
 #include "SipMessageTypes.h"
+#include "SipWireUtil.hpp"
 
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-#include <lwip/sockets.h>
-#elif defined(__linux__)
-#include <arpa/inet.h>
-#endif
-
-namespace
-{
-	std::string addrToIpPort(const sockaddr_in& addr)
-	{
-		char ipBuf[INET_ADDRSTRLEN]{};
-		inet_ntop(AF_INET, &addr.sin_addr, ipBuf, sizeof(ipBuf));
-		return std::string(ipBuf) + ":" + std::to_string(ntohs(addr.sin_port));
-	}
-}
+using sipwire::addrToIpPort;
 
 int ParkOrbit::orbitIndex(std::string_view ext) const
 {
@@ -47,14 +34,7 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 	if (slot.state == ParkState::Free)
 	{
 		// ── PARK ── answer with an a=inactive hold SDP so the parked party is held.
-		const std::string holdSdp =
-			"v=0\r\n"
-			"o=- 0 0 IN IP4 " + activeIp + "\r\n"
-			"s=pocket-dial\r\n"
-			"c=IN IP4 " + activeIp + "\r\n"
-			"t=0 0\r\n"
-			"m=audio 9 RTP/AVP 0\r\n"
-			"a=inactive\r\n";
+		const std::string holdSdp = sipwire::makeInactiveHoldSdp(activeIp);
 		auto ok = _env.messageFromPool(data->toString(), data->getSource());
 		ok->setHeader(SipMessageTypes::OK);
 		ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);

--- a/src/SIP/ParkOrbit.cpp
+++ b/src/SIP/ParkOrbit.cpp
@@ -40,7 +40,7 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 		return;
 	}
 	ParkSlot& slot = _slots[orbitIdx];
-	const std::string activeIp = _env.localIp();
+	const std::string& activeIp = _env.localIp();
 	const std::string orbit = "70" + std::to_string(orbitIdx);
 	const std::string toTag = IDGen::GenerateID(9);
 
@@ -140,27 +140,29 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 void ParkOrbit::sendReinvite(ParkSlot& slot, const std::string& sdp)
 {
 	if (slot.callID.empty() || !slot.parked) return;
-	const std::string activeIp = _env.localIp();
+	const std::string& activeIp = _env.localIp();
 	const std::string srcIpPort = activeIp + ":" + std::to_string(_env.serverPort());
 	const std::string destIpPort = addrToIpPort(slot.parkedAddr);
 
-	const std::string theirTag = slot.parkedFromTag;
 	const std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
-	const std::string body = sdp;
 
 	std::ostringstream ss;
 	ss << "INVITE sip:" << slot.parkedExt << "@" << destIpPort << " SIP/2.0\r\n"
 	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
 	   << "From: <sip:" << slot.orbit << "@" << srcIpPort << ">;tag=" << slot.localTag << "\r\n"
-	   << "To: <sip:" << slot.parkedExt << "@" << activeIp << ">;tag=" << theirTag << "\r\n"
-	   << "Call-ID: " << slot.callID << "\r\n"
+	   << "To: <sip:" << slot.parkedExt << "@" << activeIp << ">;tag=" << slot.parkedFromTag << "\r\n"
+	   // slot.callID holds the FULL "Call-ID: x@host" header line (getCallID()
+	   // returns the whole line), so strip the name back off before re-stamping it
+	   // — otherwise the re-INVITE ships "Call-ID: Call-ID: x@host" and the parked
+	   // phone never matches it to the dialog.
+	   << "Call-ID: " << siphdr::stripHeaderName(slot.callID) << "\r\n"
 	   << "CSeq: 2 INVITE\r\n"
 	   << "Max-Forwards: 70\r\n"
 	   << "Contact: <sip:" << slot.orbit << "@" << srcIpPort << ";transport=UDP>\r\n"
 	   << "User-Agent: pocket-dial\r\n"
 	   << "Content-Type: application/sdp\r\n"
-	   << "Content-Length: " << body.size() << "\r\n\r\n"
-	   << body;
+	   << "Content-Length: " << sdp.size() << "\r\n\r\n"
+	   << sdp;
 
 	auto inv = _env.messageFromPool(ss.str(), slot.parkedAddr);
 	inv->enforceG711();
@@ -173,7 +175,7 @@ void ParkOrbit::sendReinvite(ParkSlot& slot, const std::string& sdp)
 void ParkOrbit::byeParkedParty(const ParkSlot& slot)
 {
 	if (slot.callID.empty()) return;
-	const std::string activeIp = _env.localIp();
+	const std::string& activeIp = _env.localIp();
 	const std::string srcIpPort = activeIp + ":" + std::to_string(_env.serverPort());
 	const std::string fromHeader = "<sip:" + slot.orbit + "@" + srcIpPort + ">;tag=" + slot.localTag;
 	const std::string toHeader = "<sip:" + slot.parkedExt + "@" + activeIp + ">;tag=" + slot.parkedFromTag;
@@ -186,7 +188,7 @@ void ParkOrbit::startRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& 
 	std::chrono::steady_clock::time_point now)
 {
 	if (!parker) { byeParkedParty(slot); freeForCallId(slot.callID); return; }
-	const std::string activeIp = _env.localIp();
+	const std::string& activeIp = _env.localIp();
 	const std::string srcIpPort = activeIp + ":" + std::to_string(_env.serverPort());
 	const sockaddr_in& addr = parker->getAddress();
 	const std::string destIpPort = addrToIpPort(addr);
@@ -198,7 +200,6 @@ void ParkOrbit::startRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& 
 	slot.state     = ParkState::RingingBack;
 	slot.deadline  = now + std::chrono::seconds(30);
 
-	const std::string body = slot.parkedSdp;
 	std::ostringstream ss;
 	ss << "INVITE sip:" << parker->getNumber() << "@" << destIpPort << " SIP/2.0\r\n"
 	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << slot.rbBranch << "\r\n"
@@ -210,8 +211,8 @@ void ParkOrbit::startRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& 
 	   << "Contact: <sip:" << slot.orbit << "@" << srcIpPort << ";transport=UDP>\r\n"
 	   << "User-Agent: pocket-dial\r\n"
 	   << "Content-Type: application/sdp\r\n"
-	   << "Content-Length: " << body.size() << "\r\n\r\n"
-	   << body;
+	   << "Content-Length: " << slot.parkedSdp.size() << "\r\n\r\n"
+	   << slot.parkedSdp;
 
 	auto inv = _env.messageFromPool(ss.str(), addr);
 	inv->enforceG711();
@@ -231,7 +232,7 @@ bool ParkOrbit::handleOk(const std::shared_ptr<SipMessage>& data)
 	if (auto it = std::find(_pendingAcks.begin(), _pendingAcks.end(), callID);
 		it != _pendingAcks.end())
 	{
-		const std::string activeIp = _env.localIp();
+		const std::string& activeIp = _env.localIp();
 		const std::string srcIpPort = activeIp + ":" + std::to_string(_env.serverPort());
 		const std::string destIpPort = addrToIpPort(data->getSource());
 		std::ostringstream ss;
@@ -253,7 +254,7 @@ bool ParkOrbit::handleOk(const std::shared_ptr<SipMessage>& data)
 	{
 		if (slot.state == ParkState::RingingBack && slot.rbCallID == callID)
 		{
-			const std::string activeIp = _env.localIp();
+			const std::string& activeIp = _env.localIp();
 			const std::string srcIpPort = activeIp + ":" + std::to_string(_env.serverPort());
 			const std::string destIpPort = addrToIpPort(slot.rbAddr);
 			std::ostringstream ss;

--- a/src/SIP/ParkOrbit.cpp
+++ b/src/SIP/ParkOrbit.cpp
@@ -56,6 +56,7 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 		slot.localTag   = toTag;
 		slot.parker     = caller->getNumber();
 		slot.parkedAt   = std::chrono::steady_clock::now();
+		_parkChanged    = true;
 
 		auto virt = _env.allocVirtualPeer(orbit, data->getSource());
 		if (auto session = _env.allocSession(std::string(data->getCallID()), caller))
@@ -114,7 +115,7 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 	sendReinvite(slot, retrieverSdp);
 	_env.log("Park: " + caller->getNumber() + " retrieved " + slot.parkedExt + " from " + orbit);
 
-	slot = ParkSlot{};
+	releaseSlot(slot);
 }
 
 void ParkOrbit::sendReinvite(ParkSlot& slot, const std::string& sdp)
@@ -179,6 +180,7 @@ void ParkOrbit::startRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& 
 	slot.rbAddr    = addr;
 	slot.state     = ParkState::RingingBack;
 	slot.deadline  = now + std::chrono::seconds(30);
+	_parkChanged   = true;   // leaves the Parked view: the dashboard row must drop
 
 	std::ostringstream ss;
 	ss << "INVITE sip:" << parker->getNumber() << "@" << destIpPort << " SIP/2.0\r\n"
@@ -270,7 +272,7 @@ bool ParkOrbit::handleOk(const std::shared_ptr<SipMessage>& data)
 			}
 
 			_env.log("Park: parker answered ring-back on " + slot.orbit + " — bridging");
-			slot = ParkSlot{};
+			releaseSlot(slot);
 			return true;
 		}
 	}
@@ -306,13 +308,26 @@ void ParkOrbit::sweep(std::chrono::steady_clock::time_point now)
 	}
 }
 
+void ParkOrbit::releaseSlot(ParkSlot& slot)
+{
+	slot = ParkSlot{};
+	_parkChanged = true;
+}
+
+bool ParkOrbit::consumeParkChanged()
+{
+	const bool changed = _parkChanged;
+	_parkChanged = false;
+	return changed;
+}
+
 void ParkOrbit::freeForCallId(std::string_view callID)
 {
 	for (auto& slot : _slots)
 	{
 		if (slot.state != ParkState::Free && slot.callID == callID)
 		{
-			slot = ParkSlot{};
+			releaseSlot(slot);
 		}
 	}
 	_pendingAcks.erase(

--- a/src/SIP/ParkOrbit.hpp
+++ b/src/SIP/ParkOrbit.hpp
@@ -53,6 +53,13 @@ public:
 	std::vector<std::tuple<std::string, std::string, std::string, int>>
 	snapshotRows(std::chrono::steady_clock::time_point now, bool onlyParked) const;
 
+	// True (and resets the flag) if an orbit slot changed since the last call —
+	// the cue to re-mirror snapshotRows() into the dashboard snapshot. Same
+	// contract as Registrar::consumeDevicesChanged(), and polled from the same
+	// once-per-packet spot, so mirroring is no longer a duty each mutating call
+	// site has to remember: sweep() and freeForCallId() self-signal too.
+	bool consumeParkChanged();
+
 private:
 	enum class ParkState : uint8_t { Free, Parked, RingingBack, Retrieving };
 	struct ParkSlot
@@ -81,9 +88,14 @@ private:
 	void startRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& parker,
 		std::chrono::steady_clock::time_point now);
 
+	// Release a slot back to Free and flag the dashboard mirror as stale. Every
+	// path that clears a slot goes through here so none can forget to signal.
+	void releaseSlot(ParkSlot& slot);
+
 	std::array<ParkSlot, POCKETDIAL_PARK_SLOTS> _slots;
 	std::chrono::seconds _timeout{POCKETDIAL_PARK_TIMEOUT_SEC};
 	std::vector<std::string> _pendingAcks;   // park re-INVITE ACKs pending
+	bool _parkChanged = false;               // slot state moved since the last mirror
 	PbxEnv& _env;
 };
 

--- a/src/SIP/ParkOrbit.hpp
+++ b/src/SIP/ParkOrbit.hpp
@@ -55,7 +55,7 @@ public:
 
 	// True (and resets the flag) if an orbit slot changed since the last call —
 	// the cue to re-mirror snapshotRows() into the dashboard snapshot. Same
-	// contract as Registrar::consumeDevicesChanged(), and polled from the same
+	// contract as Registrar::consumeDevicesChange(), and polled from the same
 	// once-per-packet spot, so mirroring is no longer a duty each mutating call
 	// site has to remember: sweep() and freeForCallId() self-signal too.
 	bool consumeParkChanged();

--- a/src/SIP/PbxEnv.hpp
+++ b/src/SIP/PbxEnv.hpp
@@ -63,13 +63,17 @@ struct PbxEnv
 	virtual std::shared_ptr<SipMessage> serverBye(const std::string& destExt,
 		const sockaddr_in& destAddr, const std::string& callId,
 		const std::string& fromHeader, const std::string& toHeader) = 0;
-	// Visit every live session `aor` is a party to, as {Call-ID, session}. Used by
-	// the BLF machine to compute an RFC 4235 dialog state. A query rather than a
-	// reference to the session table: every other method here is a behavioural
-	// question, and handing out the container would let the engine's storage
-	// choice (map type, key, per-session locking) leak into the machines.
+	// Which end of a dialog an extension sits on.
+	enum class DialogRole { Caller, Callee };
+	// Visit every live session `aor` is a party to, as {Call-ID, session, role}.
+	// Used by the BLF machine to compute an RFC 4235 dialog state. A query rather
+	// than a reference to the session table: every other method here is a
+	// behavioural question, and handing out the container would let the engine's
+	// storage choice (map type, key, per-session locking) leak into the machines.
+	// The role is passed through because matching already determined it — the
+	// visitor would otherwise recompute the same comparison it was selected by.
 	virtual void forEachSessionInvolving(std::string_view aor,
-		const std::function<void(const std::string&, const Session&)>& fn) const = 0;
+		const std::function<void(const std::string&, const Session&, DialogRole)>& fn) const = 0;
 	// AOR charset validation (the engine's isValidAor policy).
 	virtual bool validAor(std::string_view s) const = 0;
 	// Parse the requested registration/subscription lease from Expires/Contact

--- a/src/SIP/PbxEnv.hpp
+++ b/src/SIP/PbxEnv.hpp
@@ -9,10 +9,10 @@
 #include <WinSock2.h>
 #endif
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
 class SipMessage;
 class SipClient;
@@ -63,8 +63,13 @@ struct PbxEnv
 	virtual std::shared_ptr<SipMessage> serverBye(const std::string& destExt,
 		const sockaddr_in& destAddr, const std::string& callId,
 		const std::string& fromHeader, const std::string& toHeader) = 0;
-	// Read-only view of the live-session table (BLF dialog-state computation).
-	virtual const std::unordered_map<std::string, std::shared_ptr<Session>>& sessionsView() const = 0;
+	// Visit every live session `aor` is a party to, as {Call-ID, session}. Used by
+	// the BLF machine to compute an RFC 4235 dialog state. A query rather than a
+	// reference to the session table: every other method here is a behavioural
+	// question, and handing out the container would let the engine's storage
+	// choice (map type, key, per-session locking) leak into the machines.
+	virtual void forEachSessionInvolving(std::string_view aor,
+		const std::function<void(const std::string&, const Session&)>& fn) const = 0;
 	// AOR charset validation (the engine's isValidAor policy).
 	virtual bool validAor(std::string_view s) const = 0;
 	// Parse the requested registration/subscription lease from Expires/Contact

--- a/src/SIP/RegisterBeeper.cpp
+++ b/src/SIP/RegisterBeeper.cpp
@@ -4,22 +4,9 @@
 
 #include "IDGen.hpp"
 #include "SipMessageTypes.h"
+#include "SipWireUtil.hpp"
 
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-#include <lwip/sockets.h>
-#elif defined(__linux__)
-#include <arpa/inet.h>
-#endif
-
-namespace
-{
-	std::string addrToIpPort(const sockaddr_in& addr)
-	{
-		char ipBuf[INET_ADDRSTRLEN]{};
-		inet_ntop(AF_INET, &addr.sin_addr, ipBuf, sizeof(ipBuf));
-		return std::string(ipBuf) + ":" + std::to_string(ntohs(addr.sin_port));
-	}
-}
+using sipwire::addrToIpPort;
 
 RegisterBeeper::BeepDialog* RegisterBeeper::findByCallID(std::string_view callID)
 {
@@ -74,14 +61,7 @@ void RegisterBeeper::sendBeep(const std::shared_ptr<SipClient>& phone)
 	slot->deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
 
 	// Minimal, well-formed SDP. a=inactive: no RTP will flow (server sources none).
-	std::string body =
-		"v=0\r\n"
-		"o=- 0 0 IN IP4 " + activeIp + "\r\n"
-		"s=pocket-dial\r\n"
-		"c=IN IP4 " + activeIp + "\r\n"
-		"t=0 0\r\n"
-		"m=audio 9 RTP/AVP 0\r\n"
-		"a=inactive\r\n";
+	const std::string body = sipwire::makeInactiveHoldSdp(activeIp);
 
 	std::ostringstream ss;
 	ss << "INVITE sip:" << clientNum << "@" << destIpPort << " SIP/2.0\r\n"

--- a/src/SIP/RegisterBeeper.cpp
+++ b/src/SIP/RegisterBeeper.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include "IDGen.hpp"
+#include "SipHeaderUtil.hpp"
 #include "SipMessageTypes.h"
 #include "SipWireUtil.hpp"
 
@@ -10,9 +11,15 @@ using sipwire::addrToIpPort;
 
 RegisterBeeper::BeepDialog* RegisterBeeper::findByCallID(std::string_view callID)
 {
+	// Callers hand us SipMessage::getCallID(), which returns the FULL header line
+	// ("Call-ID: x@host"), while slot.callID holds the bare id we generated in
+	// sendBeep(). Normalise before comparing — matching the raw line against the
+	// bare id never succeeded, so an answered beep was never ACKed or BYEd and
+	// sweep() went on to CANCEL an INVITE that already had a final response.
+	const std::string key = siphdr::stripHeaderName(callID);
 	for (auto& bd : _dialogs)
 	{
-		if (bd.state != BeepState::Free && bd.callID == callID)
+		if (bd.state != BeepState::Free && bd.callID == key)
 		{
 			return &bd;
 		}
@@ -109,9 +116,11 @@ bool RegisterBeeper::handleOk(const std::shared_ptr<SipMessage>& data)
 	if (bd->state == BeepState::AwaitingInviteOk &&
 		cseq.find(SipMessageTypes::INVITE) != std::string::npos)
 	{
-		auto ack = buildAck(data);
+		const std::string destIpPort = addrToIpPort(bd->addr);
+		const std::string srcIpPort = _env.localIp() + ":" + std::to_string(_env.serverPort());
+		auto ack = buildAck(*bd, data, destIpPort, srcIpPort);
 		if (ack) _env.enqueue(bd->addr, std::move(ack));
-		auto bye = buildBye(data);
+		auto bye = buildBye(*bd, data);
 		if (bye) _env.enqueue(bd->addr, std::move(bye));
 		bd->state    = BeepState::AwaitingByeOk;
 		// Re-arm the deadline so a phone that never 200s our BYE still frees its
@@ -149,58 +158,38 @@ void RegisterBeeper::sweep(std::chrono::steady_clock::time_point now)
 	}
 }
 
-std::shared_ptr<SipMessage> RegisterBeeper::buildAck(const std::shared_ptr<SipMessage>& ok)
+std::shared_ptr<SipMessage> RegisterBeeper::buildAck(const BeepDialog& bd,
+	const std::shared_ptr<SipMessage>& ok,
+	const std::string& destIpPort, const std::string& srcIpPort)
 {
 	// ACK the phone's 200 OK to our beep INVITE (RFC 3261 §13.2.2.4 / §17.1.1.3).
 	// Same Call-ID/branch/From-tag as the INVITE; To carries the phone's tag from the
 	// 200. CSeq stays "1 ACK" (matches the INVITE transaction). No body.
-	BeepDialog* bd = findByCallID(ok->getCallID());
-	if (!bd)
-	{
-		return nullptr;
-	}
-
-	std::string destIpPort = addrToIpPort(bd->addr);
-	std::string srcIpPort = _env.localIp() + ":" + std::to_string(_env.serverPort());
-
 	std::ostringstream ss;
-	ss << "ACK sip:" << bd->ext << "@" << destIpPort << " SIP/2.0\r\n"
-	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << bd->branch << "\r\n"
-	   << "From: \"PocketDial\" <sip:pbx@" << srcIpPort << ">;tag=" << bd->fromTag << "\r\n"
-	   << "To: " << ok->getTo() << "\r\n"
-	   << "Call-ID: " << bd->callID << "\r\n"
+	ss << "ACK sip:" << bd.ext << "@" << destIpPort << " SIP/2.0\r\n"
+	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << bd.branch << "\r\n"
+	   << "From: \"PocketDial\" <sip:pbx@" << srcIpPort << ">;tag=" << bd.fromTag << "\r\n"
+	   << "To: " << siphdr::stripHeaderName(ok->getTo()) << "\r\n"
+	   << "Call-ID: " << bd.callID << "\r\n"
 	   << "CSeq: 1 ACK\r\n"
 	   << "Max-Forwards: 70\r\n"
 	   << "Content-Length: 0\r\n\r\n";
 
-	return _env.messageFromPool(ss.str(), bd->addr);
+	return _env.messageFromPool(ss.str(), bd.addr);
 }
 
-std::shared_ptr<SipMessage> RegisterBeeper::buildBye(const std::shared_ptr<SipMessage>& ok)
+std::shared_ptr<SipMessage> RegisterBeeper::buildBye(const BeepDialog& bd,
+	const std::shared_ptr<SipMessage>& ok)
 {
-	// BYE to end the beep call immediately after the tone. New transaction (fresh
-	// branch, CSeq 2 BYE) within the established dialog. To carries the phone's tag.
-	BeepDialog* bd = findByCallID(ok->getCallID());
-	if (!bd)
-	{
-		return nullptr;
-	}
-
-	std::string destIpPort = addrToIpPort(bd->addr);
-	std::string srcIpPort = _env.localIp() + ":" + std::to_string(_env.serverPort());
-	std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
-
-	std::ostringstream ss;
-	ss << "BYE sip:" << bd->ext << "@" << destIpPort << " SIP/2.0\r\n"
-	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
-	   << "From: \"PocketDial\" <sip:pbx@" << srcIpPort << ">;tag=" << bd->fromTag << "\r\n"
-	   << "To: " << ok->getTo() << "\r\n"
-	   << "Call-ID: " << bd->callID << "\r\n"
-	   << "CSeq: 2 BYE\r\n"
-	   << "Max-Forwards: 70\r\n"
-	   << "Content-Length: 0\r\n\r\n";
-
-	return _env.messageFromPool(ss.str(), bd->addr);
+	// BYE to end the beep call immediately after the tone. Delegated to the engine's
+	// one server-BYE builder (PbxEnv::serverBye) so hardening applied there — CSeq 2
+	// BYE, header-name stripping, Max-Forwards policy — reaches the beep teardown
+	// too, exactly as ParkOrbit::byeParkedParty does. To carries the phone's tag.
+	const std::string srcIpPort = _env.localIp() + ":" + std::to_string(_env.serverPort());
+	const std::string fromHeader =
+		"\"PocketDial\" <sip:pbx@" + srcIpPort + ">;tag=" + bd.fromTag;
+	return _env.serverBye(bd.ext, bd.addr, bd.callID,
+		fromHeader, std::string(ok->getTo()));
 }
 
 std::shared_ptr<SipMessage> RegisterBeeper::buildCancel(std::size_t slot)

--- a/src/SIP/RegisterBeeper.cpp
+++ b/src/SIP/RegisterBeeper.cpp
@@ -116,9 +116,7 @@ bool RegisterBeeper::handleOk(const std::shared_ptr<SipMessage>& data)
 	if (bd->state == BeepState::AwaitingInviteOk &&
 		cseq.find(SipMessageTypes::INVITE) != std::string::npos)
 	{
-		const std::string destIpPort = addrToIpPort(bd->addr);
-		const std::string srcIpPort = _env.localIp() + ":" + std::to_string(_env.serverPort());
-		auto ack = buildAck(*bd, data, destIpPort, srcIpPort);
+		auto ack = buildAck(*bd, data);
 		if (ack) _env.enqueue(bd->addr, std::move(ack));
 		auto bye = buildBye(*bd, data);
 		if (bye) _env.enqueue(bd->addr, std::move(bye));
@@ -159,12 +157,14 @@ void RegisterBeeper::sweep(std::chrono::steady_clock::time_point now)
 }
 
 std::shared_ptr<SipMessage> RegisterBeeper::buildAck(const BeepDialog& bd,
-	const std::shared_ptr<SipMessage>& ok,
-	const std::string& destIpPort, const std::string& srcIpPort)
+	const std::shared_ptr<SipMessage>& ok)
 {
 	// ACK the phone's 200 OK to our beep INVITE (RFC 3261 §13.2.2.4 / §17.1.1.3).
 	// Same Call-ID/branch/From-tag as the INVITE; To carries the phone's tag from the
 	// 200. CSeq stays "1 ACK" (matches the INVITE transaction). No body.
+	const std::string destIpPort = addrToIpPort(bd.addr);
+	const std::string srcIpPort = _env.localIp() + ":" + std::to_string(_env.serverPort());
+
 	std::ostringstream ss;
 	ss << "ACK sip:" << bd.ext << "@" << destIpPort << " SIP/2.0\r\n"
 	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << bd.branch << "\r\n"

--- a/src/SIP/RegisterBeeper.hpp
+++ b/src/SIP/RegisterBeeper.hpp
@@ -62,8 +62,13 @@ private:
 	};
 
 	BeepDialog* findByCallID(std::string_view callID);
-	std::shared_ptr<SipMessage> buildAck(const std::shared_ptr<SipMessage>& ok);
-	std::shared_ptr<SipMessage> buildBye(const std::shared_ptr<SipMessage>& ok);
+	// buildAck/buildBye take the dialog handleOk() already located plus the two
+	// authority strings it already formatted — they used to re-scan the table by
+	// Call-ID and re-derive both ip:port strings, three times over per answered
+	// beep, all inside the _mutex-held 200-OK dispatch.
+	std::shared_ptr<SipMessage> buildAck(const BeepDialog& bd, const std::shared_ptr<SipMessage>& ok,
+		const std::string& destIpPort, const std::string& srcIpPort);
+	std::shared_ptr<SipMessage> buildBye(const BeepDialog& bd, const std::shared_ptr<SipMessage>& ok);
 	std::shared_ptr<SipMessage> buildCancel(std::size_t slot);
 
 	// Bounded outbound-UAC dialog table. Tiny fixed footprint; if all slots are

--- a/src/SIP/RegisterBeeper.hpp
+++ b/src/SIP/RegisterBeeper.hpp
@@ -62,12 +62,10 @@ private:
 	};
 
 	BeepDialog* findByCallID(std::string_view callID);
-	// buildAck/buildBye take the dialog handleOk() already located plus the two
-	// authority strings it already formatted — they used to re-scan the table by
-	// Call-ID and re-derive both ip:port strings, three times over per answered
-	// beep, all inside the _mutex-held 200-OK dispatch.
-	std::shared_ptr<SipMessage> buildAck(const BeepDialog& bd, const std::shared_ptr<SipMessage>& ok,
-		const std::string& destIpPort, const std::string& srcIpPort);
+	// buildAck/buildBye take the dialog handleOk() already located — they used to
+	// re-scan the table by Call-ID themselves, three linear passes over the same
+	// Call-ID per answered beep, all inside the _mutex-held 200-OK dispatch.
+	std::shared_ptr<SipMessage> buildAck(const BeepDialog& bd, const std::shared_ptr<SipMessage>& ok);
 	std::shared_ptr<SipMessage> buildBye(const BeepDialog& bd, const std::shared_ptr<SipMessage>& ok);
 	std::shared_ptr<SipMessage> buildCancel(std::size_t slot);
 

--- a/src/SIP/Registrar.cpp
+++ b/src/SIP/Registrar.cpp
@@ -1,5 +1,6 @@
 #include "Registrar.hpp"
 
+#include <algorithm>
 #include <cstdlib>
 
 #include "ArpLookup.hpp"
@@ -301,12 +302,10 @@ std::vector<Registrar::AdoptedDevice> Registrar::adoptedDevices() const
 
 void Registrar::noteChange(Change kind)
 {
-	// Structural is sticky: if the row set gained or lost an entry in this pass,
-	// a later online flip must not downgrade it to the patch-only path.
-	if (kind == Change::Structural || _devicesChanged == Change::None)
-	{
-		_devicesChanged = kind;
-	}
+	// The enum is ordered None < OnlineOnly < Structural, so taking the max keeps
+	// Structural sticky: once the row set gained or lost an entry in this pass, a
+	// later online flip must not downgrade it to the patch-only path.
+	_devicesChanged = std::max(_devicesChanged, kind);
 }
 
 Registrar::Change Registrar::consumeDevicesChange()

--- a/src/SIP/Registrar.cpp
+++ b/src/SIP/Registrar.cpp
@@ -177,7 +177,7 @@ Registrar::AuthDecision Registrar::admitLearn(
 		rec.state = DeviceState::Learned;
 		_devices.emplace(mac, std::move(rec));
 		persistDevices();
-		_devicesChanged = true;
+		noteChange(Change::Structural);
 		_env.log("Learn: adopted device " + mac + " as ext " + ext);
 		return AuthDecision::Accept;
 	}
@@ -187,7 +187,7 @@ Registrar::AuthDecision Registrar::admitLearn(
 	{
 		it->second.extension = ext;
 		persistDevices();
-		_devicesChanged = true;
+		noteChange(Change::Structural);
 	}
 
 	if (it->second.state == DeviceState::Secured)
@@ -228,7 +228,9 @@ void Registrar::markOnline(const std::string& mac, bool online)
 	if (it->second.online != online)
 	{
 		it->second.online = online;
-		_devicesChanged = true;
+		// Row set is unchanged — the mirror only needs the flag patched, not a
+		// rebuild of every mac/extension string.
+		noteChange(Change::OnlineOnly);
 	}
 }
 
@@ -254,7 +256,7 @@ bool Registrar::secure(const std::string& macOrExt)
 				it->second.state = DeviceState::Secured;
 				persistDevices();
 				changed = true;
-				_devicesChanged = true;
+				noteChange(Change::Structural);
 			}
 			_env.log("Device " + it->first + " (ext " + it->second.extension + ") secured");
 		}
@@ -277,7 +279,7 @@ bool Registrar::forget(const std::string& macOrExt)
 	_env.log("Device " + it->first + " (ext " + it->second.extension + ") forgotten");
 	_devices.erase(it);
 	persistDevices();
-	_devicesChanged = true;
+	noteChange(Change::Structural);
 	return true;
 }
 
@@ -297,11 +299,30 @@ std::vector<Registrar::AdoptedDevice> Registrar::adoptedDevices() const
 	return out;
 }
 
-bool Registrar::consumeDevicesChanged()
+void Registrar::noteChange(Change kind)
 {
-	bool was = _devicesChanged;
-	_devicesChanged = false;
+	// Structural is sticky: if the row set gained or lost an entry in this pass,
+	// a later online flip must not downgrade it to the patch-only path.
+	if (kind == Change::Structural || _devicesChanged == Change::None)
+	{
+		_devicesChanged = kind;
+	}
+}
+
+Registrar::Change Registrar::consumeDevicesChange()
+{
+	Change was = _devicesChanged;
+	_devicesChanged = Change::None;
 	return was;
+}
+
+void Registrar::copyOnlineFlagsInto(std::vector<AdoptedDevice>& rows) const
+{
+	for (auto& row : rows)
+	{
+		auto it = _devices.find(row.mac);
+		if (it != _devices.end()) row.online = it->second.online;
+	}
 }
 
 void Registrar::loadDevices()
@@ -334,7 +355,7 @@ void Registrar::loadDevices()
 		}
 	}
 	nvs_close(h);
-	_devicesChanged = !_devices.empty();
+	if (!_devices.empty()) noteChange(Change::Structural);
 #endif
 }
 

--- a/src/SIP/Registrar.hpp
+++ b/src/SIP/Registrar.hpp
@@ -86,9 +86,24 @@ public:
 	// Current registry contents (MAC-sorted by map order) for the dashboard
 	// snapshot mirror.
 	std::vector<AdoptedDevice> adoptedDevices() const;
-	// True (and resets the flag) if the registry changed since the last call —
-	// the cue to re-mirror adoptedDevices() into the dashboard snapshot.
-	bool consumeDevicesChanged();
+
+	// What moved in the registry since the last consume. Online is by far the
+	// most frequent (every registration and every lease expiry flips it, and a
+	// post-reboot storm flips it once per phone) and is the only kind that needs
+	// no new strings in the mirror — separating it keeps that case off the
+	// allocating path.
+	enum class Change : uint8_t
+	{
+		None = 0,
+		OnlineOnly,   // only volatile online flags moved; row set is unchanged
+		Structural,   // a device was adopted / re-extensioned / secured / forgotten
+	};
+	// Report (and reset) what changed since the last call. Structural outranks
+	// OnlineOnly when both happened in the same pass.
+	Change consumeDevicesChange();
+	// Refresh just the online flags of an already-mirrored row set, matched by
+	// MAC. No allocation: the mac/extension strings in `rows` are left alone.
+	void copyOnlineFlagsInto(std::vector<AdoptedDevice>& rows) const;
 
 private:
 	struct DeviceRecord
@@ -109,7 +124,9 @@ private:
 	// flood of distinct MACs cannot grow the heap without limit). NVS-persisted
 	// (namespace "pbxcfg", key "devices") minus the volatile online flags.
 	std::unordered_map<std::string, DeviceRecord> _devices;
-	bool _devicesChanged = false;
+	Change _devicesChanged = Change::None;
+	// Raise the pending change to at least `kind` (Structural is sticky).
+	void noteChange(Change kind);
 };
 
 #endif

--- a/src/SIP/Registrar.hpp
+++ b/src/SIP/Registrar.hpp
@@ -62,7 +62,7 @@ public:
 	// Learn-mode admission: resolves the source MAC, applies TOFU + MAC-lock and
 	// returns the digest decision. On a first-packet ARP miss returns Accept
 	// (deferring the lock to the next REGISTER). Records/updates the adoption
-	// entry — poll consumeDevicesChanged() afterwards to mirror the snapshot.
+	// entry — poll consumeDevicesChange() afterwards to mirror the snapshot.
 	AuthDecision admitLearn(const std::shared_ptr<SipMessage>& data,
 		const std::string& ext, std::string& outRejectReason);
 	// Emit a 401 Unauthorized with a fresh WWW-Authenticate challenge. `stale`

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -289,6 +289,14 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 			refreshDeviceSnapshot();
 		}
 
+		// Park-orbit change detection, same contract. Polling here (rather than
+		// making every mutating call site remember refreshParkSnapshot()) means a
+		// new park path cannot silently leave a stale row on the dashboard.
+		if (_park.consumeParkChanged())
+		{
+			refreshParkSnapshot();
+		}
+
 		// BLF change detection: one pass after every handled packet covers
 		// registration appear/disappear, session create/transition/teardown.
 		// NOTIFYs land in _outbox and ride out with this pass (after unlock).
@@ -483,7 +491,6 @@ void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 	if (_park.orbitIndex(destNumber) >= 0)
 	{
 		endCall(data->getCallID(), data->getFromNumber(), destNumber);
-		refreshParkSnapshot();
 		return;
 	}
 
@@ -695,7 +702,6 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		if (orbitIdx >= 0)
 		{
 			_park.onInvite(data, caller.value(), orbitIdx);
-			refreshParkSnapshot();
 			return;
 		}
 	}
@@ -1252,10 +1258,11 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
-	// Park dialogs (server-originated re-INVITE ACKs + ring-back answers).
+	// Park dialogs (server-originated re-INVITE ACKs + ring-back answers). The
+	// snapshot mirror is driven by _park.consumeParkChanged() in handle(), so a
+	// state-neutral ACK confirmation no longer pays a rebuild.
 	if (_park.handleOk(data))
 	{
-		refreshParkSnapshot();
 		return;
 	}
 	// Attended-transfer re-INVITE ACKs.
@@ -2818,8 +2825,12 @@ void RequestsHandler::tick()
 				pbx::joinMembers(g.members));
 		}
 
-		// Parked calls view: {orbit, parkedExt, parker, secondsParked}.
+		// Parked calls view: {orbit, parkedExt, parker, secondsParked}. This full
+		// rebuild already reflects anything _park.sweep() just did above, so clear
+		// the dirty flag here rather than leaving it to trigger a redundant mirror
+		// on the next packet.
 		nextSnapshot.parkedCalls = _park.snapshotRows(now, /*onlyParked=*/true);
+		_park.consumeParkChanged();
 
 		{
 			std::lock_guard<std::mutex> snapLock(_snapshotMutex);

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -284,10 +284,7 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 		// Device-registry change detection: a REGISTER may have adopted a device,
 		// re-synced its extension, or flipped its online flag inside the Registrar
 		// machine — mirror the registry into the dashboard snapshot once per packet.
-		if (_registrar.consumeDevicesChanged())
-		{
-			refreshDeviceSnapshot();
-		}
+		applyDeviceChange(_registrar.consumeDevicesChange());
 
 		// Park-orbit change detection, same contract. Polling here (rather than
 		// making every mutating call site remember refreshParkSnapshot()) means a
@@ -2500,6 +2497,31 @@ void RequestsHandler::refreshDeviceSnapshot()
 	_snapshot.devices = std::move(devices);
 }
 
+void RequestsHandler::applyDeviceChange(Registrar::Change change)
+{
+	// Caller holds _mutex; takes _snapshotMutex internally.
+	//
+	// An online flip leaves the row set identical, so patching the flags in place
+	// avoids rebuilding the vector and its two strings per device. That is the
+	// common case by a wide margin — every registration and every lease expiry
+	// flips a flag, and a post-reboot storm flips one per phone, which would
+	// otherwise make the mirror cost O(devices) allocations per REGISTER.
+	switch (change)
+	{
+		case Registrar::Change::None:
+			return;
+		case Registrar::Change::OnlineOnly:
+		{
+			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+			_registrar.copyOnlineFlagsInto(_snapshot.devices);
+			return;
+		}
+		case Registrar::Change::Structural:
+			refreshDeviceSnapshot();
+			return;
+	}
+}
+
 std::vector<RequestsHandler::AdoptedDevice> RequestsHandler::getAdoptedDevices()
 {
 	std::lock_guard<std::mutex> lock(_snapshotMutex);
@@ -2513,7 +2535,7 @@ bool RequestsHandler::secureDevice(const std::string& macOrExt)
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
 		changed = _registrar.secure(macOrExt);
-		if (_registrar.consumeDevicesChanged()) refreshDeviceSnapshot();
+		applyDeviceChange(_registrar.consumeDevicesChange());
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}
@@ -2532,7 +2554,7 @@ bool RequestsHandler::forgetDevice(const std::string& macOrExt)
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
 		removed = _registrar.forget(macOrExt);
-		if (_registrar.consumeDevicesChanged()) refreshDeviceSnapshot();
+		applyDeviceChange(_registrar.consumeDevicesChange());
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -302,14 +302,7 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 		// NOTIFYs land in _outbox and ride out with this pass (after unlock).
 		_blf.refresh();
 
-		// RFC 3261 §17: register any new outgoing INVITE in _outbox for retransmit.
-		// Scan after BLF NOTIFYs are added so the full outbox is covered; maybeTrack
-		// filters to INVITE requests only so NOTIFYs and responses are ignored.
-		for (const auto& [addr, msg] : _outbox)
-			_txLayer.maybeTrack(addr, msg);
-
-		localOutbox = std::move(_outbox);
-		_outbox.clear();
+		localOutbox = drainOutbox();
 
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
@@ -1265,10 +1258,6 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 	{
 		return;
 	}
-	// Attended-transfer re-INVITE ACKs.
-	if (handleTransferOk(data))
-		return;
-
 	auto session = getSession(data->getCallID());
 	if (session.has_value())
 	{
@@ -2837,14 +2826,7 @@ void RequestsHandler::tick()
 			_snapshot = std::move(nextSnapshot);
 		}
 
-		// RFC 3261 §17: register any new outgoing INVITEs for retransmit (mirrors
-		// the same scan in handle()). tick()-originated INVITE forks (park ring-back,
-		// hunt-group next-ring, CFNA redirect) need Timer A/B coverage too. (#70)
-		for (const auto& [addr, msg] : _outbox)
-			_txLayer.maybeTrack(addr, msg);
-
-		localOutbox = std::move(_outbox);
-		_outbox.clear();
+		localOutbox = drainOutbox();
 
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
@@ -3978,34 +3960,25 @@ std::vector<std::pair<std::string, std::string>> RequestsHandler::getPageZones()
 
 // ── Call parking (orbits 700–709): FSM lives in ParkOrbit.cpp ────────────────
 
-bool RequestsHandler::handleTransferOk(const std::shared_ptr<SipMessage>& data)
+std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> RequestsHandler::drainOutbox()
 {
-	const std::string cseq(data->getCSeq());
-	const std::string callID(data->getCallID());
-	if (cseq.find(SipMessageTypes::INVITE) == std::string::npos) return false;
+	// The single exit every deferred message passes through. RFC 3261 §17:
+	// register outgoing INVITEs for retransmit here, so Timer A/B coverage is
+	// structural rather than something each flush site re-implements — a new
+	// flush path would otherwise send one-shot UDP INVITEs that are simply lost
+	// on a dropped packet. maybeTrack filters to INVITE requests, so responses
+	// and NOTIFYs are ignored.
+	//
+	// Ordering matters (#70): the scan must run after everything that appends to
+	// _outbox during this pass (BLF NOTIFYs, tick()-originated forks — park
+	// ring-back, hunt-group next-ring, CFNA redirect), which is exactly why it
+	// belongs at the drain rather than at any individual enqueue.
+	for (const auto& [addr, msg] : _outbox)
+		_txLayer.maybeTrack(addr, msg);
 
-	auto it = std::find(_transferPendingAcks.begin(), _transferPendingAcks.end(), callID);
-	if (it == _transferPendingAcks.end()) return false;
-
-	const std::string activeIp = _localIp;
-	const std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
-	const sockaddr_in src = data->getSource();
-	char ipBuf[INET_ADDRSTRLEN]{};
-	inet_ntop(AF_INET, &src.sin_addr, ipBuf, sizeof(ipBuf));
-	const std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(src.sin_port));
-
-	std::ostringstream ss;
-	ss << "ACK sip:" << data->getToNumber() << "@" << destIpPort << " SIP/2.0\r\n"
-	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=z9hG4bK" << IDGen::GenerateID(12) << "\r\n"
-	   << "From: " << stripHeaderName(data->getFrom()) << "\r\n"
-	   << "To: " << stripHeaderName(data->getTo()) << "\r\n"
-	   << callID << "\r\n"
-	   << "CSeq: 100 ACK\r\n"
-	   << "Max-Forwards: 70\r\n"
-	   << "Content-Length: 0\r\n\r\n";
-	_outbox.emplace_back(data->getSource(), getMessageFromPool(ss.str(), data->getSource()));
-	_transferPendingAcks.erase(it);
-	return true;
+	auto drained = std::move(_outbox);
+	_outbox.clear();
+	return drained;
 }
 
 void RequestsHandler::refreshParkSnapshot()

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1786,9 +1786,13 @@ std::shared_ptr<SipMessage> RequestsHandler::buildReferNotify(const std::shared_
 	std::ostringstream ss;
 	ss << "NOTIFY sip:" << transferor->getNumber() << "@" << destIpPort << " SIP/2.0\r\n"
 	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=" << branch << "\r\n"
-	   << "From: " << refer->getTo() << "\r\n"
-	   << "To: " << refer->getFrom() << "\r\n"
-	   << "Call-ID: " << refer->getCallID() << "\r\n"
+	   // getTo()/getFrom()/getCallID() hand back the FULL header line, so the value
+	   // has to be unwrapped before it is re-stamped under a new name — otherwise
+	   // this NOTIFY goes out as "From: To: <sip:...>" and the transferor cannot
+	   // match it to the REFER dialog. Roles swap (RFC 3515 §2.4.5).
+	   << "From: " << stripHeaderName(refer->getTo()) << "\r\n"
+	   << "To: " << stripHeaderName(refer->getFrom()) << "\r\n"
+	   << "Call-ID: " << stripHeaderName(refer->getCallID()) << "\r\n"
 	   << "CSeq: 2 NOTIFY\r\n"
 	   << "Max-Forwards: 70\r\n"
 	   << "Event: refer\r\n"

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -15,6 +15,7 @@
 #include "PbxConfig.hpp"
 #include "PbxPersist.hpp"
 #include "SipHeaderUtil.hpp"
+#include "SipWireUtil.hpp"
 #include "AdminAuth.hpp"
 #include "SipDigest.hpp"
 #include "SipSecretStore.hpp"
@@ -1767,9 +1768,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildReferNotify(const std::shared_
 	// RFC 3515 §2.4.5 NOTIFY: Event: refer + message/sipfrag body reporting the
 	// transfer result. Sent within the REFER's dialog back to the transferor.
 	std::string activeIp = _localIp;
-	char ipBuf[INET_ADDRSTRLEN]{};
-	inet_ntop(AF_INET, &transferor->getAddress().sin_addr, ipBuf, sizeof(ipBuf));
-	std::string destIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(transferor->getAddress().sin_port));
+	std::string destIpPort = sipwire::addrToIpPort(transferor->getAddress());
 	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
 	std::string branch = "z9hG4bK" + IDGen::GenerateID(12);
 
@@ -2617,8 +2616,7 @@ bool RequestsHandler::sendMessageTo(const std::string& ext, const std::string& t
 		sent = true;
 
 		// Drain into a local vector and dispatch outside the lock (no IO under lock).
-		localOutbox = std::move(_outbox);
-		_outbox.clear();
+		localOutbox = drainOutbox();
 	}
 
 	for (auto& [addr, msg] : localOutbox)
@@ -2845,6 +2843,15 @@ void RequestsHandler::tick()
 
 		{
 			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+			// `devices` and `pageZones` are NOT rebuilt above: they are mirrored out
+			// of band (applyDeviceChange on a registry change, and the page-zone
+			// config path) because their sources only move on an admin action or a
+			// REGISTER. Carry them across the swap — assigning a fresh snapshot over
+			// the old one would blank both every tick, so the dashboard's adopted
+			// devices and paging zones would flash empty a second after any update
+			// and stay empty until the next change.
+			nextSnapshot.devices   = std::move(_snapshot.devices);
+			nextSnapshot.pageZones = std::move(_snapshot.pageZones);
 			_snapshot = std::move(nextSnapshot);
 		}
 

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -540,6 +540,9 @@ private:
 	// Mirror the Registrar's adopted-device registry into the dashboard snapshot.
 	// Caller holds _mutex; takes _snapshotMutex internally.
 	void refreshDeviceSnapshot();
+	// Mirror a Registrar registry change into the dashboard snapshot, taking the
+	// cheap in-place path for an online-flag-only change. Caller holds _mutex.
+	void applyDeviceChange(Registrar::Change change);
 
 	// NVS persistence for _forwards / _ringGroups / _pageZones. No-ops on host (the
 	// maps are the store); on ESP they read/write the "pbxcfg" NVS namespace.

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -316,9 +316,7 @@ private:
 	// Call parking / park-orbit: the orbit FSM lives in ParkOrbit (see
 	// ParkOrbit.hpp). Guarded by _mutex.
 	ParkOrbit _park{*this};
-	std::vector<std::string> _transferPendingAcks; // attended-transfer re-INVITE ACKs pending
 
-	bool handleTransferOk(const std::shared_ptr<SipMessage>& data);
 	// Mirror the park orbits into the dashboard snapshot. Caller holds _mutex;
 	// takes _snapshotMutex internally.
 	void refreshParkSnapshot();
@@ -460,6 +458,10 @@ private:
 	std::mutex _mutex;
 	OnHandledEvent _onHandled;
 	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> _outbox;
+	// Take everything queued this pass, registering outgoing INVITEs for
+	// retransmit on the way out. The one place messages leave _outbox — see the
+	// #70 ordering note on the definition. Caller holds _mutex.
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> drainOutbox();
 
 	std::string _serverIp;
 	std::string _localIp;   // resolved once at construction; avoids getPrimaryLocalIP() under _mutex

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -277,14 +277,15 @@ private:
 		return buildServerBye(destExt, destAddr, callId, fromHeader, toHeader);
 	}
 	void forEachSessionInvolving(std::string_view aor,
-		const std::function<void(const std::string&, const Session&)>& fn) const override
+		const std::function<void(const std::string&, const Session&, DialogRole)>& fn) const override
 	{
 		for (const auto& [callID, session] : _sessions)
 		{
 			if (!session) continue;
-			const bool isSrc  = session->getSrc()  && session->getSrc()->getNumber()  == aor;
-			const bool isDest = session->getDest() && session->getDest()->getNumber() == aor;
-			if (isSrc || isDest) fn(callID, *session);
+			if (session->getSrc() && session->getSrc()->getNumber() == aor)
+				fn(callID, *session, DialogRole::Caller);
+			else if (session->getDest() && session->getDest()->getNumber() == aor)
+				fn(callID, *session, DialogRole::Callee);
 		}
 	}
 	bool validAor(std::string_view s) const override

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -276,9 +276,16 @@ private:
 	{
 		return buildServerBye(destExt, destAddr, callId, fromHeader, toHeader);
 	}
-	const std::unordered_map<std::string, std::shared_ptr<Session>>& sessionsView() const override
+	void forEachSessionInvolving(std::string_view aor,
+		const std::function<void(const std::string&, const Session&)>& fn) const override
 	{
-		return _sessions;
+		for (const auto& [callID, session] : _sessions)
+		{
+			if (!session) continue;
+			const bool isSrc  = session->getSrc()  && session->getSrc()->getNumber()  == aor;
+			const bool isDest = session->getDest() && session->getDest()->getNumber() == aor;
+			if (isSrc || isDest) fn(callID, *session);
+		}
 	}
 	bool validAor(std::string_view s) const override
 	{

--- a/src/SIP/SipMessage.cpp
+++ b/src/SIP/SipMessage.cpp
@@ -461,6 +461,12 @@ std::string_view SipMessage::getAuthorization() const
 	return idx == std::string::npos ? std::string_view{} : std::string_view(_headerLines[idx]);
 }
 
+std::string_view SipMessage::getEvent() const
+{
+	size_t idx = findHeaderIndex("event", "o");
+	return idx == std::string::npos ? std::string_view{} : std::string_view(_headerLines[idx]);
+}
+
 std::string_view SipMessage::extractNumber(std::string_view header) const
 {
 	auto sipPos = header.find("sip:");

--- a/src/SIP/SipMessage.hpp
+++ b/src/SIP/SipMessage.hpp
@@ -85,6 +85,10 @@ public:
 	// Full `Authorization:` request-header line (or empty if absent). The value
 	// is fed to SipDigest::parseAuthorization, which tolerates the header name.
 	std::string_view getAuthorization() const;
+	// Full `Event:` header line (RFC 6665), compact form `o:`. Empty when absent.
+	// The subscription machinery wants the package name only — strip the header
+	// name with siphdr::stripHeaderName and cut at the first ';' parameter.
+	std::string_view getEvent() const;
 	sockaddr_in getSource() const;
 	std::optional<PocketDial::SipStatusInfo> getStatusInfo() const
 	{

--- a/src/SIP/SipWireUtil.hpp
+++ b/src/SIP/SipWireUtil.hpp
@@ -1,0 +1,49 @@
+#ifndef SIP_WIRE_UTIL_HPP
+#define SIP_WIRE_UTIL_HPP
+
+// Shared request-building plumbing for the decomposed SIP state machines
+// (ParkOrbit, RegisterBeeper, BlfSubscriptions, ...). Each of them mints raw
+// requests by hand and needs the same two pieces: an "ip:port" authority string
+// and the minimal held offer. Kept out of SipHeaderUtil.hpp deliberately —
+// that header is pure string work and must stay free of socket includes.
+
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+#include <lwip/sockets.h>
+#elif defined(__linux__)
+#include <arpa/inet.h>
+#elif defined _WIN32 || defined _WIN64
+#include <WinSock2.h>
+#include <ws2tcpip.h>   // inet_ntop / INET_ADDRSTRLEN live here, not in WinSock2.h
+#endif
+
+#include <string>
+
+namespace sipwire
+{
+	// "a.b.c.d:port" for a v4 peer — the authority the machines stamp into a
+	// request-URI and into the Via/Contact host of server-minted requests.
+	inline std::string addrToIpPort(const sockaddr_in& addr)
+	{
+		char ipBuf[INET_ADDRSTRLEN]{};
+		inet_ntop(AF_INET, &addr.sin_addr, ipBuf, sizeof(ipBuf));
+		return std::string(ipBuf) + ":" + std::to_string(ntohs(addr.sin_port));
+	}
+
+	// Minimal, well-formed a=inactive offer: the server sources no RTP, so the
+	// far end holds the stream. Used by the park hold answer and by the register
+	// beep INVITE — they must not drift apart, or a phone that tolerates one
+	// would choke on the other.
+	inline std::string makeInactiveHoldSdp(const std::string& localIp)
+	{
+		return
+			"v=0\r\n"
+			"o=- 0 0 IN IP4 " + localIp + "\r\n"
+			"s=pocket-dial\r\n"
+			"c=IN IP4 " + localIp + "\r\n"
+			"t=0 0\r\n"
+			"m=audio 9 RTP/AVP 0\r\n"
+			"a=inactive\r\n";
+	}
+}
+
+#endif

--- a/src/SIP/TransactionLayer.cpp
+++ b/src/SIP/TransactionLayer.cpp
@@ -132,8 +132,9 @@ void TransactionLayer::sweep(std::chrono::steady_clock::time_point now)
 		{
 			if (tx.msgLen > 0 && !tx.msgTruncated)
 			{
-				std::string retxStr(tx.msg, tx.msgLen);
-				auto retx = _env.messageFromPool(retxStr, tx.peer);
+				// messageFromPool takes its raw string by value — hand it the copy
+				// straight off the transaction buffer instead of copying twice.
+				auto retx = _env.messageFromPool(std::string(tx.msg, tx.msgLen), tx.peer);
 				if (retx) _env.enqueue(tx.peer, std::move(retx));
 			}
 			tx.currentIntervalMs *= 2;

--- a/tests/BlfSubscriptions_test.cpp
+++ b/tests/BlfSubscriptions_test.cpp
@@ -9,14 +9,6 @@
 
 namespace
 {
-	int countOf(const std::string& hay, const std::string& needle)
-	{
-		int n = 0;
-		for (size_t p = hay.find(needle); p != std::string::npos; p = hay.find(needle, p + needle.size()))
-			++n;
-		return n;
-	}
-
 	std::shared_ptr<SipMessage> subscribe(const std::string& watcher, const std::string& target,
 		const std::string& callId, const std::string& eventHdr, int expires,
 		const sockaddr_in& src)
@@ -50,9 +42,9 @@ TEST(BlfSubscriptions, AcceptsDialogSubscribeAndNotifiesWithSwappedDialogRoles)
 	const std::string notify = env.sentRaw(1);
 	EXPECT_EQ(notify.rfind("NOTIFY sip:192.168.1.60:5060", 0), 0u) << notify;
 	// Exactly one From/To/Call-ID, each a bare value under the right name.
-	EXPECT_EQ(countOf(notify, "From:"), 1) << notify;
-	EXPECT_EQ(countOf(notify, "To:"), 1) << notify;
-	EXPECT_EQ(countOf(notify, "Call-ID:"), 1) << notify;
+	EXPECT_EQ(FakePbxEnv::countOf(notify, "From:"), 1) << notify;
+	EXPECT_EQ(FakePbxEnv::countOf(notify, "To:"), 1) << notify;
+	EXPECT_EQ(FakePbxEnv::countOf(notify, "Call-ID:"), 1) << notify;
 	EXPECT_EQ(notify.find("From: To:"), std::string::npos) << notify;
 	EXPECT_EQ(notify.find("To: From:"), std::string::npos) << notify;
 	// RFC 6665 §4.4.1: roles swap — our To (with our tag) becomes the NOTIFY From.

--- a/tests/BlfSubscriptions_test.cpp
+++ b/tests/BlfSubscriptions_test.cpp
@@ -1,0 +1,135 @@
+// Wire-level tests for the BLF/dialog-info subscription machine
+// (src/SIP/BlfSubscriptions.cpp): the event-package gate, the 202 Accepted, and
+// the header shape of the NOTIFY it mints inside the subscription dialog.
+
+#include <gtest/gtest.h>
+
+#include "BlfSubscriptions.hpp"
+#include "FakePbxEnv.hpp"
+
+namespace
+{
+	int countOf(const std::string& hay, const std::string& needle)
+	{
+		int n = 0;
+		for (size_t p = hay.find(needle); p != std::string::npos; p = hay.find(needle, p + needle.size()))
+			++n;
+		return n;
+	}
+
+	std::shared_ptr<SipMessage> subscribe(const std::string& watcher, const std::string& target,
+		const std::string& callId, const std::string& eventHdr, int expires,
+		const sockaddr_in& src)
+	{
+		std::string raw =
+			"SUBSCRIBE sip:" + target + "@192.168.1.10 SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.1.60:5060;branch=z9hG4bKwatch\r\n"
+			"From: <sip:" + watcher + "@192.168.1.10>;tag=watchertag\r\n"
+			"To: <sip:" + target + "@192.168.1.10>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 SUBSCRIBE\r\n";
+		if (!eventHdr.empty()) raw += eventHdr + "\r\n";
+		raw += "Expires: " + std::to_string(expires) + "\r\n"
+			   "Content-Length: 0\r\n\r\n";
+		return std::make_shared<SipMessage>(raw, src);
+	}
+}
+
+TEST(BlfSubscriptions, AcceptsDialogSubscribeAndNotifiesWithSwappedDialogRoles)
+{
+	FakePbxEnv env;
+	BlfSubscriptions blf(env);
+	const sockaddr_in watcherAddr = FakePbxEnv::addr("192.168.1.60", 5060);
+
+	blf.onSubscribe(subscribe("200", "101", "watch-1@192.168.1.60", "Event: dialog", 3600,
+		watcherAddr));
+
+	ASSERT_EQ(env.sent.size(), 2u);          // 202 Accepted, then the initial NOTIFY
+	EXPECT_NE(env.sentRaw(0).find("202 Accepted"), std::string::npos) << env.sentRaw(0);
+
+	const std::string notify = env.sentRaw(1);
+	EXPECT_EQ(notify.rfind("NOTIFY sip:192.168.1.60:5060", 0), 0u) << notify;
+	// Exactly one From/To/Call-ID, each a bare value under the right name.
+	EXPECT_EQ(countOf(notify, "From:"), 1) << notify;
+	EXPECT_EQ(countOf(notify, "To:"), 1) << notify;
+	EXPECT_EQ(countOf(notify, "Call-ID:"), 1) << notify;
+	EXPECT_EQ(notify.find("From: To:"), std::string::npos) << notify;
+	EXPECT_EQ(notify.find("To: From:"), std::string::npos) << notify;
+	// RFC 6665 §4.4.1: roles swap — our To (with our tag) becomes the NOTIFY From.
+	EXPECT_NE(notify.find("From: <sip:101@192.168.1.10>;tag="), std::string::npos) << notify;
+	EXPECT_NE(notify.find("To: <sip:200@192.168.1.10>;tag=watchertag"), std::string::npos)
+		<< notify;
+	EXPECT_NE(notify.find("Call-ID: watch-1@192.168.1.60\r\n"), std::string::npos) << notify;
+	EXPECT_NE(notify.find("Subscription-State: active;expires="), std::string::npos) << notify;
+	// Idle target: dialog-info document carries no <dialog> element.
+	EXPECT_NE(notify.find("application/dialog-info+xml"), std::string::npos) << notify;
+	EXPECT_EQ(notify.find("<dialog "), std::string::npos) << notify;
+}
+
+// Only the RFC 4235 "dialog" package is implemented; anything else is 489.
+TEST(BlfSubscriptions, RejectsUnsupportedEventPackage)
+{
+	FakePbxEnv env;
+	BlfSubscriptions blf(env);
+	const sockaddr_in watcherAddr = FakePbxEnv::addr("192.168.1.60", 5060);
+
+	blf.onSubscribe(subscribe("200", "101", "watch-2@192.168.1.60", "Event: presence", 3600,
+		watcherAddr));
+
+	ASSERT_EQ(env.sent.size(), 1u);
+	EXPECT_NE(env.sentRaw(0).find("Bad Event"), std::string::npos) << env.sentRaw(0);
+	EXPECT_NE(env.sentRaw(0).find("Allow-Events: dialog"), std::string::npos) << env.sentRaw(0);
+}
+
+// The compact form "o:" is the Event header (RFC 6665 §8.2.1), and an Event
+// header carrying an ;id= parameter still names the dialog package.
+TEST(BlfSubscriptions, AcceptsCompactEventHeaderAndIgnoresParameters)
+{
+	FakePbxEnv env;
+	BlfSubscriptions blf(env);
+	const sockaddr_in watcherAddr = FakePbxEnv::addr("192.168.1.60", 5060);
+
+	blf.onSubscribe(subscribe("200", "101", "watch-3@192.168.1.60", "o: dialog;id=7", 3600,
+		watcherAddr));
+
+	ASSERT_EQ(env.sent.size(), 2u) << env.sentRaw(0);
+	EXPECT_NE(env.sentRaw(0).find("202 Accepted"), std::string::npos) << env.sentRaw(0);
+}
+
+// A SUBSCRIBE with no Event header at all must not be treated as "dialog" — and
+// must not pick up the SDP origin line, which is also named "o".
+TEST(BlfSubscriptions, MissingEventHeaderIsRejected)
+{
+	FakePbxEnv env;
+	BlfSubscriptions blf(env);
+	const sockaddr_in watcherAddr = FakePbxEnv::addr("192.168.1.60", 5060);
+
+	blf.onSubscribe(subscribe("200", "101", "watch-4@192.168.1.60", "", 3600, watcherAddr));
+
+	ASSERT_EQ(env.sent.size(), 1u);
+	EXPECT_NE(env.sentRaw(0).find("Bad Event"), std::string::npos) << env.sentRaw(0);
+}
+
+// A watched extension in a connected call lights the lamp: state=confirmed.
+TEST(BlfSubscriptions, ConfirmedCallOnWatchedTargetNotifiesConfirmed)
+{
+	FakePbxEnv env;
+	BlfSubscriptions blf(env);
+	const sockaddr_in watcherAddr = FakePbxEnv::addr("192.168.1.60", 5060);
+	const sockaddr_in phoneAddr   = FakePbxEnv::addr("192.168.1.50", 5060);
+
+	auto caller = std::make_shared<SipClient>("101", phoneAddr);
+	auto callee = std::make_shared<SipClient>("102", phoneAddr);
+	auto session = std::make_shared<Session>("call-abc", caller);
+	session->setDest(callee);
+	session->setState(Session::State::Connected);
+	env.sessions.emplace("call-abc", session);
+
+	blf.onSubscribe(subscribe("200", "101", "watch-5@192.168.1.60", "Event: dialog", 3600,
+		watcherAddr));
+
+	ASSERT_EQ(env.sent.size(), 2u);
+	const std::string notify = env.sentRaw(1);
+	EXPECT_NE(notify.find("<state>confirmed</state>"), std::string::npos) << notify;
+	EXPECT_NE(notify.find("direction=\"initiator\""), std::string::npos) << notify;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,11 @@ add_executable(sip_parser_tests
     # Phase 0 of docs/PLAN_ADMIN_HTTP_ONLY.md: dark-by-default HTTP admin plane
     # test contract. Pulls in HttpServer.cpp for the first time in this target.
     AdminHttpGate_test.cpp
+    # Wire-level coverage for the decomposed SIP state machines, driven through a
+    # FakePbxEnv that records what each machine enqueues. The park/beep/BLF paths
+    # build their requests by hand, so only a byte-level assertion catches header
+    # defects like a doubled "Call-ID:" in the park retrieve re-INVITE.
+    ParkOrbit_test.cpp
     # SIP digest-auth primitives + per-extension HA1 secret store. Both are
     # host-compilable: SipDigest vendors a portable MD5 (no mbedTLS) and
     # SipSecretStore uses an in-memory map under !ESP_PLATFORM (no NVS).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(sip_parser_tests
     # build their requests by hand, so only a byte-level assertion catches header
     # defects like a doubled "Call-ID:" in the park retrieve re-INVITE.
     ParkOrbit_test.cpp
+    RegisterBeeper_test.cpp
     # SIP digest-auth primitives + per-extension HA1 secret store. Both are
     # host-compilable: SipDigest vendors a portable MD5 (no mbedTLS) and
     # SipSecretStore uses an in-memory map under !ESP_PLATFORM (no NVS).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(sip_parser_tests
     # defects like a doubled "Call-ID:" in the park retrieve re-INVITE.
     ParkOrbit_test.cpp
     RegisterBeeper_test.cpp
+    BlfSubscriptions_test.cpp
     # SIP digest-auth primitives + per-extension HA1 secret store. Both are
     # host-compilable: SipDigest vendors a portable MD5 (no mbedTLS) and
     # SipSecretStore uses an in-memory map under !ESP_PLATFORM (no NVS).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(sip_parser_tests
     ParkOrbit_test.cpp
     RegisterBeeper_test.cpp
     BlfSubscriptions_test.cpp
+    DashboardSnapshot_test.cpp
     # SIP digest-auth primitives + per-extension HA1 secret store. Both are
     # host-compilable: SipDigest vendors a portable MD5 (no mbedTLS) and
     # SipSecretStore uses an in-memory map under !ESP_PLATFORM (no NVS).

--- a/tests/DashboardSnapshot_test.cpp
+++ b/tests/DashboardSnapshot_test.cpp
@@ -1,0 +1,74 @@
+// Regression coverage for the dashboard snapshot swap in RequestsHandler::tick().
+//
+// The snapshot has two kinds of field. Most are rebuilt from scratch every tick
+// (clients, sessions, cdr, dnd, forwards, ringGroups, parkedCalls). Two are
+// mirrored out of band because their sources only move on an admin action or a
+// REGISTER: `pageZones` (setPageZone) and `devices` (the Registrar registry).
+// tick() assembles a fresh RegistrarSnapshot and move-assigns it over the live
+// one, so the out-of-band fields have to be carried across that swap or they are
+// blanked once a second.
+
+#include <gtest/gtest.h>
+
+#include "RequestsHandler.hpp"
+
+namespace
+{
+	RequestsHandler makeHandler()
+	{
+		return RequestsHandler("127.0.0.1", 5060,
+			[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	}
+}
+
+// A configured paging zone must still be on the dashboard after a tick.
+TEST(DashboardSnapshot, TickPreservesConfiguredPageZones)
+{
+	auto handler = makeHandler();
+
+	handler.setPageZone("980", "101,102,103");
+	ASSERT_EQ(handler.getPageZones().size(), 1u);
+
+	handler.tick();
+
+	auto zones = handler.getPageZones();
+	ASSERT_EQ(zones.size(), 1u) << "tick() blanked the out-of-band pageZones mirror";
+	EXPECT_EQ(zones[0].first, "980");
+	EXPECT_EQ(zones[0].second, "101,102,103");
+
+	// Still there after several more ticks — the swap must not erode it.
+	handler.tick();
+	handler.tick();
+	EXPECT_EQ(handler.getPageZones().size(), 1u);
+}
+
+// Clearing a zone must survive a tick too — the carry-over must not resurrect
+// state that was deliberately removed.
+TEST(DashboardSnapshot, TickPreservesPageZoneRemoval)
+{
+	auto handler = makeHandler();
+
+	handler.setPageZone("981", "201,202");
+	ASSERT_EQ(handler.getPageZones().size(), 1u);
+
+	handler.setPageZone("981", "");          // empty membership deletes the zone
+	ASSERT_TRUE(handler.getPageZones().empty());
+
+	handler.tick();
+	EXPECT_TRUE(handler.getPageZones().empty());
+}
+
+// The adopted-device mirror rides the same carry-over. It cannot be populated
+// on host (adoption needs an ARP lookup, which is a nullopt stub off-device), so
+// this pins the reachable half: an empty registry stays empty and tick() does
+// not fault on the moved-from vectors.
+TEST(DashboardSnapshot, TickKeepsDeviceMirrorConsistent)
+{
+	auto handler = makeHandler();
+
+	EXPECT_TRUE(handler.getAdoptedDevices().empty());
+	handler.tick();
+	EXPECT_TRUE(handler.getAdoptedDevices().empty());
+	handler.tick();
+	EXPECT_TRUE(handler.getAdoptedDevices().empty());
+}

--- a/tests/FakePbxEnv.hpp
+++ b/tests/FakePbxEnv.hpp
@@ -1,0 +1,150 @@
+#ifndef FAKE_PBX_ENV_HPP
+#define FAKE_PBX_ENV_HPP
+
+// Minimal in-memory PbxEnv for host tests of the decomposed SIP state machines
+// (ParkOrbit, RegisterBeeper, BlfSubscriptions). It records everything the
+// machine under test enqueues so a test can assert on the exact bytes that would
+// have gone out on the wire — the layer the 131-test suite never covered, which
+// is how a doubled "Call-ID: Call-ID:" survived in the park re-INVITE.
+
+#if defined(__linux__)
+#include <arpa/inet.h>
+#elif defined _WIN32 || defined _WIN64
+#include <ws2tcpip.h>
+#endif
+
+#include <cctype>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "PbxEnv.hpp"
+#include "Session.hpp"
+#include "SipClient.hpp"
+#include "SipHeaderUtil.hpp"
+#include "SipMessage.hpp"
+
+class FakePbxEnv : public PbxEnv
+{
+public:
+	struct Sent
+	{
+		sockaddr_in to{};
+		std::string raw;
+	};
+
+	std::vector<Sent>        sent;
+	std::vector<std::string> logs;
+
+	// Registered extensions findRegistered() resolves against.
+	std::unordered_map<std::string, std::shared_ptr<SipClient>> registered;
+	std::unordered_map<std::string, std::shared_ptr<Session>>   sessions;
+
+	// Set false to simulate a drained session pool (the 503 guard paths).
+	bool sessionPoolAvailable = true;
+
+	static sockaddr_in addr(const char* ip, uint16_t port)
+	{
+		sockaddr_in a{};
+		a.sin_family = AF_INET;
+		a.sin_port   = htons(port);
+		::inet_pton(AF_INET, ip, &a.sin_addr);
+		return a;
+	}
+
+	// Raw text of the nth enqueued message (empty when out of range).
+	std::string sentRaw(std::size_t i) const
+	{
+		return i < sent.size() ? sent[i].raw : std::string{};
+	}
+
+	// ── PbxEnv ───────────────────────────────────────────────────────────────
+	void enqueue(const sockaddr_in& to, std::shared_ptr<SipMessage> msg) override
+	{
+		sent.push_back(Sent{to, msg ? msg->toString() : std::string{}});
+	}
+	std::shared_ptr<SipMessage> messageFromPool(std::string raw, sockaddr_in src) override
+	{
+		return std::make_shared<SipMessage>(raw, src);
+	}
+	void log(std::string msg, bool /*isError*/ = false) override
+	{
+		logs.push_back(std::move(msg));
+	}
+	const std::string& localIp() const override { return _localIp; }
+	int serverPort() const override { return 5060; }
+
+	std::shared_ptr<SipClient> findRegistered(std::string_view number) override
+	{
+		auto it = registered.find(std::string(number));
+		return it == registered.end() ? nullptr : it->second;
+	}
+	std::shared_ptr<SipClient> allocVirtualPeer(std::string number, const sockaddr_in& a) override
+	{
+		return std::make_shared<SipClient>(std::move(number), a);
+	}
+	std::shared_ptr<Session> allocSession(const std::string& callID,
+		const std::shared_ptr<SipClient>& src) override
+	{
+		if (!sessionPoolAvailable) return nullptr;
+		return std::make_shared<Session>(callID, src);
+	}
+	void insertSession(const std::string& callID, const std::shared_ptr<Session>& session) override
+	{
+		sessions.emplace(callID, session);
+	}
+	std::shared_ptr<Session> findSession(std::string_view callID) override
+	{
+		auto it = sessions.find(std::string(callID));
+		return it == sessions.end() ? nullptr : it->second;
+	}
+	std::string contactFor(std::string_view number) const override
+	{
+		return "<sip:" + std::string(number) + "@" + _localIp + ":5060>";
+	}
+	std::shared_ptr<SipMessage> serverBye(const std::string& destExt,
+		const sockaddr_in& destAddr, const std::string& callId,
+		const std::string& fromHeader, const std::string& toHeader) override
+	{
+		// Mirrors RequestsHandler::buildServerBye: strips any header-name prefix
+		// off the three dialog fields and emits CSeq 2 BYE.
+		std::string raw =
+			"BYE sip:" + destExt + "@" + _localIp + " SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + _localIp + ":5060;branch=z9hG4bKfake\r\n"
+			"From: " + siphdr::stripHeaderName(fromHeader) + "\r\n"
+			"To: " + siphdr::stripHeaderName(toHeader) + "\r\n"
+			"Call-ID: " + siphdr::stripHeaderName(callId) + "\r\n"
+			"CSeq: 2 BYE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return std::make_shared<SipMessage>(raw, destAddr);
+	}
+	const std::unordered_map<std::string, std::shared_ptr<Session>>& sessionsView() const override
+	{
+		return sessions;
+	}
+	bool validAor(std::string_view s) const override
+	{
+		if (s.empty() || s.size() > 32) return false;
+		for (char c : s)
+		{
+			if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '.' || c == '-' || c == '_'))
+				return false;
+		}
+		return true;
+	}
+	int requestedExpires(const std::shared_ptr<SipMessage>& msg) const override
+	{
+		const std::string raw = msg ? msg->toString() : std::string{};
+		auto p = raw.find("Expires:");
+		if (p == std::string::npos) return 3600;
+		return std::atoi(raw.c_str() + p + 8);
+	}
+
+private:
+	std::string _localIp = "192.168.1.10";
+};
+
+#endif

--- a/tests/FakePbxEnv.hpp
+++ b/tests/FakePbxEnv.hpp
@@ -121,9 +121,16 @@ public:
 			"Content-Length: 0\r\n\r\n";
 		return std::make_shared<SipMessage>(raw, destAddr);
 	}
-	const std::unordered_map<std::string, std::shared_ptr<Session>>& sessionsView() const override
+	void forEachSessionInvolving(std::string_view aor,
+		const std::function<void(const std::string&, const Session&)>& fn) const override
 	{
-		return sessions;
+		for (const auto& [callID, session] : sessions)
+		{
+			if (!session) continue;
+			const bool isSrc  = session->getSrc()  && session->getSrc()->getNumber()  == aor;
+			const bool isDest = session->getDest() && session->getDest()->getNumber() == aor;
+			if (isSrc || isDest) fn(callID, *session);
+		}
 	}
 	bool validAor(std::string_view s) const override
 	{

--- a/tests/FakePbxEnv.hpp
+++ b/tests/FakePbxEnv.hpp
@@ -35,8 +35,21 @@ public:
 		std::string raw;
 	};
 
+	// One recorded serverBye() call. Asserting on these rather than on the bytes
+	// the fake minted is what actually pins the delegation: the real builder is
+	// RequestsHandler::buildServerBye, which is private and not linked into this
+	// target, so any BYE text here is the fake's own and proves nothing about it.
+	struct ByeCall
+	{
+		std::string destExt;
+		std::string callId;
+		std::string fromHeader;
+		std::string toHeader;
+	};
+
 	std::vector<Sent>        sent;
 	std::vector<std::string> logs;
+	std::vector<ByeCall>     byeCalls;
 
 	// Registered extensions findRegistered() resolves against.
 	std::unordered_map<std::string, std::shared_ptr<SipClient>> registered;
@@ -58,6 +71,19 @@ public:
 	std::string sentRaw(std::size_t i) const
 	{
 		return i < sent.size() ? sent[i].raw : std::string{};
+	}
+
+	// Count non-overlapping occurrences of `needle` in `hay` — the header-shape
+	// assertion every machine test needs ("exactly one To: line").
+	static int countOf(const std::string& hay, const std::string& needle)
+	{
+		int n = 0;
+		for (size_t p = hay.find(needle); p != std::string::npos;
+			p = hay.find(needle, p + needle.size()))
+		{
+			++n;
+		}
+		return n;
 	}
 
 	// ── PbxEnv ───────────────────────────────────────────────────────────────
@@ -108,6 +134,7 @@ public:
 		const sockaddr_in& destAddr, const std::string& callId,
 		const std::string& fromHeader, const std::string& toHeader) override
 	{
+		byeCalls.push_back(ByeCall{destExt, callId, fromHeader, toHeader});
 		// Mirrors RequestsHandler::buildServerBye: strips any header-name prefix
 		// off the three dialog fields and emits CSeq 2 BYE.
 		std::string raw =
@@ -122,14 +149,15 @@ public:
 		return std::make_shared<SipMessage>(raw, destAddr);
 	}
 	void forEachSessionInvolving(std::string_view aor,
-		const std::function<void(const std::string&, const Session&)>& fn) const override
+		const std::function<void(const std::string&, const Session&, DialogRole)>& fn) const override
 	{
 		for (const auto& [callID, session] : sessions)
 		{
 			if (!session) continue;
-			const bool isSrc  = session->getSrc()  && session->getSrc()->getNumber()  == aor;
-			const bool isDest = session->getDest() && session->getDest()->getNumber() == aor;
-			if (isSrc || isDest) fn(callID, *session);
+			if (session->getSrc() && session->getSrc()->getNumber() == aor)
+				fn(callID, *session, DialogRole::Caller);
+			else if (session->getDest() && session->getDest()->getNumber() == aor)
+				fn(callID, *session, DialogRole::Callee);
 		}
 	}
 	bool validAor(std::string_view s) const override

--- a/tests/ParkOrbit_test.cpp
+++ b/tests/ParkOrbit_test.cpp
@@ -33,15 +33,6 @@ namespace
 			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
 		return std::make_shared<SipMessage>(raw, src);
 	}
-
-	// Count non-overlapping occurrences of `needle` in `hay`.
-	int countOf(const std::string& hay, const std::string& needle)
-	{
-		int n = 0;
-		for (size_t p = hay.find(needle); p != std::string::npos; p = hay.find(needle, p + needle.size()))
-			++n;
-		return n;
-	}
 }
 
 // Park a call on 700, then retrieve it from a second extension. The retrieve
@@ -70,7 +61,7 @@ TEST(ParkOrbit, RetrieveReinviteCarriesSingleCallIdHeader)
 
 	const std::string reinvite = env.sentRaw(2);
 	EXPECT_EQ(reinvite.rfind("INVITE sip:101@", 0), 0u) << reinvite;
-	EXPECT_EQ(countOf(reinvite, "Call-ID:"), 1) << reinvite;
+	EXPECT_EQ(FakePbxEnv::countOf(reinvite, "Call-ID:"), 1) << reinvite;
 	EXPECT_NE(reinvite.find("Call-ID: parked-call-1@192.168.1.50\r\n"), std::string::npos)
 		<< reinvite;
 	// The re-INVITE must offer the retriever's SDP so media re-points at them.
@@ -108,9 +99,9 @@ TEST(ParkOrbit, ReinviteOkIsAckedWithSingleCallIdHeader)
 
 	const std::string ack = env.sentRaw(before);
 	EXPECT_EQ(ack.rfind("ACK sip:", 0), 0u) << ack;
-	EXPECT_EQ(countOf(ack, "Call-ID:"), 1) << ack;
-	EXPECT_EQ(countOf(ack, "From:"), 1) << ack;
-	EXPECT_EQ(countOf(ack, "To:"), 1) << ack;
+	EXPECT_EQ(FakePbxEnv::countOf(ack, "Call-ID:"), 1) << ack;
+	EXPECT_EQ(FakePbxEnv::countOf(ack, "From:"), 1) << ack;
+	EXPECT_EQ(FakePbxEnv::countOf(ack, "To:"), 1) << ack;
 }
 
 // The dashboard mirror is driven by a dirty flag rather than by each call site

--- a/tests/ParkOrbit_test.cpp
+++ b/tests/ParkOrbit_test.cpp
@@ -1,0 +1,140 @@
+// Wire-level tests for the park-orbit state machine (src/SIP/ParkOrbit.cpp).
+// The park paths had no host coverage at all, which is how a doubled Call-ID
+// header survived in the retrieve re-INVITE from the pre-decomposition monolith.
+
+#include <gtest/gtest.h>
+
+#include "FakePbxEnv.hpp"
+#include "ParkOrbit.hpp"
+
+namespace
+{
+	// `mediaIp` is the caller's own IP: it lands in the SDP c= line, which is what
+	// the retrieve path swaps between the two legs.
+	std::shared_ptr<SipMessage> inviteTo(const std::string& orbit, const std::string& fromExt,
+		const std::string& callId, const sockaddr_in& src, const std::string& mediaIp)
+	{
+		const std::string body =
+			"v=0\r\n"
+			"o=- 1 1 IN IP4 " + mediaIp + "\r\n"
+			"s=call\r\n"
+			"c=IN IP4 " + mediaIp + "\r\n"
+			"t=0 0\r\n"
+			"m=audio 4000 RTP/AVP 0\r\n";
+		const std::string raw =
+			"INVITE sip:" + orbit + "@192.168.1.10 SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + mediaIp + ":5060;branch=z9hG4bKcaller\r\n"
+			"From: <sip:" + fromExt + "@192.168.1.10>;tag=callertag\r\n"
+			"To: <sip:" + orbit + "@192.168.1.10>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Contact: <sip:" + fromExt + "@" + mediaIp + ":5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		return std::make_shared<SipMessage>(raw, src);
+	}
+
+	// Count non-overlapping occurrences of `needle` in `hay`.
+	int countOf(const std::string& hay, const std::string& needle)
+	{
+		int n = 0;
+		for (size_t p = hay.find(needle); p != std::string::npos; p = hay.find(needle, p + needle.size()))
+			++n;
+		return n;
+	}
+}
+
+// Park a call on 700, then retrieve it from a second extension. The retrieve
+// sends a re-INVITE to the parked party; its Call-ID must be the parked dialog's
+// Call-ID exactly once — "Call-ID: Call-ID: x@host" is what the phone rejects.
+TEST(ParkOrbit, RetrieveReinviteCarriesSingleCallIdHeader)
+{
+	FakePbxEnv env;
+	ParkOrbit park(env);
+
+	const sockaddr_in parkedAddr    = FakePbxEnv::addr("192.168.1.50", 5060);
+	const sockaddr_in retrieverAddr = FakePbxEnv::addr("192.168.1.51", 5060);
+
+	auto parkedClient    = std::make_shared<SipClient>("101", parkedAddr);
+	auto retrieverClient = std::make_shared<SipClient>("102", retrieverAddr);
+
+	ASSERT_EQ(park.orbitIndex("700"), 0);
+
+	park.onInvite(inviteTo("700", "101", "parked-call-1@192.168.1.50", parkedAddr, "192.168.1.50"),
+		parkedClient, 0);
+	ASSERT_EQ(env.sent.size(), 1u);           // 200 OK (hold) to the parked party
+
+	park.onInvite(inviteTo("700", "102", "retrieve-call-1@192.168.1.51", retrieverAddr, "192.168.1.51"),
+		retrieverClient, 0);
+	ASSERT_EQ(env.sent.size(), 3u);           // + 200 OK to retriever, + re-INVITE
+
+	const std::string reinvite = env.sentRaw(2);
+	EXPECT_EQ(reinvite.rfind("INVITE sip:101@", 0), 0u) << reinvite;
+	EXPECT_EQ(countOf(reinvite, "Call-ID:"), 1) << reinvite;
+	EXPECT_NE(reinvite.find("Call-ID: parked-call-1@192.168.1.50\r\n"), std::string::npos)
+		<< reinvite;
+	// The re-INVITE must offer the retriever's SDP so media re-points at them.
+	EXPECT_NE(reinvite.find("c=IN IP4 192.168.1.51"), std::string::npos) << reinvite;
+}
+
+// The parked party's 200 OK to that re-INVITE is ACKed, and the ACK likewise
+// carries exactly one Call-ID header line.
+TEST(ParkOrbit, ReinviteOkIsAckedWithSingleCallIdHeader)
+{
+	FakePbxEnv env;
+	ParkOrbit park(env);
+
+	const sockaddr_in parkedAddr    = FakePbxEnv::addr("192.168.1.50", 5060);
+	const sockaddr_in retrieverAddr = FakePbxEnv::addr("192.168.1.51", 5060);
+
+	park.onInvite(inviteTo("700", "101", "parked-call-2@192.168.1.50", parkedAddr, "192.168.1.50"),
+		std::make_shared<SipClient>("101", parkedAddr), 0);
+	park.onInvite(inviteTo("700", "102", "retrieve-call-2@192.168.1.51", retrieverAddr, "192.168.1.51"),
+		std::make_shared<SipClient>("102", retrieverAddr), 0);
+	const std::size_t before = env.sent.size();
+
+	const std::string okRaw =
+		"SIP/2.0 200 OK\r\n"
+		"Via: SIP/2.0/UDP 192.168.1.10:5060;branch=z9hG4bKpark\r\n"
+		"From: <sip:700@192.168.1.10:5060>;tag=servertag\r\n"
+		"To: <sip:101@192.168.1.10>;tag=callertag\r\n"
+		"Call-ID: parked-call-2@192.168.1.50\r\n"
+		"CSeq: 2 INVITE\r\n"
+		"Content-Length: 0\r\n\r\n";
+	auto ok = std::make_shared<SipMessage>(okRaw, parkedAddr);
+
+	EXPECT_TRUE(park.handleOk(ok));
+	ASSERT_EQ(env.sent.size(), before + 1);
+
+	const std::string ack = env.sentRaw(before);
+	EXPECT_EQ(ack.rfind("ACK sip:", 0), 0u) << ack;
+	EXPECT_EQ(countOf(ack, "Call-ID:"), 1) << ack;
+	EXPECT_EQ(countOf(ack, "From:"), 1) << ack;
+	EXPECT_EQ(countOf(ack, "To:"), 1) << ack;
+}
+
+// A retrieve that cannot get a session must 503 the retriever and leave the
+// orbit occupied rather than half-tearing-down the parked leg (#71).
+TEST(ParkOrbit, RetrieveWithExhaustedSessionPoolLeavesSlotParked)
+{
+	FakePbxEnv env;
+	ParkOrbit park(env);
+
+	const sockaddr_in parkedAddr    = FakePbxEnv::addr("192.168.1.50", 5060);
+	const sockaddr_in retrieverAddr = FakePbxEnv::addr("192.168.1.51", 5060);
+
+	park.onInvite(inviteTo("700", "101", "parked-call-3@192.168.1.50", parkedAddr, "192.168.1.50"),
+		std::make_shared<SipClient>("101", parkedAddr), 0);
+
+	env.sessionPoolAvailable = false;
+	park.onInvite(inviteTo("700", "102", "retrieve-call-3@192.168.1.51", retrieverAddr, "192.168.1.51"),
+		std::make_shared<SipClient>("102", retrieverAddr), 0);
+
+	EXPECT_NE(env.sentRaw(1).find("503 Service Unavailable"), std::string::npos)
+		<< env.sentRaw(1);
+	// Slot still holds the parked call: it shows up in the dashboard rows.
+	auto rows = park.snapshotRows(std::chrono::steady_clock::now(), /*onlyParked=*/true);
+	ASSERT_EQ(rows.size(), 1u);
+	EXPECT_EQ(std::get<0>(rows[0]), "700");
+	EXPECT_EQ(std::get<1>(rows[0]), "101");
+}

--- a/tests/ParkOrbit_test.cpp
+++ b/tests/ParkOrbit_test.cpp
@@ -113,6 +113,41 @@ TEST(ParkOrbit, ReinviteOkIsAckedWithSingleCallIdHeader)
 	EXPECT_EQ(countOf(ack, "To:"), 1) << ack;
 }
 
+// The dashboard mirror is driven by a dirty flag rather than by each call site
+// remembering to refresh, so every path that moves slot state must signal — and
+// a state-neutral response must not.
+TEST(ParkOrbit, ParkChangedFlagTracksSlotStateNotTraffic)
+{
+	FakePbxEnv env;
+	ParkOrbit park(env);
+	const sockaddr_in parkedAddr = FakePbxEnv::addr("192.168.1.50", 5060);
+
+	EXPECT_FALSE(park.consumeParkChanged());   // nothing has happened yet
+
+	park.onInvite(inviteTo("700", "101", "parked-call-4@192.168.1.50", parkedAddr, "192.168.1.50"),
+		std::make_shared<SipClient>("101", parkedAddr), 0);
+	EXPECT_TRUE(park.consumeParkChanged());    // a call landed in an orbit
+	EXPECT_FALSE(park.consumeParkChanged());   // consuming resets it
+
+	// A 200 OK that belongs to no park dialog changes nothing.
+	const std::string strayOk =
+		"SIP/2.0 200 OK\r\n"
+		"Via: SIP/2.0/UDP 192.168.1.10:5060;branch=z9hG4bKstray\r\n"
+		"From: <sip:700@192.168.1.10:5060>;tag=t\r\n"
+		"To: <sip:101@192.168.1.10>;tag=u\r\n"
+		"Call-ID: not-a-park-dialog@192.168.1.50\r\n"
+		"CSeq: 2 INVITE\r\n"
+		"Content-Length: 0\r\n\r\n";
+	EXPECT_FALSE(park.handleOk(std::make_shared<SipMessage>(strayOk, parkedAddr)));
+	EXPECT_FALSE(park.consumeParkChanged());
+
+	// Teardown of the parked call frees the slot and must signal, even though it
+	// reaches ParkOrbit through freeForCallId() rather than a park call site.
+	park.freeForCallId("Call-ID: parked-call-4@192.168.1.50");
+	EXPECT_TRUE(park.consumeParkChanged());
+	EXPECT_TRUE(park.snapshotRows(std::chrono::steady_clock::now(), /*onlyParked=*/false).empty());
+}
+
 // A retrieve that cannot get a session must 503 the retriever and leave the
 // orbit occupied rather than half-tearing-down the parked leg (#71).
 TEST(ParkOrbit, RetrieveWithExhaustedSessionPoolLeavesSlotParked)

--- a/tests/RegisterBeeper_test.cpp
+++ b/tests/RegisterBeeper_test.cpp
@@ -1,0 +1,93 @@
+// Wire-level tests for the register-beep UAC dialog (src/SIP/RegisterBeeper.cpp).
+// The beep builds its INVITE/ACK/BYE by hand, so only a byte-level assertion
+// catches header defects — the ACK used to stamp "To: " on top of getTo(), which
+// already returns the full "To: ..." header line.
+
+#include <gtest/gtest.h>
+
+#include "FakePbxEnv.hpp"
+#include "RegisterBeeper.hpp"
+
+namespace
+{
+	int countOf(const std::string& hay, const std::string& needle)
+	{
+		int n = 0;
+		for (size_t p = hay.find(needle); p != std::string::npos; p = hay.find(needle, p + needle.size()))
+			++n;
+		return n;
+	}
+
+	// The phone's 200 OK to our beep INVITE, echoing the Call-ID we generated.
+	std::shared_ptr<SipMessage> okFor(const std::string& callId, const sockaddr_in& from)
+	{
+		const std::string raw =
+			"SIP/2.0 200 OK\r\n"
+			"Via: SIP/2.0/UDP 192.168.1.10:5060;branch=z9hG4bKbeep\r\n"
+			"From: \"PocketDial\" <sip:pbx@192.168.1.10:5060>;tag=servertag\r\n"
+			"To: <sip:101@192.168.1.10>;tag=phonetag\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return std::make_shared<SipMessage>(raw, from);
+	}
+
+	// Pull the Call-ID value out of the INVITE the beeper just sent.
+	std::string callIdOf(const std::string& raw)
+	{
+		auto p = raw.find("Call-ID: ");
+		if (p == std::string::npos) return {};
+		p += 9;
+		return raw.substr(p, raw.find("\r\n", p) - p);
+	}
+}
+
+TEST(RegisterBeeper, AnsweredBeepAcksAndByesWithWellFormedHeaders)
+{
+	FakePbxEnv env;
+	RegisterBeeper beeper(env);
+
+	const sockaddr_in phoneAddr = FakePbxEnv::addr("192.168.1.50", 5060);
+	beeper.sendBeep(std::make_shared<SipClient>("101", phoneAddr));
+
+	ASSERT_EQ(env.sent.size(), 1u);
+	const std::string invite = env.sentRaw(0);
+	EXPECT_EQ(invite.rfind("INVITE sip:101@192.168.1.50:5060", 0), 0u) << invite;
+	EXPECT_NE(invite.find("a=inactive"), std::string::npos) << invite;
+
+	const std::string callId = callIdOf(invite);
+	ASSERT_FALSE(callId.empty());
+
+	// Phone auto-answers: expect ACK then BYE.
+	EXPECT_TRUE(beeper.handleOk(okFor(callId, phoneAddr)));
+	ASSERT_EQ(env.sent.size(), 3u);
+
+	const std::string ack = env.sentRaw(1);
+	EXPECT_EQ(ack.rfind("ACK sip:101@", 0), 0u) << ack;
+	EXPECT_EQ(countOf(ack, "To:"), 1) << ack;
+	EXPECT_EQ(countOf(ack, "From:"), 1) << ack;
+	EXPECT_EQ(countOf(ack, "Call-ID:"), 1) << ack;
+	// The phone's tag must survive onto the ACK or the dialog does not match.
+	EXPECT_NE(ack.find("tag=phonetag"), std::string::npos) << ack;
+	EXPECT_NE(ack.find("Call-ID: " + callId + "\r\n"), std::string::npos) << ack;
+
+	const std::string bye = env.sentRaw(2);
+	EXPECT_EQ(bye.rfind("BYE sip:101@", 0), 0u) << bye;
+	EXPECT_EQ(countOf(bye, "To:"), 1) << bye;
+	EXPECT_EQ(countOf(bye, "Call-ID:"), 1) << bye;
+	EXPECT_NE(bye.find("CSeq: 2 BYE"), std::string::npos) << bye;
+	EXPECT_NE(bye.find("tag=phonetag"), std::string::npos) << bye;
+	EXPECT_NE(bye.find("Call-ID: " + callId + "\r\n"), std::string::npos) << bye;
+}
+
+// A 200 OK for an unknown Call-ID is not ours — handleOk must decline it so the
+// engine goes on to its normal session lookup.
+TEST(RegisterBeeper, ForeignOkIsNotConsumed)
+{
+	FakePbxEnv env;
+	RegisterBeeper beeper(env);
+	const sockaddr_in phoneAddr = FakePbxEnv::addr("192.168.1.50", 5060);
+
+	EXPECT_FALSE(beeper.handleOk(okFor("not-a-beep-dialog@192.168.1.50", phoneAddr)));
+	EXPECT_TRUE(env.sent.empty());
+}

--- a/tests/RegisterBeeper_test.cpp
+++ b/tests/RegisterBeeper_test.cpp
@@ -10,14 +10,6 @@
 
 namespace
 {
-	int countOf(const std::string& hay, const std::string& needle)
-	{
-		int n = 0;
-		for (size_t p = hay.find(needle); p != std::string::npos; p = hay.find(needle, p + needle.size()))
-			++n;
-		return n;
-	}
-
 	// The phone's 200 OK to our beep INVITE, echoing the Call-ID we generated.
 	std::shared_ptr<SipMessage> okFor(const std::string& callId, const sockaddr_in& from)
 	{
@@ -64,20 +56,23 @@ TEST(RegisterBeeper, AnsweredBeepAcksAndByesWithWellFormedHeaders)
 
 	const std::string ack = env.sentRaw(1);
 	EXPECT_EQ(ack.rfind("ACK sip:101@", 0), 0u) << ack;
-	EXPECT_EQ(countOf(ack, "To:"), 1) << ack;
-	EXPECT_EQ(countOf(ack, "From:"), 1) << ack;
-	EXPECT_EQ(countOf(ack, "Call-ID:"), 1) << ack;
+	EXPECT_EQ(FakePbxEnv::countOf(ack, "To:"), 1) << ack;
+	EXPECT_EQ(FakePbxEnv::countOf(ack, "From:"), 1) << ack;
+	EXPECT_EQ(FakePbxEnv::countOf(ack, "Call-ID:"), 1) << ack;
 	// The phone's tag must survive onto the ACK or the dialog does not match.
 	EXPECT_NE(ack.find("tag=phonetag"), std::string::npos) << ack;
 	EXPECT_NE(ack.find("Call-ID: " + callId + "\r\n"), std::string::npos) << ack;
 
-	const std::string bye = env.sentRaw(2);
-	EXPECT_EQ(bye.rfind("BYE sip:101@", 0), 0u) << bye;
-	EXPECT_EQ(countOf(bye, "To:"), 1) << bye;
-	EXPECT_EQ(countOf(bye, "Call-ID:"), 1) << bye;
-	EXPECT_NE(bye.find("CSeq: 2 BYE"), std::string::npos) << bye;
-	EXPECT_NE(bye.find("tag=phonetag"), std::string::npos) << bye;
-	EXPECT_NE(bye.find("Call-ID: " + callId + "\r\n"), std::string::npos) << bye;
+	// The BYE is delegated to PbxEnv::serverBye (the engine's single server-BYE
+	// builder), so assert on what the beeper handed it — asserting on the bytes
+	// would only be testing FakePbxEnv's own stand-in for that builder.
+	ASSERT_EQ(env.byeCalls.size(), 1u);
+	const auto& bye = env.byeCalls[0];
+	EXPECT_EQ(bye.destExt, "101");
+	EXPECT_EQ(bye.callId, callId);                    // bare value, not the header line
+	EXPECT_NE(bye.toHeader.find("tag=phonetag"), std::string::npos) << bye.toHeader;
+	EXPECT_NE(bye.fromHeader.find("<sip:pbx@"), std::string::npos) << bye.fromHeader;
+	EXPECT_NE(bye.fromHeader.find(";tag="), std::string::npos) << bye.fromHeader;
 }
 
 // A 200 OK for an unknown Call-ID is not ours — handleOk must decline it so the


### PR DESCRIPTION
Branch review of #96 (`fix/sip-decomposition-followups`), which this branch is built on top of — same 9 commits, plus one correction found during review. All CI checks on #96 (CodeQL, ESP-IDF matrix ×4, host build/tests, deployment guardrail audit) are green, and merging this will auto-resolve #96 since it shares the same commit history.

## Review

Went through the full diff line by line, cross-checking every header-stripping call site against `SipMessage::getCallID()`/`getTo()`/`getFrom()`/`getEvent()` (which all return the full header line, not the bare value — the theme of this PR), the `PbxEnv::forEachSessionInvolving()` role-matching logic, and the `ParkOrbit`/`Registrar` dashboard dirty-flag plumbing (`_parkChanged` / `Registrar::Change`) against every call site that mutates state, to confirm no path was left able to silently skip a dashboard refresh. No functional bugs found — the fixes described below are correct and match their host-test coverage.

## Fixed — malformed headers on server-minted requests

`SipMessage::getCallID()` / `getTo()` / `getFrom()` return the **full header line**, not the bare value. Four hand-built request paths treated them as bare values and re-stamped the header name on top. All predate the decomposition (they came in with the `b3cf191` protocol backport) and were carried through it untouched:

- **Park retrieve re-INVITE** shipped `Call-ID: Call-ID: x@host`, so the parked phone could not match the request to its dialog and media never renegotiated.
- **Register beep** matched dialogs by comparing the bare Call-ID it generated against the full header line — a comparison that could never succeed. An answered beep was therefore never ACKed and never BYEd, and five seconds later `sweep()` sent a CANCEL for an INVITE that already had a final response (illegal per RFC 3261 §9.1). Its ACK also emitted `To: To: <...>`.
- **REFER progress NOTIFY** (RFC 3515 §2.4.5) emitted `From: To: ...`, `To: From: ...` and `Call-ID: Call-ID: ...`.

## Changed — shared plumbing instead of per-machine copies

- `SipWireUtil.hpp` owns `addrToIpPort()` and the `a=inactive` hold offer, which had been pasted into ParkOrbit, RegisterBeeper and BlfSubscriptions (each with its own socket-include block, none with a Windows branch — `inet_ntop` needs `ws2tcpip.h`, so those files could not build on MSVC).
- `BlfSubscriptions` drops its three private header parsers for the shared `siphdr::stripHeaderName` and a new `SipMessage::getEvent()` accessor. The old event-package scanner re-serialised the whole message and matched any line named `o` — which is also the SDP origin line's name.
- `ParkOrbit::consumeParkChanged()` mirrors `Registrar::consumeDevicesChanged()`, so the dashboard mirror is polled once per packet instead of being a duty each mutating call site had to remember. Paths that never signalled at all (`sweep()`, `freeForCallId()` via `endCall`) now do.
- `PbxEnv::sessionsView()` (a reference to `RequestsHandler`'s whole `_sessions` map) is replaced by `forEachSessionInvolving()`, keeping the session table's representation private.
- `RequestsHandler::drainOutbox()` is the single point messages leave the outbox by, so RFC 3261 §17 retransmit registration is structural rather than a scan duplicated at each flush site.
- Registrar registry changes are now classified: an online-flag flip patches the snapshot rows in place instead of rebuilding the vector and two strings per device, which is what a post-reboot registration storm would otherwise cost.

## Removed

- `handleTransferOk()` and `_transferPendingAcks` — unreachable since they were introduced; no commit ever added an entry to the list, so the lookup always failed and `onOk()` paid a wasted call on every 200 OK.

## Test coverage added

New host-side suites (`FakePbxEnv.hpp` harness): `ParkOrbit_test` (4), `RegisterBeeper_test` (2), `BlfSubscriptions_test` (5), `DashboardSnapshot_test` (3) — **14 new tests**, 131 → 145.

## Fixed in this branch on top of #96

- `CHANGELOG.md` claimed "142/142 GoogleTest, up from 131" (+11). Grep-counting `^TEST(` across the four new test files gives 4+2+5+3 = 14, and 131 + 14 = 145, not 142. Corrected the total; left a comment on #96 with the same note.

## Follow-up noted, not fixed here (pre-existing, out of scope)

`RegisterBeeper::BeepState` declares `AwaitingCancelDone` ("CANCEL sent, lingering until the 487 final response is ACKed") but nothing ever transitions into it — `sweep()` sends the CANCEL and immediately frees the slot in the same pass (`RegisterBeeper.cpp`, `sweep()`). If the phone races a 200 OK past an in-flight CANCEL (RFC 3261 §9.1's "UAS already sent a final response" case), `findByCallID` won't find it — the slot is already `Free` — so that OK falls through to normal session handling instead of getting ACKed and BYEd through the beep path. This predates the branch (the enum is unchanged in the diff) and touches CANCEL-race semantics that deserve their own test, so I left it as a comment rather than bundling a fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ch4bPa2P2m9Z3AeehQZYe)_