### PR TITLE
Close out ISSUES.md #76, #77, #93, #94, #41

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,16 +6,6 @@ This document serves as the active issue tracker and architectural roadmap for *
 
 ## Active Issues & Backlog Roadmap
 
-### 🟡 Issue #93: Already-provisioned admin PINs beginning `4887` are shadowed by the `*4887` HTTP-open star-code
-* **Status**: ⏳ Open / Documented residual
-* **Labels**: `security`, `dtmf`
-* **Severity**: Low
-
-#### Description
-`*4887` is matched incrementally in `onDtmfInfo` before the `*PIN#code` parser, so a PIN beginning with those four digits can never complete a DTMF admin command — the star-code fires mid-entry and clears the accumulator. `POST /api/admin/set-pin` now rejects the `4887` prefix (regression test `AdminHttpGate.SetPin_RejectsReservedStarCodePrefix`), but that only covers new/changed PINs; a device provisioned before the guard keeps the collision. The PIN is stored salted+hashed, so a boot-time scan is impossible — the practical ceiling is documentation (done: CHANGELOG) plus optionally a behavioral warning when the star-code fires and the same call continues with `#`-digits. GitHub #93.
-
----
-
 ### 🔵 Issue #94: `docs/API.md` endpoint catalog is stale
 * **Status**: ⏳ Open / Doc debt
 * **Labels**: `documentation`
@@ -184,6 +174,20 @@ until a fork (or a future pass here) adds the routing policy.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #93: Already-provisioned admin PINs beginning `4887` are shadowed by the `*4887` HTTP-open star-code
+* **Status**: ✅ Resolved (to its practical ceiling)
+* **Labels**: `security`, `dtmf`
+
+#### Resolution
+`*4887` is matched incrementally in `onDtmfInfo` before the `*PIN#code` parser, so a PIN beginning with those four digits can never complete a DTMF admin command — the star-code fires mid-entry and clears the accumulator. The PIN is stored salted+hashed, so a boot-time scan for already-provisioned collisions is fundamentally impossible; that residual is accepted, not fixable, and stays true regardless of anything else here. What the issue asked for is everything short of that impossible scan, and both pieces are now in place and verified:
+
+1. **Guard new/changed PINs.** `POST /api/admin/set-pin` rejects any PIN starting with `4887` (`AdminHttpGate.SetPin_RejectsReservedStarCodePrefix`), so the collision can't be freshly created going forward.
+2. **Behavioral warning for the existing-device case.** `onDtmfInfo` detects the shape of an interrupted `*PIN#code` entry immediately after `*4887` fires (`accum.starCodeFiredAtTick`) and logs a targeted warning naming the `4887` collision and pointing at `POST /api/admin/set-pin` to rotate the PIN — one warning per incident, verified by `AdminHttpGate.Trigger_ContinuedEntryAfterStarCodeLogsShadowedPinWarning` (warns) and `AdminHttpGate.Trigger_PlainStarCodeWithNoContinuationDoesNotWarn` (doesn't false-positive on an ordinary `*4887`-only open).
+
+Both are also documented outside the code: `CHANGELOG.md` records the guard and the detection, and `docs/THREAT_MODEL.md` §E-4/residuals carries the full writeup (mitigation, false-positive/negative shape, and the rotate-your-PIN remediation). Verified via the full host suite (168/168, including the three tests above) — no code change was needed, only closing out `ISSUES.md` to match what had already shipped.
+
+---
 
 ### 🟢 Issue #77: DTMF CLASS codes bypass `setDnd()`/`setForward()`, dashboard goes stale
 * **Status**: ✅ Resolved

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -26,18 +26,6 @@ API.md's detailed specs (§4–§5) cover only the original five endpoints. `/ap
 
 ---
 
-### 🟡 Issue #77: DTMF CLASS codes bypass `setDnd()`/`setForward()`, dashboard goes stale
-* **Status**: ⏳ Open / Planned
-* **Labels**: `concurrency`, `dashboard`, `tech-debt`
-* **Severity**: Medium
-
-#### Description
-`onDtmfInfo` runs inside `handle()`'s `_mutex` lock (`RequestsHandler.cpp:175`, non-recursive). `setDnd()`/`setForward()` (`RequestsHandler.cpp:2249`/`2330`) each independently take that same `_mutex`, so `onDtmfInfo` cannot call them without deadlocking — and doesn't. Instead, `*60`/`*80` (`RequestsHandler.cpp:4056`/`4066`) write `_dnd` directly, and `*73`/`*72NNNN` (`RequestsHandler.cpp:4078`/`4160`) write `_forwards` directly, bypassing the setters entirely (comment at `:4048` acknowledges this: "We're already inside `_mutex`"). Consequence: `_snapshot.dnd`/`_snapshot.forwards`, which the HTTP dashboard's status endpoint reads, are refreshed *only* inside those setters — a DTMF-triggered DND/forward change never appears on the dashboard until an unrelated HTTP-side call happens to touch the same extension. `*72NNNN`'s inline path also skips a guard `setForward()` has (rejecting virtual extensions as forward targets).
-
-Found during a mutation-path audit of the admin plane (2026-07-15); a real fix needs either a recursive mutex or lock-already-held internal setter variants, not a one-line patch. Related check while here: `*PIN#999`'s DTMF factory-reset (`RequestsHandler.cpp:3987`) does a full `nvs_flash_erase()` where the HTTP factory-reset path only erases a scoped set of keys — worth confirming that divergence is intentional before closing this out.
-
----
-
 ### 🟡 Issue #74: Hold/resume on broadcast (ring-group) calls is not yet supported
 * **Status**: ⏳ Open / Planned
 * **Labels**: `bug`, `hold-resume`, `broadcast`
@@ -196,6 +184,23 @@ until a fork (or a future pass here) adds the routing policy.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #77: DTMF CLASS codes bypass `setDnd()`/`setForward()`, dashboard goes stale
+* **Status**: ✅ Resolved
+* **Labels**: `concurrency`, `dashboard`, `tech-debt`
+
+#### Resolution
+`onDtmfInfo` runs inside `handle()`'s `_mutex` lock (non-recursive). `setDnd()`/`setForward()` each independently took that same `_mutex`, so `onDtmfInfo` couldn't call them without deadlocking — and didn't. `*60`/`*80` wrote `_dnd` directly, and `*73`/`*72NNNN` wrote `_forwards` directly, bypassing the setters' dashboard-snapshot refresh entirely: `_snapshot.dnd`/`_snapshot.forwards` (what the HTTP dashboard's status endpoint actually reads) were only ever refreshed inside `setDnd()`/`setForward()`, so a DTMF-triggered DND/forward change never appeared on the dashboard until an unrelated HTTP-side call happened to touch the same extension.
+
+Fixed with the lock-already-held internal setter variants the issue called for, not a recursive mutex: `setDndLocked()`/`setForwardLocked()` now hold the mutation + snapshot-refresh body that used to live directly inside `setDnd()`/`setForward()`. The public setters take `_mutex` and call the `*Locked` core; `onDtmfInfo`'s `*60`/`*80`/`*73`/`*72NNNN` call the same `*Locked` core directly, since they're already inside `handle()`'s `_mutex`. One code path, one snapshot refresh, for both the HTTP and DTMF trigger.
+
+This also closed the `*72NNNN` gap noted in the issue: `setForward()`'s guard rejecting `777`/`999` as the extension being configured now applies to the DTMF path too, since `*72NNNN`/`*73` route through `setForwardLocked()` instead of touching `_forwards` inline — a crafted mid-dialog INFO with `From: 777` can no longer set up a forward entry on the virtual echo extension (regression test: `DtmfClassCodes.Star72NNNN_RejectsVirtualExtensionAsTheConfiguredExtension`).
+
+New regression coverage (`tests/DtmfClassCodes_test.cpp`, 5 tests) drives real DTMF INFO packets through `handle()` and asserts against `getDndExtensions()`/`getForwards()` — the same snapshot-reading getters the dashboard uses — not the internal maps, so the tests fail the way the original bug actually manifested (stale dashboard) rather than passing against the live-map state that was never the problem. Full host suite: 168/168 passing.
+
+**Not changed, flagged for a deliberate decision:** the issue also asked to confirm whether `*PIN#999`'s DTMF factory-reset diverging from the HTTP factory-reset is intentional. Confirmed it's a real, non-trivial divergence, not a documentation gap: the DTMF path calls `nvs_flash_erase()` — a full NVS partition wipe (PBX config, CDR history, adopted-device registry, per-extension SIP secrets, everything) — while `HttpServer::sendApiFactoryReset` only erases `wifi_mode`/`wifi_ssid`/`wifi_pass`/`decayed` plus the admin credential via `AdminAuth::clearCredential()` (also scoped — salt/hash + session state only). One is a hard wipe, the other a soft network/credential reset, under the same "factory reset" name reached by two different triggers. Left unchanged here since picking a behavior is a product/security decision (how much a physical-access DTMF factory-reset should destroy) rather than a bug fix; the two paths' actual scope is now documented precisely enough for that decision to be made deliberately rather than by omission.
+
+---
 
 ### 🟢 Issue #76: `SipMessage` representation — parse-mutate-reparse on every setter
 * **Status**: ✅ Resolved

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,16 +6,6 @@ This document serves as the active issue tracker and architectural roadmap for *
 
 ## Active Issues & Backlog Roadmap
 
-### 🔵 Issue #94: `docs/API.md` endpoint catalog is stale
-* **Status**: ⏳ Open / Doc debt
-* **Labels**: `documentation`
-* **Severity**: Low
-
-#### Description
-API.md's detailed specs (§4–§5) cover only the original five endpoints. `/api/cdr`, `/api/dnd`, `/api/forward`, `/api/group`, `/api/factory-reset`, `/api/configuring`, `/api/ota/*`, and the admin session endpoints have no per-endpoint specs. §0 (added 2026-07-17) summarizes the admin layer + dark-by-default reachability and carries a partial-catalog banner, so the doc is honest but incomplete. Source of truth: `HttpServer::handleClient()`. GitHub #94.
-
----
-
 ### 🟡 Issue #74: Hold/resume on broadcast (ring-group) calls is not yet supported
 * **Status**: ⏳ Open / Planned
 * **Labels**: `bug`, `hold-resume`, `broadcast`
@@ -174,6 +164,17 @@ until a fork (or a future pass here) adds the routing policy.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #94: `docs/API.md` endpoint catalog is stale
+* **Status**: ✅ Resolved
+* **Labels**: `documentation`
+
+#### Resolution
+Cross-checked `docs/API.md`'s §4 catalog against the actual route dispatch in `src/Helpers/HttpServer.cpp::handleClient()` (grepped every `req.path ==` / request-line match, including `/api/ota/upload`'s special-cased streaming interception and `/config/<mac>.cfg`'s prefix match). Every route the server actually serves now has a full per-endpoint spec: `/`, `/api/status`, `/api/kill`, `/api/cdr`, `/api/pcap`, `/api/trace`, `/config/<mac>.cfg`, `/api/dnd`, `/api/forward`, `/api/group`, `/api/wifi/scan`, `/api/wifi/connect`, `/api/wifi/mode_ap`, `/api/configuring`, `/api/factory-reset`, `/api/ota/status`, `/api/ota/upload`, `/api/ota/reboot` — all present with method, auth requirements, request params, response codes, and example payloads. The admin session endpoints (`/api/admin/*`) are covered in §0 by design (the doc's own note explains why they're not repeated in §4), not a gap. The partial-catalog banner this issue referenced is already gone.
+
+This was done by an earlier commit (`3a65c13 docs(api): fill in the stale endpoint catalog`, plus later additions as `/api/pcap`/`/api/trace`/`/config/<mac>.cfg` shipped) — `ISSUES.md` just hadn't been updated to reflect it. No doc changes were needed here beyond closing out the tracker entry.
+
+---
 
 ### 🟢 Issue #93: Already-provisioned admin PINs beginning `4887` are shadowed by the `*4887` HTTP-open star-code
 * **Status**: ✅ Resolved (to its practical ceiling)

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -38,21 +38,6 @@ Found during a mutation-path audit of the admin plane (2026-07-15); a real fix n
 
 ---
 
-### 🟡 Issue #76: `SipMessage` representation — parse-mutate-reparse on every setter
-* **Status**: ⏳ Open / Planned
-* **Labels**: `performance`, `sip-core`, `tech-debt`
-* **Severity**: Medium
-* **Priority**: do this before taking on any further SIP-layer language/parsing work — it's the load-bearing piece underneath all of it.
-
-#### Description
-`src/SIP/SipMessage.cpp` (740 lines) still represents a message as a single mutable string (`_messageStr`), with every setter (`setHeader`/`setVia`/`setTo`/`setContact`/`setBody`/`syncContentLength`/...) doing an in-place `.replace()` on that string followed by a full reparse. A normal outbound response that touches five or six of those setters therefore re-scans the entire datagram five or six times to emit one packet — on an S3, not a spare-cycles platform.
-
-This is already flagged yellow in `docs/REALITY_CHECK.md` ("transient stack-to-heap cloning of `SipMessage` objects remains") — not new information, just not yet actioned.
-
-Not a memory-safety bug. The fix is a representation change, not a hardening pass: parse once into an immutable typed message, then build responses instead of mutating raw text in place. Pure C++, no new dependency.
-
----
-
 ### 🟡 Issue #74: Hold/resume on broadcast (ring-group) calls is not yet supported
 * **Status**: ⏳ Open / Planned
 * **Labels**: `bug`, `hold-resume`, `broadcast`
@@ -211,6 +196,19 @@ until a fork (or a future pass here) adds the routing policy.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #76: `SipMessage` representation — parse-mutate-reparse on every setter
+* **Status**: ✅ Resolved
+* **Labels**: `performance`, `sip-core`, `tech-debt`
+
+#### Resolution
+The `_messageStr`-plus-full-reparse representation this issue described no longer matches the code — `src/SIP/SipMessage.cpp` was already rewritten (`dfeecba`, cppcheck follow-up in `146f63b`) to own its parsed pieces directly: a `_startLine` string, an ordered `_headerLines` vector, and a `_body` string, no shared buffer. Setters (`setVia`/`setTo`/`setContact`/`setCSeq`/...) do a single by-name lookup-and-replace against `_headerLines`; there is no cached derived state to keep in sync, so nothing needs a reparse after a mutation. `reparse()` is gone from both `SipMessage` and `SipSdpMessage`.
+
+Auditing this turned up one real residual: every response-building call site in `RequestsHandler.cpp` (51 of them) cloned a message into the static pool via `getMessageFromPool(source->toString(), source->getSource())` — serializing the already-parsed source back into one wire string and then re-splitting that string, even though `SipMessage`'s copy assignment (`= default`, added by the same rewrite specifically so messages could be cloned cheaply) is already a plain owned-string/vector copy with nothing to reconstruct. Added a `getMessageFromPool(const SipMessage&)` overload that copies the parsed fields directly (`*msg = source`, no stringify/resplit) and switched all 51 sites to it. The 4 call sites that build a message from scratch (`ss.str()`, no prior `SipMessage` to clone) were left untouched — there's no redundant reparse to remove there. Verified with the full host test suite (163/163 passing, host build) and a live REGISTER + echo-call (777) smoke test against the built `SipServer` binary (no `SIP Message pool exhausted` fallback observed under a 10-client registration + 5-concurrent-call load).
+
+Also corrected `docs/REALITY_CHECK.md`'s stale "transient stack-to-heap cloning of `SipMessage` objects remains" note (§2 of the scorecard): that had already been resolved separately by the static `_messagePool` (`RequestsHandler::getMessageFromPool()`), which every response-building call site already used before this change; only the wasted reparse on top of it remained, fixed above.
+
+---
 
 ### 🟢 Issue #73: `Held` state CDR-logged as Failed with zero duration
 * **Status**: ✅ Resolved (sip-backport)

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -38,16 +38,6 @@ Since physical target hardware (smart display JC3248W535EN, POE boards, etc.) is
 
 ---
 
-### 🟡 Issue #41: SIP core: Arduino IDE platform detection guards need verification (ESP32/ARDUINO defines)
-* **Status**: ⏳ Open / Planned
-* **Labels**: `build-system`, `compatibility`
-* **Severity**: Low
-
-#### Description
-Arduino IDE build configs should be verified against platform detection macros (`ESP32`, `ARDUINO`, `ESP_PLATFORM`) to ensure smooth compatibility for hobbyist flashing.
-
----
-
 ### 🔵 Issue #35: [Feature Request] Zero-Touch Phone Auto-Provisioning (HTTP)
 * **Status**: ⏳ Open / Planned (Backlog)
 * **Labels**: `feature-request`, `provisioning`
@@ -164,6 +154,24 @@ until a fork (or a future pass here) adds the routing policy.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #41: SIP core: Arduino IDE platform detection guards need verification (ESP32/ARDUINO defines)
+* **Status**: ✅ Resolved (static audit; no Arduino IDE/hardware available to compile-verify)
+* **Labels**: `build-system`, `compatibility`
+
+#### Resolution
+No Arduino IDE, `arduino-cli`, or ESP32 toolchain is available in this environment, so this couldn't be closed with an actual compile — what follows is a full static audit of every platform-detection guard in `src/`, `main/`, and `sketches/`, plus what was safe to fix without a compiler to check the result.
+
+**Inventory.** `src/` uses one dominant, deliberate pattern — `#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)` — in ~70 places across `RequestsHandler`, `Registrar`, `RtpSender`/`RtpReceiver`, `UdpServer`, `SipClient`, `SipDigest`, `AdminAuth`, `SipSecretStore`, `ArpLookup`, `PcapCapture`, `PbxEnv`, `SipWireUtil`. This is clearly intentional defensive coverage: `ESP_PLATFORM` is the ESP-IDF native define, `ESP32`/`ARDUINO` are what the Arduino-ESP32 core defines, and different core generations have varied in which of the three they set.
+
+**Narrower than that pattern, audited individually:**
+* `src/SIP/SipMessage.hpp` (socket header selection) and `src/SIP/TelephonyApiConfig.cpp` (×2, NVS header selection) checked only `ESP_PLATFORM || ESP32`, missing `ARDUINO`. Fixed to the 3-way form. This project only ships ESP32 sketches, and the Arduino-ESP32 core has always defined `ESP32` alongside `ARDUINO` for any ESP32 board, so `ARDUINO` without `ESP32` can't actually occur here — the fix has zero behavioral effect on any real build, it's pure consistency with the established convention. Verified with the full host suite (168/168) since these headers also compile on host (hitting the `#elif __linux__`/`#else` branches there either way).
+* `main/ui/ui.cpp` checks `ESP_PLATFORM` alone. Left as-is: `main/` is exclusively the ESP-IDF-native app entry (`idf.py`-only, per `main/CMakeLists.txt`'s use of `IDF_VERSION_MAJOR` etc.) — the Arduino sketches in `sketches/` have their own `setup()`/`loop()` and never compile anything under `main/`. Not reachable from the Arduino build path at all, so out of scope for this issue.
+* `src/Helpers/HttpServer.hpp`/`.cpp` (socket includes, 6 sites) and `src/Helpers/OtaUpdater.hpp`/`.cpp` (the ESP-IDF `esp_ota_*`/`esp_partition_t` wrapper) check `ESP_PLATFORM` alone, with **no** `ESP32`/`ARDUINO` fallback — and both *are* compiled into every Arduino sketch (each `.ino`'s header comment says to add every `.cpp` from `src/Helpers/`, and `HttpServer.cpp` calls into `OtaUpdater`). **Not changed** — I could not verify on a real toolchain whether this is a live bug, and the two plausible outcomes differ (compile failure, which is loud and immediately visible to a hobbyist flashing it, vs. a "silent host-stub" OTA on some older core, which the `OtaUpdater.cpp` header comment frames as one of two *deliberate* side-by-side implementations, not an oversight). Mitigating: every actively-maintained sketch's own header comment pins **"ESP32 Arduino Core ≥ 3.0" / "3.x"** (`SipServerETH.ino`, `SipServer_T_ETH_Lite_W5500.ino`, `SipServer_T_POE_Pro_LAN8720.ino`, `SipServer_JC3248W535.ino`) — core 3.x is built as an ESP-IDF component and reliably defines `ESP_PLATFORM`, so against the documented minimum supported core this is not a live gap. It would only bite on an older (2.x or earlier) core, which isn't what these sketches say to install. Flagged here rather than changed blind, since getting this wrong in either direction (widening a guard that turns out to matter, or leaving a real gap) isn't something I can confirm without a real Arduino IDE + `arduino-esp32` compile — left for whoever next has that hardware/toolchain available.
+
+No sketch-level (`.ino`) platform-detection branching exists to audit — the `.ino` files are pure hardware pin-mapping/setup code with no `#ifdef` on `ESP_PLATFORM`/`ESP32`/`ARDUINO` of their own; the `ARDUINO_EVENT_ETH_*` cases in the Ethernet sketches are event-enum switches (WiFi/ETH event callback dispatch), not platform guards.
+
+---
 
 ### 🟢 Issue #94: `docs/API.md` endpoint catalog is stale
 * **Status**: ✅ Resolved

--- a/docs/REALITY_CHECK.md
+++ b/docs/REALITY_CHECK.md
@@ -45,7 +45,7 @@ graph TD
 | Criterion | Target Metric | Post-Refactor Status | Grade | Technical Summary |
 | :--- | :--- | :--- | :---: | :--- |
 | **1. Safe Panic Handling** | Zero CPU panics in Onboarding Setup Mode on `/api/status` calls | Full protection with pointer null-checks | **`🟢 PASS`** | `HttpServer` now utilizes a safe `RequestsHandler*` pointer instead of a raw reference, backed by explicit `nullptr` checks on all status and administration endpoints. |
-| **2. Heap Fragmentation** | Zero steady-state allocations (`new`/`std::make_shared`) for clients/sessions | Pre-allocated static pools recycled via custom resets | **`🟡 PASS`**<br>*With Notes* | Static pools of size 32 (`SipClient`) and 8 (`Session`) eliminate steady-state allocations for active elements. Transient stack-to-heap cloning of `SipMessage` objects remains. |
+| **2. Heap Fragmentation** | Zero steady-state allocations (`new`/`std::make_shared`) for clients/sessions | Pre-allocated static pools recycled via custom resets | **`🟢 PASS`** | Static pools of size 32 (`SipClient`), 8 (`Session`), and `POCKETDIAL_MSG_POOL` (`SipMessage`) eliminate steady-state allocations for active elements and response cloning alike. |
 | **3. Stack Watermark Safety** | Stack allocations < 1.5 KB; Heap-allocated buffers for large frames | Large buffers shifted to the heap; high watermarks safe | **`🟢 PASS`** | The 4 KB socket read buffer was moved from local stack to heap-allocated `std::vector` inside `handleClient()`. generous 8 KB stack sizes allocated to all core tasks. |
 | **4. Lock-Free Polling** | HTTP polling bypasses signaling lock; zero packet drop during poll | Double-buffered snapshot with isolated mutex | **`🟢 PASS`** | Core `_mutex` is bypassed for dashboard queries. `HttpServer` fetches data from a copied snapshot protected by `_snapshotMutex`, written once per second during `tick()`. |
 | **5. Rate Limiting** | Protection from registration flood; drops packet under attack | Bounded rate limits with sweep | **`🟢 PASS`** | Fully implemented using a 60-second idle bucket sweep and token bucket algorithm capped at `MAX_BUCKETS = 256` to prevent heap exhaustion. `_packetsDropped` is properly tracked. |
@@ -76,7 +76,7 @@ graph TD
 * **Remaining Risks:** None. Onboarding AP/Setup mode runs stably without any panics.
 
 ### 2. Heap Fragmentation Mitigation (Steady-state dynamic allocation)
-* **Grade:** `🟡 PASS WITH RESERVATIONS`
+* **Grade:** `🟢 PASS`
 * **Issue Background:** [Issue #53](../ISSUES.md#L67-L83) detailed the hazard of executing dynamic allocations (`std::make_shared`) inside the active UDP signaling path. High-frequency SIP registration traffic would fragment the ESP32's limited heap, eventually leading to `bad_alloc` panics or out-of-memory crashes.
 * **Code Verification:**
   * `RequestsHandler` pre-allocates pools in its constructor (`src/SIP/RequestsHandler.cpp:31-39`):
@@ -89,11 +89,8 @@ graph TD
     }
     ```
   * Active elements are recycled in `allocateClient` (`src/SIP/RequestsHandler.cpp:1043`) and `allocateSession` (`src/SIP/RequestsHandler.cpp:1078`) using `client->reset(...)` rather than allocating new objects.
-* **Reservations & Remaining Risks:** 
-  * While persistent structures (`SipClient`, `Session`) are safely pooled, temporary objects are still dynamically allocated. For example, when building keep-alive pings (`RequestsHandler.cpp:1040`) or cloning messages during response generation (`RequestsHandler.cpp:848`), the code invokes `std::make_shared<SipMessage>`. 
-  * Although these are transient heap allocations that are immediately freed when the task block completes, they still cause mild heap churn. 
-  > [!IMPORTANT]
-  > **Recommendation:** To achieve absolute deterministic behavior, the transient `SipMessage` instances should also be allocated from a static pool, or parsed into static memory structures.
+  * The transient `SipMessage` allocations this section used to flag are also gone: `RequestsHandler::getMessageFromPool()` draws from a static `_messagePool` (sized `POCKETDIAL_MSG_POOL`) instead of `make_shared`-ing a fresh message per response, and every response-building call site in `RequestsHandler.cpp` goes through it. `std::make_shared<SipSdpMessage>` now appears only at pool-init time and as the last-resort fallback when the pool itself is exhausted (logged, not silent).
+* **Remaining Risks:** None outstanding for this criterion. (Issue #76 additionally closed out a related redundant-work gap: cloning a message into the pool used to serialize the source back to a wire string and re-split it — `getMessageFromPool(source->toString(), source->getSource())` — even though the pool slot could just as well be assigned directly from the parsed source. A `getMessageFromPool(const SipMessage&)` overload now does that direct copy; see ISSUES.md.)
 
 ### 3. Stack Watermark Safety (HTTP Client Handling Task)
 * **Grade:** `🟢 PASS`

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -2287,45 +2287,51 @@ std::optional<RequestsHandler::ProvisioningInfo> RequestsHandler::findProvisioni
 	return std::nullopt;
 }
 
+void RequestsHandler::setDndLocked(const std::string& extension, bool on)
+{
+	if (on)
+	{
+		// Bound the map so a flood of distinct extensions can't grow the heap
+		// without limit. Mirror the client-pool cap; reject new keys past it.
+		if (_dnd.find(extension) == _dnd.end() &&
+			_dnd.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
+		{
+			queueLog("DND set ignored (table full) for extension " + extension, true);
+		}
+		else
+		{
+			_dnd[extension] = true;
+		}
+	}
+	else
+	{
+		// Turning DND off frees the slot, so the map only ever holds the
+		// extensions that are actively in DND (bounded by registrations).
+		_dnd.erase(extension);
+	}
+	queueLog("DND " + std::string(on ? "enabled" : "disabled") + " for extension " + extension);
+
+	// Refresh the DND view in the dashboard snapshot immediately so the UI
+	// reflects the change without waiting for the next tick(). Same refresh
+	// regardless of whether the mutation came from the HTTP setter or a DTMF
+	// CLASS code (Issue #77) — both funnel through here.
+	{
+		std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+		_snapshot.dnd.clear();
+		_snapshot.dnd.reserve(_dnd.size());
+		for (const auto& [ext, enabled] : _dnd)
+		{
+			if (enabled) _snapshot.dnd.push_back(ext);
+		}
+	}
+}
+
 void RequestsHandler::setDnd(const std::string& extension, bool on)
 {
 	std::vector<std::pair<bool, std::string>> localLogs;
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
-		if (on)
-		{
-			// Bound the map so a flood of distinct extensions can't grow the heap
-			// without limit. Mirror the client-pool cap; reject new keys past it.
-			if (_dnd.find(extension) == _dnd.end() &&
-				_dnd.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
-			{
-				queueLog("DND set ignored (table full) for extension " + extension, true);
-			}
-			else
-			{
-				_dnd[extension] = true;
-			}
-		}
-		else
-		{
-			// Turning DND off frees the slot, so the map only ever holds the
-			// extensions that are actively in DND (bounded by registrations).
-			_dnd.erase(extension);
-		}
-		queueLog("DND " + std::string(on ? "enabled" : "disabled") + " for extension " + extension);
-
-		// Refresh the DND view in the dashboard snapshot immediately so the UI
-		// reflects the change without waiting for the next tick().
-		{
-			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
-			_snapshot.dnd.clear();
-			_snapshot.dnd.reserve(_dnd.size());
-			for (const auto& [ext, enabled] : _dnd)
-			{
-				if (enabled) _snapshot.dnd.push_back(ext);
-			}
-		}
-
+		setDndLocked(extension, on);
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}
@@ -2368,57 +2374,66 @@ std::string RequestsHandler::getForwardTarget(const std::string& extension, cons
 	return {};
 }
 
+void RequestsHandler::setForwardLocked(const std::string& extension, const std::string& trigger, const std::string& target)
+{
+	// Reject the virtual extensions outright; they are not real endpoints.
+	// Previously only the HTTP-facing setForward() applied this guard — the
+	// DTMF *73/*72NNNN inline path skipped it entirely (Issue #77), so a
+	// crafted mid-dialog INFO with From: 777/999 could set up a "forward" on
+	// a virtual extension. Routing both callers through here closes that gap.
+	if (extension == "777" || extension == "999")
+	{
+		queueLog("Forward set ignored for virtual extension " + extension, true);
+	}
+	else
+	{
+		auto it = _forwards.find(extension);
+		bool isNew = (it == _forwards.end());
+
+		// Bound the table like _dnd: refuse a brand-new extension past the cap.
+		if (isNew && _forwards.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
+		{
+			queueLog("Forward set ignored (table full) for extension " + extension, true);
+		}
+		else
+		{
+			pbx::ForwardConfig& cfg = _forwards[extension];
+			if (trigger == "always")        cfg.always   = target;
+			else if (trigger == "busy")     cfg.busy     = target;
+			else if (trigger == "noanswer") cfg.noAnswer = target;
+
+			// Drop the entry entirely once no trigger remains set, so the map only
+			// holds actively-forwarded extensions (bounded by registrations).
+			if (cfg.empty())
+			{
+				_forwards.erase(extension);
+			}
+			queueLog("Forward " + trigger + " for " + extension +
+				(target.empty() ? " cleared" : (" -> " + target)));
+			persistForwards();
+		}
+	}
+
+	// Refresh the dashboard snapshot immediately (mirror setDnd). Same refresh
+	// regardless of whether the mutation came from the HTTP setter or a DTMF
+	// CLASS code (Issue #77) — both funnel through here.
+	{
+		std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+		_snapshot.forwards.clear();
+		_snapshot.forwards.reserve(_forwards.size());
+		for (const auto& [ext, cfg] : _forwards)
+		{
+			_snapshot.forwards.emplace_back(ext, cfg.always, cfg.busy, cfg.noAnswer);
+		}
+	}
+}
+
 void RequestsHandler::setForward(const std::string& extension, const std::string& trigger, const std::string& target)
 {
 	std::vector<std::pair<bool, std::string>> localLogs;
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
-
-		// Reject the virtual extensions outright; they are not real endpoints.
-		if (extension == "777" || extension == "999")
-		{
-			queueLog("Forward set ignored for virtual extension " + extension, true);
-		}
-		else
-		{
-			auto it = _forwards.find(extension);
-			bool isNew = (it == _forwards.end());
-
-			// Bound the table like _dnd: refuse a brand-new extension past the cap.
-			if (isNew && _forwards.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
-			{
-				queueLog("Forward set ignored (table full) for extension " + extension, true);
-			}
-			else
-			{
-				pbx::ForwardConfig& cfg = _forwards[extension];
-				if (trigger == "always")        cfg.always   = target;
-				else if (trigger == "busy")     cfg.busy     = target;
-				else if (trigger == "noanswer") cfg.noAnswer = target;
-
-				// Drop the entry entirely once no trigger remains set, so the map only
-				// holds actively-forwarded extensions (bounded by registrations).
-				if (cfg.empty())
-				{
-					_forwards.erase(extension);
-				}
-				queueLog("Forward " + trigger + " for " + extension +
-					(target.empty() ? " cleared" : (" -> " + target)));
-				persistForwards();
-			}
-		}
-
-		// Refresh the dashboard snapshot immediately (mirror setDnd).
-		{
-			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
-			_snapshot.forwards.clear();
-			_snapshot.forwards.reserve(_forwards.size());
-			for (const auto& [ext, cfg] : _forwards)
-			{
-				_snapshot.forwards.emplace_back(ext, cfg.always, cfg.busy, cfg.noAnswer);
-			}
-		}
-
+		setForwardLocked(extension, trigger, target);
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}
@@ -3607,17 +3622,11 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 	// *60 — Enable Selective Call Rejection (DND=true) for caller's extension.
 	if (seq == "*60")
 	{
-		// isDndEnabled / setDnd operate on the _dnd map. We're already inside _mutex.
-		if (_dnd.find(callerExt) == _dnd.end() &&
-			_dnd.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
-		{
-			queueLog("*60 SCR: DND table full for " + callerExt, true);
-		}
-		else
-		{
-			_dnd[callerExt] = true;
-			queueLog("*60 SCR enabled for " + callerExt);
-		}
+		// Issue #77: route through the same lock-already-held core setDnd()
+		// uses (we're already inside _mutex here, via handle()) so the
+		// dashboard snapshot refreshes immediately instead of only on the
+		// next unrelated HTTP-side setDnd() call.
+		setDndLocked(callerExt, true);
 		accum.digits.clear();
 		return;
 	}
@@ -3625,8 +3634,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 	// *80 — Disable SCR/DND for caller's extension.
 	if (seq == "*80")
 	{
-		_dnd.erase(callerExt);
-		queueLog("*80 SCR disabled for " + callerExt);
+		setDndLocked(callerExt, false);
 		accum.digits.clear();
 		return;
 	}
@@ -3634,14 +3642,11 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 	// *73 — Disable CFU for caller's extension.
 	if (seq == "*73")
 	{
-		auto it = _forwards.find(callerExt);
-		if (it != _forwards.end())
-		{
-			it->second.always.clear();
-			if (it->second.empty()) _forwards.erase(it);
-			persistForwards();
-		}
-		queueLog("*73 CFU disabled for " + callerExt);
+		// Issue #77: setForwardLocked with an empty target clears the
+		// "always" trigger exactly like the old inline erase did, but also
+		// refreshes the dashboard snapshot and applies the virtual-extension
+		// guard that the old inline path skipped.
+		setForwardLocked(callerExt, "always", "");
 		accum.digits.clear();
 		return;
 	}
@@ -3712,17 +3717,11 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 		std::string target = seq.substr(3);
 		if (target.size() >= 4 && isValidAor(target))
 		{
-			bool isNew = (_forwards.find(callerExt) == _forwards.end());
-			if (isNew && _forwards.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
-			{
-				queueLog("*72 CFU: forward table full for " + callerExt, true);
-			}
-			else
-			{
-				_forwards[callerExt].always = target;
-				persistForwards();
-				queueLog("*72 CFU enabled: " + callerExt + " -> " + target);
-			}
+			// Issue #77: setForwardLocked applies the same table-full guard and
+			// the virtual-extension guard setForward() has always had (which
+			// this inline path used to skip), and refreshes the dashboard
+			// snapshot immediately instead of leaving it stale.
+			setForwardLocked(callerExt, "always", target);
 			accum.digits.clear();
 			return;
 		}

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -130,6 +130,22 @@ std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(std::string mess
 	return std::make_shared<SipSdpMessage>(std::move(message), src);
 }
 
+std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(const SipMessage& source)
+{
+	for (auto& msg : _messagePool)
+	{
+		if (msg.use_count() == 1)
+		{
+			*msg = source;
+			return msg;
+		}
+	}
+	std::cerr << "[WARNING] SIP Message pool exhausted! Fallback to heap allocation.\n";
+	std::shared_ptr<SipMessage> msg = std::make_shared<SipSdpMessage>("", sockaddr_in{});
+	*msg = source;
+	return msg;
+}
+
 void RequestsHandler::initHandlers()
 {
 	_handlers.emplace(SipMessageTypes::REGISTER,          std::bind(&RequestsHandler::onRegister,       this, std::placeholders::_1));
@@ -269,7 +285,7 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 			}
 			// Always 200 OK a SIP INFO (RFC 6086 §4.2.1).
 			{
-				auto infoOk = getMessageFromPool(request->toString(), request->getSource());
+				auto infoOk = getMessageFromPool(*request);
 				infoOk->setHeader(SipMessageTypes::OK);
 				std::string activeIp = _localIp;
 				infoOk->setVia(std::string(request->getVia()) + ";received=" + activeIp);
@@ -345,7 +361,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 
 	if (!isValidAor(fromNumber))
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader("SIP/2.0 400 Bad Request");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -425,7 +441,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 		else
 		{
 			// Server full: reply with 503 Service Unavailable
-			auto response = getMessageFromPool(data->toString(), data->getSource());
+			auto response = getMessageFromPool(*data);
 			response->setHeader("SIP/2.0 503 Service Unavailable");
 			response->clearBody();
 			std::string activeIp = _localIp;
@@ -435,7 +451,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 		}
 	}
 
-	auto response = getMessageFromPool(data->toString(), data->getSource());
+	auto response = getMessageFromPool(*data);
 	response->setHeader(SipMessageTypes::OK);
 	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -447,7 +463,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 
 void RequestsHandler::onOptions(std::shared_ptr<SipMessage> data)
 {
-	auto response = getMessageFromPool(data->toString(), data->getSource());
+	auto response = getMessageFromPool(*data);
 	response->setHeader(SipMessageTypes::OK);
 	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -508,7 +524,7 @@ void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 
 			for (const auto& target : session.value()->getPendingTargets())
 			{
-				auto cancelMsg = getMessageFromPool(data->toString(), data->getSource());
+				auto cancelMsg = getMessageFromPool(*data);
 				char ipBuf[INET_ADDRSTRLEN]{};
 				inet_ntop(AF_INET, &target->getAddress().sin_addr, ipBuf, sizeof(ipBuf));
 				std::string targetIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(target->getAddress().sin_port));
@@ -567,7 +583,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 
 	if (!isValidAor(data->getFromNumber()) || !isValidAor(data->getToNumber()))
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader("SIP/2.0 400 Bad Request");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -580,7 +596,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	auto caller = findClient(data->getFromNumber());
 	if (!caller.has_value())
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -593,7 +609,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	if (destNumber == "777")
 	{
 		// SDP loopback echo test
-		auto ringing = getMessageFromPool(data->toString(), data->getSource());
+		auto ringing = getMessageFromPool(*data);
 		ringing->setHeader("SIP/2.0 180 Ringing");
 		ringing->clearBody();
 		std::string activeIp = _localIp;
@@ -603,7 +619,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		ringing->setContact(buildContact("777"));
 		_outbox.emplace_back(data->getSource(), std::move(ringing));
 
-		auto okResponse = getMessageFromPool(data->toString(), data->getSource());
+		auto okResponse = getMessageFromPool(*data);
 		okResponse->setHeader(SipMessageTypes::OK);
 		okResponse->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		okResponse->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -643,7 +659,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 
 		if (targets.empty())
 		{
-			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 			responseObj->setHeader(SipMessageTypes::NOT_FOUND);
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -673,7 +689,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 
 			if (targets.empty())
 			{
-				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 				responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
 				responseObj->clearBody();
 				responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -727,7 +743,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 
 		if (members.empty())
 		{
-			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 			responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -745,7 +761,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		auto newSession = allocateSession(std::string(data->getCallID()), caller.value());
 		if (!newSession)
 		{
-			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 			responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -761,7 +777,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		_sessions.emplace(data->getCallID(), newSession);
 
 		// 180 Ringing back to the caller while we walk the list.
-		auto ringing = getMessageFromPool(data->toString(), data->getSource());
+		auto ringing = getMessageFromPool(*data);
 		ringing->setHeader("SIP/2.0 180 Ringing");
 		ringing->clearBody();
 		std::string activeIp = _localIp;
@@ -795,7 +811,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// extensions are handled above and so are never affected by DND.
 	if (isDndEnabled(destNumber))
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader("SIP/2.0 480 Temporarily Unavailable");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -810,7 +826,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	if (!called.has_value())
 	{
 		// Send "SIP/2.0 404 Not Found"
-		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 		responseObj->setHeader(SipMessageTypes::NOT_FOUND);
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -826,7 +842,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	if (!message) 
 	{
 		queueLog("Couldn't get SDP from " + std::string(data->getFromNumber()) + "'s INVITE request.", true);
-		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 		responseObj->setHeader(SipMessageTypes::BAD_REQUEST);
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -837,7 +853,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	auto newSession = allocateSession(std::string(data->getCallID()), caller.value());
 	if (!newSession)
 	{
-		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 		responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -862,7 +878,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		newSession->armRingTimer(std::chrono::steady_clock::now() + NO_ANSWER_TIMEOUT);
 	}
 
-	auto response = getMessageFromPool(data->toString(), data->getSource());
+	auto response = getMessageFromPool(*data);
 	response->setContact(buildContact(caller.value()->getNumber()));
 	endHandle(data->getToNumber(), response);
 }
@@ -942,7 +958,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	// one media slot/socket/task is never double-booked (degrade gracefully).
 	if (_rtpSender.isActive())
 	{
-		auto busy = getMessageFromPool(data->toString(), data->getSource());
+		auto busy = getMessageFromPool(*data);
 		busy->setHeader("SIP/2.0 486 Busy Here");
 		busy->clearBody();
 		busy->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -957,7 +973,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	uint16_t destPort = 0;
 	if (!parseCallerRtp(data, destIp, destPort))
 	{
-		auto bad = getMessageFromPool(data->toString(), data->getSource());
+		auto bad = getMessageFromPool(*data);
 		bad->setHeader(SipMessageTypes::BAD_REQUEST);
 		bad->clearBody();
 		bad->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -973,7 +989,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	// recoverable only by the caller hanging up. On failure answer 500 instead.
 	if (!_rtpSender.start(destIp, destPort, std::string(data->getCallID())))
 	{
-		auto err = getMessageFromPool(data->toString(), data->getSource());
+		auto err = getMessageFromPool(*data);
 		err->setHeader("SIP/2.0 500 Server Internal Error");
 		err->clearBody();
 		err->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -995,7 +1011,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	if (!newSession)
 	{
 		_rtpSender.stop(std::string(data->getCallID()));
-		auto busy = getMessageFromPool(data->toString(), data->getSource());
+		auto busy = getMessageFromPool(*data);
 		busy->setHeader("SIP/2.0 503 Service Unavailable");
 		busy->clearBody();
 		busy->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1019,7 +1035,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	// Assemble the OK from the INVITE's headers + our body. clearBody() leaves the
 	// header/blank-line boundary intact; we then append Content-Type + the SDP and
 	// let syncContentLength() (invoked by enforceG711) fix the length.
-	auto ok = getMessageFromPool(data->toString(), data->getSource());
+	auto ok = getMessageFromPool(*data);
 	ok->setHeader(SipMessageTypes::OK);
 	ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	ok->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -1177,7 +1193,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 
 	if (destNumber == "777")
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader(SipMessageTypes::OK);
 		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1191,7 +1207,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		// Media beachhead teardown: stop the RTP tone stream (only if it owns this
 		// Call-ID), 200 OK the BYE, and end the session. Stream stop is idempotent.
 		_rtpSender.stop(std::string(data->getCallID()));
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader(SipMessageTypes::OK);
 		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1202,7 +1218,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 
 	if (destNumber == "999" || isPageZoneDialog(destNumber))
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader(SipMessageTypes::OK);
 		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1213,7 +1229,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 			auto answeringClient = session.value()->getDest();
 			if (answeringClient)
 			{
-				auto byeFork = getMessageFromPool(data->toString(), data->getSource());
+				auto byeFork = getMessageFromPool(*data);
 				std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 				char ipBuf[INET_ADDRSTRLEN]{};
@@ -1339,7 +1355,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 
 					auto inviteMsg = session.value()->getInviteMessage();
 
-					auto response = getMessageFromPool(data->toString(), data->getSource());
+					auto response = getMessageFromPool(*data);
 					response->setContact(buildContact(answeringClient->getNumber()));
 
 					if (inviteMsg)
@@ -1370,7 +1386,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 						{
 							if (target->getNumber() != answeringClient->getNumber())
 							{
-								auto cancelMsg = getMessageFromPool(inviteMsg->toString(), inviteMsg->getSource());
+								auto cancelMsg = getMessageFromPool(*inviteMsg);
 								char ipBuf[INET_ADDRSTRLEN]{};
 								inet_ntop(AF_INET, &target->getAddress().sin_addr, ipBuf, sizeof(ipBuf));
 								std::string targetIpPort = std::string(ipBuf) + ":" + std::to_string(ntohs(target->getAddress().sin_port));
@@ -1399,7 +1415,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 			if (!sdpMessage) 
 			{
 				queueLog("Couldn't get SDP from: " + client.value()->getNumber() + "'s OK message.", true);
-				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(data->toString(), data->getSource());
+				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
 				responseObj->setHeader(SipMessageTypes::BAD_REQUEST);
 				responseObj->clearBody();
 				responseObj->setContact(buildContact(data->getToNumber()));
@@ -1416,7 +1432,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 			                                std::string(data->getTo()));
 			session->get()->setRemoteSdp(std::string(data->getBody()));
 			armSessionTimer(session->get(), data);
-			auto response = getMessageFromPool(data->toString(), data->getSource());
+			auto response = getMessageFromPool(*data);
 			response->setContact(buildContact(data->getToNumber()));
 			endHandle(data->getFromNumber(), std::move(response));
 			return;
@@ -1449,7 +1465,7 @@ void RequestsHandler::onAck(std::shared_ptr<SipMessage> data)
 		auto answeringClient = session.value()->getDest();
 		if (answeringClient)
 		{
-			auto ackFork = getMessageFromPool(data->toString(), data->getSource());
+			auto ackFork = getMessageFromPool(*data);
 			std::string activeIp = _localIp;
 			std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 
@@ -1511,7 +1527,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 	if (!transferorOpt.has_value())
 	{
 		// Unknown transferor: reject (consistent with onInvite's 403 for non-registered).
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -1554,7 +1570,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 
 	if (target.empty() || !isValidAor(target))
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader(SipMessageTypes::BAD_REQUEST);
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -1565,7 +1581,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 
 	// 202 Accepted to the transferor (RFC 3515 §2.4.4).
 	{
-		auto accepted = getMessageFromPool(data->toString(), data->getSource());
+		auto accepted = getMessageFromPool(*data);
 		accepted->setHeader(SipMessageTypes::ACCEPTED);
 		accepted->clearBody();
 		std::string activeIp = _localIp;
@@ -1611,7 +1627,7 @@ void RequestsHandler::onMessage(std::shared_ptr<SipMessage> data)
 	// Inbound MESSAGE hygiene (RFC 3428). Phones may send delivery receipts / IMs;
 	// if we don't 200 them they retransmit. We do NOT interpret the body and the
 	// server never originates a MESSAGE. Simple stateless ack, mirroring onOptions().
-	auto response = getMessageFromPool(data->toString(), data->getSource());
+	auto response = getMessageFromPool(*data);
 	response->setHeader(SipMessageTypes::OK);
 	response->clearBody();
 	std::string activeIp = _localIp;
@@ -1625,7 +1641,7 @@ void RequestsHandler::buildInviteFork(const std::shared_ptr<SipMessage>& invite,
 	const std::shared_ptr<SipClient>& target,
 	bool intercom)
 {
-	auto inviteFork = getMessageFromPool(invite->toString(), invite->getSource());
+	auto inviteFork = getMessageFromPool(*invite);
 	inviteFork->setContact(buildContact(caller->getNumber()));
 
 	std::string activeIp = _localIp;
@@ -1663,7 +1679,7 @@ void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
 	auto newSession = allocateSession(std::string(invite->getCallID()), caller);
 	if (!newSession)
 	{
-		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(invite->toString(), invite->getSource());
+		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*invite);
 		responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller->getNumber()));
@@ -1677,7 +1693,7 @@ void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
 
 	std::string contactExt = intercom ? std::string("999") : std::string(invite->getToNumber());
 
-	auto ringing = getMessageFromPool(invite->toString(), invite->getSource());
+	auto ringing = getMessageFromPool(*invite);
 	ringing->setHeader("SIP/2.0 180 Ringing");
 	ringing->clearBody();
 	std::string activeIp = _localIp;
@@ -1753,7 +1769,7 @@ bool RequestsHandler::redirectInvite(const std::shared_ptr<SipMessage>& invite,
 		session = allocateSession(std::string(invite->getCallID()), caller);
 		if (!session)
 		{
-			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(invite->toString(), invite->getSource());
+			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*invite);
 			responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller->getNumber()));
@@ -1814,7 +1830,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildCancel(const std::shared_ptr<S
 	std::string activeIp = _localIp;
 	std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 
-	auto cancelMsg = getMessageFromPool(invite->toString(), invite->getSource());
+	auto cancelMsg = getMessageFromPool(*invite);
 
 	char ipBuf[INET_ADDRSTRLEN]{};
 	inet_ntop(AF_INET, &target->getAddress().sin_addr, ipBuf, sizeof(ipBuf));
@@ -2129,7 +2145,7 @@ void RequestsHandler::endHandle(std::string_view destNumber, std::shared_ptr<Sip
 	else
 	{
 		// Clone the message so we don't mutate a shared object's header
-		auto notFound = getMessageFromPool(message->toString(), message->getSource());
+		auto notFound = getMessageFromPool(*message);
 		notFound->setHeader(SipMessageTypes::NOT_FOUND);
 		notFound->clearBody();
 		auto src = message->getSource();
@@ -2747,7 +2763,7 @@ void RequestsHandler::tick()
 					auto invite = session->getInviteMessage();
 					if (invite && session->getSrc())
 					{
-						auto resp = getMessageFromPool(invite->toString(), invite->getSource());
+						auto resp = getMessageFromPool(*invite);
 						resp->setHeader(SipMessageTypes::UNAVAILABLE);
 						resp->clearBody();
 						resp->setContact(buildContact(session->getGroupExt()));
@@ -3576,7 +3592,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 		// A non-admin caller attempting the admin-menu pattern (*PIN#…): reject.
 		// CLASS service codes (*60/*72/…) have no '#', so they fall through to the
 		// per-subscriber feature handling below for any registered caller.
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -3746,7 +3762,7 @@ void RequestsHandler::onReinvite(std::shared_ptr<SipMessage> data)
 	const std::string destNum = dest ? dest->getNumber() : "";
 	if (destNum == "777" || !src || !dest)
 	{
-		auto response = getMessageFromPool(data->toString(), data->getSource());
+		auto response = getMessageFromPool(*data);
 		response->setHeader("SIP/2.0 488 Not Acceptable Here");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -3807,7 +3823,7 @@ void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
 	auto sessionOpt = getSession(data->getCallID());
 	if (!sessionOpt.has_value())
 	{
-		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		auto resp = getMessageFromPool(*data);
 		resp->setHeader("SIP/2.0 481 Call/Transaction Does Not Exist");
 		resp->clearBody();
 		_outbox.emplace_back(data->getSource(), std::move(resp));
@@ -3819,7 +3835,7 @@ void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
 	if (!data->hasSdp())
 	{
 		// Bodiless UPDATE: session-timer refresh — 200 OK and reset expiry.
-		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		auto resp = getMessageFromPool(*data);
 		resp->setHeader(SipMessageTypes::OK);
 		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		resp->clearBody();
@@ -3842,7 +3858,7 @@ void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
 
 	if (destNum == "777" || !src || !dest)
 	{
-		auto resp = getMessageFromPool(data->toString(), data->getSource());
+		auto resp = getMessageFromPool(*data);
 		resp->setHeader("SIP/2.0 488 Not Acceptable Here");
 		resp->clearBody();
 		_outbox.emplace_back(data->getSource(), std::move(resp));
@@ -4104,7 +4120,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildOkWithSdp(
 	const std::string& toTag,
 	const std::string& sdpBody)
 {
-	auto ok = getMessageFromPool(inviteMsg->toString(), inviteMsg->getSource());
+	auto ok = getMessageFromPool(*inviteMsg);
 	ok->setHeader(SipMessageTypes::OK);
 	ok->setVia(std::string(inviteMsg->getVia()) + ";received=" + activeIp);
 	ok->setTo(std::string(inviteMsg->getTo()) + ";tag=" + toTag);

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -49,6 +49,13 @@ public:
 		OnHandledEvent onHandledEvent);
 
 	static std::shared_ptr<SipMessage> getMessageFromPool(std::string message, sockaddr_in src);
+	// Clones an already-parsed message into a free pool slot via a direct field
+	// copy (SipMessage's copy assignment is a plain owned-string/vector copy —
+	// no shared buffer to fix up). Used by every response-building call site that
+	// used to go through getMessageFromPool(source->toString(), source->getSource()),
+	// which paid a full serialize + reparse just to duplicate a message we had
+	// already parsed once (issue #76).
+	static std::shared_ptr<SipMessage> getMessageFromPool(const SipMessage& source);
 
 	// ── Media beachhead static helpers (pure; host-unit-tested) ──────────────────
 	// Build the server's own SDP body for the 440 answer (server media: PCMU on the

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -367,6 +367,19 @@ private:
 	// (std::mutex is non-recursive); does a bounded map lookup, no locking.
 	bool isDndEnabled(const std::string& extension);
 
+	// Lock-already-held mutation cores for setDnd()/setForward() (Issue #77).
+	// _mutex is non-recursive, and onDtmfInfo() runs inside handle()'s _mutex
+	// lock, so it cannot call the public setDnd()/setForward() without
+	// deadlocking. These do the actual map mutation + dashboard-snapshot
+	// refresh (queueLog only — no _mutex/_logQueue handling of their own) so
+	// both the public setters (after taking _mutex) and onDtmfInfo's CLASS
+	// code handling (already inside it) share one code path and one snapshot
+	// refresh, instead of onDtmfInfo writing _dnd/_forwards directly and
+	// leaving the dashboard snapshot stale until an unrelated HTTP-side call
+	// happens to touch the same extension.
+	void setDndLocked(const std::string& extension, bool on);
+	void setForwardLocked(const std::string& extension, const std::string& trigger, const std::string& target);
+
 	// Internal forward/group/zone lookups used by onInvite()/onBusy()/tick(). Caller
 	// MUST already hold _mutex (non-recursive) — bounded map lookups, no locking.
 	// getForwardTarget returns "" when no forward of that trigger is configured.

--- a/src/SIP/SipMessage.hpp
+++ b/src/SIP/SipMessage.hpp
@@ -1,7 +1,7 @@
 #ifndef SIP_MESSAGE_HPP
 #define SIP_MESSAGE_HPP
 
-#if defined(ESP_PLATFORM) || defined(ESP32)
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
 #include <lwip/sockets.h>
 #undef INADDR_NONE
 #elif defined(__linux__)

--- a/src/SIP/TelephonyApiConfig.cpp
+++ b/src/SIP/TelephonyApiConfig.cpp
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <algorithm>
 
-#if defined(ESP_PLATFORM) || defined(ESP32)
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
 	// Persisted in a DEDICATED NVS namespace ("tapicfg") so a factory-reset of
 	// the PBX config ("pbxcfg") never collaterally wipes — or accidentally
 	// dumps — API credentials. NOTE: values are plaintext in flash unless the
@@ -152,7 +152,7 @@ std::string TelephonyApiConfig::setActiveSlot(size_t idx)
 
 // ── Persistence backends ──────────────────────────────────────────────────────
 
-#if defined(ESP_PLATFORM) || defined(ESP32)
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
 
 void TelephonyApiConfig::load()
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,10 @@ add_executable(sip_parser_tests
     # Phase 0 of docs/PLAN_ADMIN_HTTP_ONLY.md: dark-by-default HTTP admin plane
     # test contract. Pulls in HttpServer.cpp for the first time in this target.
     AdminHttpGate_test.cpp
+    # Issue #77: DTMF CLASS codes (*60/*80/*73/*72NNNN) must update the same
+    # dashboard snapshot the HTTP setters do, not bypass it by writing
+    # _dnd/_forwards directly from inside onDtmfInfo's _mutex lock.
+    DtmfClassCodes_test.cpp
     # Wire-level coverage for the decomposed SIP state machines, driven through a
     # FakePbxEnv that records what each machine enqueues. The park/beep/BLF paths
     # build their requests by hand, so only a byte-level assertion catches header

--- a/tests/DtmfClassCodes_test.cpp
+++ b/tests/DtmfClassCodes_test.cpp
@@ -1,0 +1,169 @@
+// DtmfClassCodes_test.cpp — Issue #77 regression coverage.
+//
+// onDtmfInfo() runs inside handle()'s _mutex lock, so *60/*80 (DND) and
+// *73/*72NNNN (call forward) used to write _dnd/_forwards directly instead of
+// calling setDnd()/setForward() (which independently take the same
+// non-recursive _mutex and would deadlock). That bypassed the dashboard
+// snapshot refresh those setters do, so a DTMF-triggered DND/forward change
+// never showed up on the HTTP dashboard (getDndExtensions()/getForwards(),
+// which read the snapshot, not the live maps) until an unrelated HTTP-side
+// call happened to touch the same extension.
+//
+// These tests drive onDtmfInfo() through RequestsHandler::handle() (real SIP
+// INFO packets, one digit per packet, mirroring how a handset accumulates
+// DTMF) and assert against the snapshot-reading getters a dashboard poll
+// would actually use — the same observable the bug hid from.
+
+#include <gtest/gtest.h>
+#include "RequestsHandler.hpp"
+#include "SipMessage.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <WinSock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	std::shared_ptr<SipMessage> makeRegisterFor(const std::string& from, const std::string& srcIp,
+	                                             const std::string& callId)
+	{
+		sockaddr_in s{}; s.sin_family = AF_INET;
+		s.sin_addr.s_addr = inet_addr(srcIp.c_str());
+		s.sin_port = htons(5060);
+		std::string raw =
+			"REGISTER sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + srcIp + ":5060;branch=z9hG4bKr\r\n"
+			"From: <sip:" + from + "@server>;tag=rt\r\n"
+			"To: <sip:" + from + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 REGISTER\r\n"
+			"Contact: <sip:" + from + "@" + srcIp + ":5060>;expires=3600\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, s);
+	}
+
+	std::shared_ptr<SipMessage> makeInfoDigit(const std::string& from, const std::string& srcIp,
+	                                           const std::string& callId, char digit)
+	{
+		sockaddr_in s{}; s.sin_family = AF_INET;
+		s.sin_addr.s_addr = inet_addr(srcIp.c_str());
+		s.sin_port = htons(5060);
+		std::string body = std::string("Signal=") + digit + "\r\nDuration=100\r\n";
+		std::string head =
+			"INFO sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + srcIp + ":5060;branch=z9hG4bKi\r\n"
+			"From: <sip:" + from + "@server>;tag=it\r\n"
+			"To: <sip:server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INFO\r\n"
+			"Content-Type: application/dtmf-relay\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(head + body, s);
+	}
+
+	void sendDtmfSequence(RequestsHandler& handler, const std::string& from,
+	                      const std::string& srcIp, const std::string& callId,
+	                      const std::string& seq)
+	{
+		for (char c : seq)
+		{
+			handler.handle(makeInfoDigit(from, srcIp, callId, c));
+		}
+	}
+
+	bool contains(const std::vector<std::string>& v, const std::string& s)
+	{
+		for (const auto& x : v) if (x == s) return true;
+		return false;
+	}
+}
+
+TEST(DtmfClassCodes, StarSixty_SetsDndAndSnapshotReflectsItImmediately)
+{
+	RequestsHandler handler("192.168.5.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	handler.handle(makeRegisterFor("301", "192.168.5.50", "reg-60"));
+
+	ASSERT_FALSE(contains(handler.getDndExtensions(), "301"));
+
+	sendDtmfSequence(handler, "301", "192.168.5.50", "dtmf-60", "*60");
+
+	EXPECT_TRUE(contains(handler.getDndExtensions(), "301"))
+		<< "*60 must be visible via the same snapshot the HTTP dashboard reads, "
+		   "not just in the internal _dnd map";
+}
+
+TEST(DtmfClassCodes, StarEighty_ClearsDndSetByStarSixty)
+{
+	RequestsHandler handler("192.168.5.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	handler.handle(makeRegisterFor("302", "192.168.5.51", "reg-80"));
+
+	sendDtmfSequence(handler, "302", "192.168.5.51", "dtmf-80a", "*60");
+	ASSERT_TRUE(contains(handler.getDndExtensions(), "302"));
+
+	sendDtmfSequence(handler, "302", "192.168.5.51", "dtmf-80b", "*80");
+	EXPECT_FALSE(contains(handler.getDndExtensions(), "302"));
+}
+
+TEST(DtmfClassCodes, Star72NNNN_SetsForwardAndSnapshotReflectsItImmediately)
+{
+	RequestsHandler handler("192.168.5.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	handler.handle(makeRegisterFor("303", "192.168.5.52", "reg-72"));
+
+	sendDtmfSequence(handler, "303", "192.168.5.52", "dtmf-72", "*725500");
+
+	bool found = false;
+	for (const auto& [ext, always, busy, noAnswer] : handler.getForwards())
+	{
+		if (ext == "303")
+		{
+			found = true;
+			EXPECT_EQ(always, "5500");
+		}
+	}
+	EXPECT_TRUE(found) << "*72NNNN must be visible via the same snapshot the "
+	                       "HTTP dashboard reads, not just in the internal "
+	                       "_forwards map";
+}
+
+TEST(DtmfClassCodes, Star73_ClearsForwardSetByStar72NNNN)
+{
+	RequestsHandler handler("192.168.5.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	handler.handle(makeRegisterFor("304", "192.168.5.53", "reg-73"));
+
+	sendDtmfSequence(handler, "304", "192.168.5.53", "dtmf-73a", "*725501");
+	bool foundBefore = false;
+	for (const auto& [ext, always, busy, noAnswer] : handler.getForwards())
+	{
+		if (ext == "304") foundBefore = true;
+	}
+	ASSERT_TRUE(foundBefore);
+
+	sendDtmfSequence(handler, "304", "192.168.5.53", "dtmf-73b", "*73");
+	for (const auto& [ext, always, busy, noAnswer] : handler.getForwards())
+	{
+		EXPECT_NE(ext, "304") << "*73 must clear the entry entirely once no trigger remains set";
+	}
+}
+
+TEST(DtmfClassCodes, Star72NNNN_RejectsVirtualExtensionAsTheConfiguredExtension)
+{
+	// Issue #77: setForward()'s "extension == 777/999" guard used to only
+	// apply to the HTTP-facing setter — the DTMF *72NNNN inline path skipped
+	// it. A crafted mid-dialog INFO with From: 777 must not be able to set up
+	// a forward entry on the virtual echo extension.
+	RequestsHandler handler("192.168.5.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+
+	sendDtmfSequence(handler, "777", "192.168.5.54", "dtmf-virt", "*725502");
+
+	for (const auto& [ext, always, busy, noAnswer] : handler.getForwards())
+	{
+		EXPECT_NE(ext, "777") << "virtual extension 777 must never get a forward entry";
+	}
+}


### PR DESCRIPTION
## Summary

Worked `ISSUES.md` starting at #76 in priority order. Two issues needed real fixes; three turned out to already be shipped in code/docs and just needed the tracker caught up.

**#76 — `SipMessage` mutation overhead**: the parse-mutate-reparse representation the issue described was already replaced (earlier commits `dfeecba`/`146f63b`) with owned start-line/header-vector/body storage and no reparse-on-setter. The real residual: 51 response-cloning call sites in `RequestsHandler.cpp` still round-tripped through `toString()` + full reparse to duplicate an already-parsed message. Added `getMessageFromPool(const SipMessage&)` (direct field copy, no stringify/resplit) and switched all 51 sites to it.

**#77 — DTMF CLASS codes bypass `setDnd()`/`setForward()`**: `onDtmfInfo` runs inside `handle()`'s `_mutex`, so it couldn't call `setDnd()`/`setForward()` (same non-recursive mutex) without deadlocking — so `*60`/`*80`/`*73`/`*72NNNN` wrote `_dnd`/`_forwards` directly, bypassing the dashboard-snapshot refresh those setters do. Fixed with lock-already-held `setDndLocked()`/`setForwardLocked()` cores shared by both the public setters and the DTMF path, closing the dashboard staleness and (as a side effect) the missing virtual-extension guard on `*72NNNN`. Added `tests/DtmfClassCodes_test.cpp` (5 tests) asserting against the actual snapshot-reading getters the dashboard uses.

**#93, #94, #41**: verified already resolved by earlier commits — the DTMF `4887`-prefix PIN guard + behavioral warning (#93), the `docs/API.md` endpoint catalog (#94), and most Arduino platform-detection guards (#41, plus widened two remaining 2-way `ESP_PLATFORM||ESP32` guards to the established 3-way `||ARDUINO` pattern for consistency). `ISSUES.md` updated to move all five from Active to Resolved with full writeups, including flagged-not-changed items (the DTMF-vs-HTTP factory-reset NVS-erase scope divergence for #77, and the `HttpServer`/`OtaUpdater` `ESP_PLATFORM`-only guards for #41 — both need a human/toolchain decision this session can't make).

## Test plan
- No ESP-IDF/QEMU toolchain is available in this sandbox, so validated via the host CMake build instead (googletest pulled from the `apt`-installed source since GitHub's raw archive host isn't in this session's egress allowlist).
- [x] Full host test suite: 168/168 passing (163 existing + 5 new `DtmfClassCodes` tests)
- [x] Live smoke test of the built `SipServer` binary: REGISTER storm + concurrent echo calls (100% success), no `SIP Message pool exhausted` fallback observed
- [x] `-Wall -Wextra -Wpedantic` clean build throughout

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaoHcJRgy3ZVFqJ9P6eYwY)_