### PR TITLE
fix(sip): close Issue #101 — pool backpressure, handout race, SDP cache, pcap alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,193 @@
 # Changelog
 
+## Unreleased (issue-101-closeout) - 2026-08-17
+
+Closes Issue #101: items **A**, **B**, **D** and **E** are fixed, **C** is
+formally declined and recorded as such.
+
+### Fixed — data race in the message-pool handout (#101(E), found by the audit)
+
+- `findFreePoolSlot()` scanned the **static** `_messagePool` for `use_count()==1`
+  and then copied the `shared_ptr` — a check-then-take with no synchronization,
+  reachable concurrently from two tasks: the UDP receive task
+  (`UdpServer.cpp:134` → `SipServer::onNewMessage` →
+  `SipMessageFactory::createMessage` → `getMessageFromPool`), which holds **no
+  lock** because `handle()` only takes `_mutex` afterwards on the
+  already-allocated message; and the tick task (`esp_main.cpp:192`, or
+  `SipServer::tickLoop` on desktop) via `TransactionLayer::sweep`, under
+  `_mutex`.
+
+  Both could observe `use_count()==1` on the same slot and both take it, then
+  `reset()` it concurrently — two owners writing one `SipMessage` and
+  reallocating its strings under each other. Holding `_mutex` on one side does
+  not help: a lock only excludes other holders of that same lock. It fires under
+  exactly the load that item A exists to harden against.
+
+  Fixed with a dedicated **leaf** mutex around the scan-and-take (nothing inside
+  its critical section may take another lock, so it is safe regardless of whether
+  the caller already holds `_mutex`). Message initialization stays outside the
+  critical section, which is by then exclusively owned. The fallback deleter is
+  documented as never taking that mutex — the last reference can drop while it is
+  held, so a locking deleter could self-deadlock.
+
+### Fixed — pool-exhaustion backpressure (#101(A))
+
+- `getMessageFromPool()` and `allocateVirtualPeer()` fell back to **unbounded**
+  heap allocation once their pools were drawn down. Both now allow a bounded
+  number of heap fallbacks alive at once — `POCKETDIAL_MSG_HEAP_FALLBACK_MAX` (8)
+  and `POCKETDIAL_VPEER_HEAP_FALLBACK_MAX` (4) in `PoolConfig.hpp` — tracked by
+  an atomic in-flight counter that the `shared_ptr` deleter decrements, and
+  return `nullptr` past that. It is a ceiling on concurrent use, not a rate, so a
+  burst is absorbed and only sustained over-subscription is refused.
+
+  On refusal the contract is **drop, not 503**: building a 503 would need a
+  message out of the very pool that just came up empty, so `allocateSession()`'s
+  reject-and-503 pattern is not available here. SIP over UDP retransmits
+  (RFC 3261 §17), so a dropped packet costs latency rather than the call. The
+  allocation is also exception-balanced — see the comments; the ownership rules
+  around a throwing `shared_ptr` constructor are easy to get wrong in both
+  directions.
+
+- 67 call sites updated (55 `getMessageFromPool` in `RequestsHandler.cpp`, 12
+  `messageFromPool` across the decomposed machines), with the failure action
+  matched to context: `return` in void handlers, `continue` in fork/sweep loops
+  so one refusal skips a target rather than aborting a broadcast, and `nullptr`
+  propagation out of builders. Resources are acquired before state is mutated, so
+  a refusal never leaves a half-built session — the ordering discipline Issue #71
+  established for the park path.
+
+  Two things kept that from being 67 hand-written checks. `enqueue()` now drops a
+  null centrally, covering every inline `enqueue(addr, messageFromPool(...))` and
+  guaranteeing `drainOutbox()` — which dereferences every entry — never sees one.
+  And the highest-volume path needed **no** new code: `createMessage()` already
+  returned `nullopt` on null and `handle()` already dropped it, so an inbound
+  packet that cannot be represented is discarded at the earliest possible point.
+
+- `BlfSubscriptions` no longer records `lastState`/`version` when the NOTIFY it
+  just built was refused. Banking a state that was never sent would suppress the
+  retry and strand that watcher's busy-lamp until the target's state changed
+  *again*; leaving it untouched means the next `refresh()` retries.
+
+### Declined — `maybeTrack()` duplication (#101(C))
+
+- Re-examined and deliberately **not** changed, matching the original call. The
+  four blocks each copy a different `string_view` into a different fixed `char[]`
+  member and share only their shape; folding them into a helper trades four
+  obvious bounds-safe copies for one indirection, on the retransmit path, for no
+  behavioral gain. Recorded in `ISSUES.md` so it is not re-litigated.
+
+### Fixed — PcapCapture allocation under the caller's lock (#101(D))
+
+- The ring no longer pops and pushes. Once full it overwrites the oldest entry in
+  place and recycles that entry's buffer, so the steady-state capture path
+  allocates nothing; it still grows lazily, so a quiet node never pays for slots
+  it has not used. Readers now walk from the ring head, since storage order stops
+  matching capture order after a wrap.
+- `recordInto()` hands the slot's buffer to the caller and a new
+  `SipMessage::toString(std::string&)` serializes straight into it, removing the
+  per-packet temporary that both capture sites built *before* `record()` even
+  copied it. Worth doing properly because capture is unconditional — there is no
+  enable flag, so this ran on every inbound and outbound message under `_mutex`.
+
+### Verification
+
+- Host suite: **188/188** passing (168 before this work). The new tests are
+  mutation-verified — with each fix reverted in turn they fail, including the two
+  that initially did not: same-shape SDP bodies let stale offsets land on correct
+  text, and assigning two `SipSdpMessage` lvalues does not reproduce the pool's
+  base-subobject assignment.
+- Device: all seven edited translation units compile clean for ESP32-S3
+  (`xtensa-esp32s3-elf-g++`) under `-Wall -Wextra`, and the full `idf.py build`
+  links for the esp32s3 target.
+- Not covered: no on-hardware or QEMU run. The concurrency fix in particular is
+  argued from the code and pinned by a host-thread test; it has not been observed
+  under real dual-task load on a device.
+
+### #101(E) audit — remaining findings, all clean
+
+- **Endianness / packed structs**: `RtpSender::buildRtpHeader` writes every
+  multi-byte RTP field byte-by-byte in big-endian and `RtpReceiver` parses the
+  same way — no packed structs, no buffer-to-header casts, so no strict-aliasing
+  exposure and no host-endianness assumption. `SipWireUtil.hpp` is clean.
+- **Blocking calls on the retransmit-timer path**: `sweep()` does no socket I/O
+  (sends are deferred to the outbox and drained after unlock, per Issue #51), no
+  NVS, no sleep, and already null-checked its pool draw.
+- **Watchdog starvation**: every long-lived loop blocks or yields each iteration
+  — `recvfrom()` with `SO_RCVTIMEO` in both receive loops, `vTaskDelayUntil` /
+  `sleep_until` in the RTP send loops, `vTaskDelay` backoff in the bind-retry
+  loops. No spin-waits.
+
+---
+
+## Unreleased (issue-101-B-sdp-parse-cache) - 2026-08-17
+
+Issue #101 item **B**.
+
+### Fixed
+
+- `SipSdpMessage`: the six SDP accessors re-parsed the entire body on every
+  call — `getRtpPort()` alone walked it twice, and call setup touches several
+  of them per INVITE. They now share one single-pass parse, cached until the
+  body changes (Issue #101.B).
+
+- `SipMessage`: added a private `_bodyGen` counter, bumped by every `_body`
+  mutation (`reset()`, `setBody()`, `clearBody()`, `enforceG711()`) and
+  published to derived classes as `bodyGeneration()`. This is what makes the
+  cache above safe on a **pooled** message: `RequestsHandler` recycles the same
+  `SipSdpMessage` objects across unrelated calls via `reset()` and
+  `*msg = source`, so a cache keyed on a plain valid/dirty flag would serve the
+  previous call's `c=`/`m=` lines to the next call — wrong media endpoint, not
+  merely a stale read.
+
+  The cache stores `(offset, length)` spans rather than `string_view`s, so the
+  copy used by the pool's `*msg = source` recycle stays correct instead of
+  leaving the destination pointing into the source's body. This preserves the
+  "no `string_view` to fix up after a copy" property `SipMessage` already
+  documents.
+
+- `SipMessage::operator=` is no longer `= default`: it now copies every member
+  except `_bodyGen`, which it advances instead. The pool assigns through a base
+  reference — `getMessageFromPool(const SipMessage&)` does `*msg = source` on a
+  `shared_ptr<SipMessage>`, so only the `SipMessage` subobject is assigned and a
+  derived class's cache is left untouched. With the generation copied, the
+  destination's stale cache could match the incoming generation and be treated
+  as fresh. Bumping keeps the counter a strictly per-object timeline, so
+  "recorded generation == current generation" can only ever mean "parsed from
+  exactly these bytes". Implicit move operations were already suppressed (both
+  copy operations were previously user-declared as `= default`), so this is not
+  a change in value-category behavior.
+
+- `SipSdpMessage::operator=` is likewise hand-written, for the same reason one
+  level down: the implicit one advanced this object's body generation through
+  the base operator and then overwrote its *cache* generation with the source's,
+  crossing two objects' private counters. When those collided, a stale cache
+  read as current against a body it was never parsed from. Assignment now drops
+  the cache instead of copying it. The copy *constructor* stays defaulted and is
+  correct as-is — it takes both counters from the same object, so a fresh cache
+  stays fresh and a stale one stays stale.
+
+### Testing
+
+- New `tests/SipSdpMessage_cache_test.cpp` (13 tests): accessor parity with the
+  old per-call parse, and cache invalidation across every body-mutation path,
+  including both pool-recycle paths and both assignment defects above. Verified
+  by mutation — with the invalidation deliberately disabled, 8 of them fail.
+
+  Three of these only got teeth after being rewritten, and the failure modes are
+  worth knowing about. First, the two SDP bodies the tests switch between must
+  differ in line *length*, not just in content: with same-shape bodies the stale
+  offsets landed on the new body's correct text and the invalidation tests
+  passed against a knowingly broken cache. Second, a test that assigns one
+  `SipSdpMessage` lvalue to another does NOT reproduce the pool's assignment —
+  that one goes through a `SipMessage&` and assigns only the base subobject.
+  Third, the derived-assignment defect is a *collision* between two counters, so
+  that test sweeps a range of prior-mutation counts on both objects instead of
+  hardcoding the one pair that happens to line up today.
+- Full host suite: 180/180 passing (168 before this change).
+- Device build: all seven edited translation units compile clean for ESP32-S3
+  under `-Wall -Wextra`, and the full `idf.py build` links (see the closeout
+  section above).
+
 ## Unreleased (post-100-review-followups) - 2026-08-09
 
 A pass through `src/SIP` following a laziness/reuse-discipline review plus an

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,24 +6,6 @@ This document serves as the active issue tracker and architectural roadmap for *
 
 ## Active Issues & Backlog Roadmap
 
-### 🟡 Issue #101: Pool-exhaustion backpressure, SDP re-parse, PcapCapture alloc-under-lock, incomplete firmware audit
-* **Status**: ⏳ Open / Planned
-* **Labels**: `performance`, `reliability`, `memory-safety`, `cleanup`, `refactoring`, `esp32`
-* **Severity**: Medium (bundles five sub-items, ranked A-E in the issue body; A and D are the medium-severity ones)
-
-#### Description
-Follow-up from a two-pass review of `src/SIP` (a laziness/reuse-discipline pass plus an embedded-firmware hardware-risk pass) run after PR #100. Two duplication findings and one pre-existing host-build break from that review were fixed directly on `main` (see commit); this issue tracks the five items deliberately **not** fixed in that pass:
-
-- **A** — `getMessageFromPool()`/`allocateVirtualPeer()` (`RequestsHandler.cpp`) still fall back to an unbounded heap allocation on pool exhaustion, unlike `allocateSession()`'s correct reject-and-503 pattern. Mitigated this pass with rate-limited logging + a `ponytail:` ceiling comment; the real reject-and-drop redesign touches ~55 call sites (`getMessageFromPool()` alone is called ~55 times across the file) and needs its own PR.
-- **B** — `SipSdpMessage` re-parses the full SDP body on every accessor call (`SipSdpMessage.cpp:92-120`), no caching.
-- **C** — `TransactionLayer::maybeTrack()` (`TransactionLayer.cpp:39-57`) repeats a correct bounds-safe copy pattern 4x; left as-is, refactor risk outweighs the line-count benefit.
-- **D** — `PcapCapture::record()` (`PcapCapture.hpp:60-66`) does a per-SIP-packet `std::string` alloc/free while holding the caller's mutex, on the hot path when capture is enabled.
-- **E** — The firmware-lens pass didn't finish walking `SipWireUtil.hpp`/`RtpReceiver.cpp`/`RtpSender.cpp` (endianness/packed-struct), `TransactionLayer.cpp` (blocking calls on the retransmit-timer path), or watchdog-starvation risk in long-running loops.
-
-Full detail per item: https://github.com/GlomarGadaffi/pocket-dial/issues/101
-
----
-
 ### 🟡 Issue #74: Hold/resume on broadcast (ring-group) calls is not yet supported
 * **Status**: ⏳ Open / Planned
 * **Labels**: `bug`, `hold-resume`, `broadcast`
@@ -172,6 +154,45 @@ until a fork (or a future pass here) adds the routing policy.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #101: Pool-exhaustion backpressure, SDP re-parse, PcapCapture alloc-under-lock, incomplete firmware audit
+* **Status**: ✅ Resolved 2026-08-17 — **A**, **B**, **D**, **E** fixed; **C** formally declined (see below)
+* **Labels**: `performance`, `reliability`, `memory-safety`, `cleanup`, `refactoring`, `esp32`
+* **Severity**: Medium (bundles five sub-items, ranked A-E in the issue body; A and D are the medium-severity ones)
+
+#### Description
+Follow-up from a two-pass review of `src/SIP` (a laziness/reuse-discipline pass plus an embedded-firmware hardware-risk pass) run after PR #100. Two duplication findings and one pre-existing host-build break from that review were fixed directly on `main` (see commit); this issue tracks the five items deliberately **not** fixed in that pass:
+
+- ~~**A** — `getMessageFromPool()`/`allocateVirtualPeer()` (`RequestsHandler.cpp`) still fall back to an unbounded heap allocation on pool exhaustion.~~ ✅ **Fixed 2026-08-17.** Both now fall back to a *bounded* number of heap allocations alive at once (`POCKETDIAL_MSG_HEAP_FALLBACK_MAX`, `POCKETDIAL_VPEER_HEAP_FALLBACK_MAX` in `PoolConfig.hpp`), tracked by an atomic in-flight counter decremented from the shared_ptr deleter, and return `nullptr` past that.
+
+  On refusal the contract is **drop, not 503** — building a 503 would need a message out of the very pool that just came up empty, so the reject-and-503 pattern `allocateSession()` uses is not available here. SIP over UDP retransmits (RFC 3261 §17), so a dropped packet costs latency rather than the call.
+
+  67 call sites updated (55 `getMessageFromPool` in `RequestsHandler.cpp`, 12 `messageFromPool` across the decomposed machines). Two things kept that from being 67 hand-written checks: `enqueue()` now drops a null centrally, which covers every inline `enqueue(addr, messageFromPool(...))`; and the highest-volume path — inbound packets — needed no new code at all, because `SipMessageFactory::createMessage` already returned `nullopt` on null and `handle()` already dropped it. Where a builder returns null its callers mostly checked already. Covered by `tests/RequestsHandler_pool_test.cpp`.
+- ~~**B** — `SipSdpMessage` re-parses the full SDP body on every accessor call (`SipSdpMessage.cpp:92-120`), no caching.~~ ✅ **Fixed 2026-08-17.** The six accessors now share one single-pass parse, cached until the body changes. Invalidation is driven by a `_bodyGen` counter on `SipMessage`, bumped by every `_body` mutation and published as `bodyGeneration()` — not a valid/dirty flag, because pooled messages are recycled through `reset()` and `*msg = source` and a flag-based cache would hand the previous call's `c=`/`m=` lines to the next call. The cache holds `(offset, length)` spans rather than `string_view`s so the pool's copy stays correct, and `SipMessage::operator=` is no longer `= default` (it advances `_bodyGen` instead of adopting the source's — the pool assigns through a base reference, so only the base subobject is assigned and a copied generation could make the destination's stale cache look fresh). Covered by `tests/SipSdpMessage_cache_test.cpp` (12 tests, mutation-verified).
+- **C** — `TransactionLayer::maybeTrack()` (`TransactionLayer.cpp:39-57`) repeats a correct bounds-safe copy pattern 4x. ⛔ **Declined 2026-08-17, deliberately not fixed.** Re-examined and the original call stands: the four blocks each copy a different `std::string_view` into a different fixed `char[]` member, and the only thing they share is shape. Folding them into a helper trades four obvious bounds-safe copies for one indirection over a member pointer or a lambda per field — the code gets shorter and the review surface gets worse, on the retransmit path, for no behavioral gain. Recorded here so the next reviewer does not re-litigate it.
+- ~~**D** — `PcapCapture::record()` (`PcapCapture.hpp:60-66`) does a per-SIP-packet `std::string` alloc/free while holding the caller's mutex.~~ ✅ **Fixed 2026-08-17.** The ring no longer pops and pushes; once full it overwrites the oldest entry in place and recycles that entry's buffer, so the steady-state capture path allocates nothing. `recordInto()` additionally hands the slot's buffer back to the caller and a new `SipMessage::toString(std::string&)` serializes straight into it, removing the per-packet temporary the two capture sites were building *before* `record()` even copied it. Worth doing properly because capture is unconditional — there is no enable flag, so this ran on every inbound and outbound message under `_mutex`. Covered by 3 new tests in `tests/PcapCapture_test.cpp`.
+- ~~**E** — The firmware-lens pass didn't finish walking `SipWireUtil.hpp`/`RtpReceiver.cpp`/`RtpSender.cpp` (endianness/packed-struct), `TransactionLayer.cpp` (blocking calls on the retransmit-timer path), or watchdog-starvation risk in long-running loops.~~ ✅ **Completed 2026-08-17.** Findings below.
+
+#### #101(E) audit findings
+
+**1. Data race in the message-pool handout — FOUND AND FIXED (the significant one).**
+`findFreePoolSlot()` scanned the *static* `_messagePool` for `use_count()==1` and then copied the `shared_ptr` — a check-then-take with no synchronization, reachable concurrently from two tasks:
+
+* the UDP receive task (`UdpServer.cpp:134` → `SipServer::onNewMessage` → `SipMessageFactory::createMessage` → `getMessageFromPool`), holding **no lock** — `handle()` only takes `_mutex` afterwards, on the already-allocated message;
+* the tick task (`esp_main.cpp:192`, or `SipServer::tickLoop` on desktop) → `tick()` → `TransactionLayer::sweep` → `messageFromPool`, under `_mutex`.
+
+Both could observe `use_count()==1` on the same slot and both take it, then `reset()` it concurrently — two owners writing one `SipMessage` and reallocating its strings under each other. Holding `_mutex` on one side does not help: a lock only excludes other holders of that same lock. It fires precisely under load (retransmit sweep active while packets arrive), which is the scenario item A exists to harden. Fixed with a dedicated leaf mutex around the scan-and-take; the fallback deleter is documented as never taking it, since the last reference can drop while it is held.
+
+**2. Endianness / packed structs — clean.** `RtpSender::buildRtpHeader` writes every multi-byte RTP field byte-by-byte in big-endian (`RtpSender.cpp:122-142`); `RtpReceiver` parses the same way. No packed structs, no casting a buffer to a header type, so no strict-aliasing exposure and no host-endianness assumption. `SipWireUtil.hpp` uses `ntohs` on a real `sockaddr_in` field and `inet_ntop` with a correctly-sized `INET_ADDRSTRLEN` buffer.
+
+**3. Blocking calls on the retransmit-timer path — clean, with one note.** `TransactionLayer::sweep()` allocates nothing but a pooled message, does no socket I/O (sends are deferred to the outbox and drained after unlock, per Issue #51), touches no NVS, and never sleeps. It already null-checked `messageFromPool` before this change. Note for the record: every `TransactionLayer` method runs *under* the engine `_mutex` by design (documented at `TransactionLayer.hpp:20`), and `maybeTrack()` does one `msg->toString()` heap allocation on the send path — bounded and not on the timer path, so left alone.
+
+**4. Watchdog starvation in long-running loops — clean.** Every long-lived loop blocks or yields on each iteration, so the idle task always runs: `UdpServer::receiveLoop` and `RtpReceiver::receiveLoop` block in `recvfrom()` with `SO_RCVTIMEO` set; `RtpSender`'s ESP send loop paces with `vTaskDelayUntil` and its host counterpart with `sleep_until`; the bind-retry loops back off with `vTaskDelay`. No spin-waits, no unbounded no-yield work.
+
+Full detail per item: https://github.com/GlomarGadaffi/pocket-dial/issues/101
+
+---
+
 
 ### 🟢 Issue #41: SIP core: Arduino IDE platform detection guards need verification (ESP32/ARDUINO defines)
 * **Status**: ✅ Resolved (static audit; no Arduino IDE/hardware available to compile-verify)

--- a/src/SIP/BlfSubscriptions.cpp
+++ b/src/SIP/BlfSubscriptions.cpp
@@ -149,6 +149,7 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 	if (pkg != "dialog")
 	{
 		auto resp = _env.messageFromPool(data->toString(), data->getSource());
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 		resp->setHeader(SipMessageTypes::BAD_EVENT);
 		resp->clearBody();
 		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -162,6 +163,7 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 	if (!_env.validAor(target))
 	{
 		auto resp = _env.messageFromPool(data->toString(), data->getSource());
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 		resp->setHeader(SipMessageTypes::BAD_REQUEST);
 		resp->clearBody();
 		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -190,6 +192,7 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 		if (sub == nullptr)
 		{
 			auto resp = _env.messageFromPool(data->toString(), data->getSource());
+			if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 			resp->setHeader("SIP/2.0 503 Service Unavailable");
 			resp->clearBody();
 			resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -210,6 +213,7 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 	// 4. 202 Accepted (RFC 6665 §4.2.1).
 	{
 		auto resp = _env.messageFromPool(data->toString(), data->getSource());
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 		resp->setHeader(SipMessageTypes::ACCEPTED);
 		resp->clearBody();
 		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -231,9 +235,16 @@ void BlfSubscriptions::onSubscribe(const std::shared_ptr<SipMessage>& data)
 	std::string state = computeDialogState(target, dir, dialogId);
 	const bool terminating = (expires == 0);
 	auto notify = buildDialogNotify(*sub, state, dir, dialogId, terminating, "noresource");
-	_env.enqueue(sub->addr, std::move(notify));
-	sub->lastState = state + "|" + dir + "|" + dialogId;
-	sub->version++;
+	// Same reasoning as refresh(): only bank lastState if the NOTIFY was actually
+	// built, so a pool refusal leaves it empty and the next refresh() retries
+	// rather than treating this state as already delivered (#101A). The
+	// `terminating` teardown below still runs either way.
+	if (notify)
+	{
+		_env.enqueue(sub->addr, std::move(notify));
+		sub->lastState = state + "|" + dir + "|" + dialogId;
+		sub->version++;
+	}
 
 	if (terminating)
 	{
@@ -252,6 +263,11 @@ void BlfSubscriptions::refresh()
 		std::string token = state + "|" + dir + "|" + dialogId;
 		if (token == sub.lastState) continue;
 		auto notify = buildDialogNotify(sub, state, dir, dialogId, false, "");
+		// Do NOT record lastState if the pool refused: the token is what suppresses
+		// re-notifying, so banking a state we never sent would leave this watcher's
+		// lamp stale until the target's state changes AGAIN. Leaving it untouched
+		// means the next refresh() retries this NOTIFY (#101A).
+		if (!notify) continue;
 		_env.enqueue(sub.addr, std::move(notify));
 		sub.lastState = token;
 		sub.version++;

--- a/src/SIP/BlfSubscriptions.cpp
+++ b/src/SIP/BlfSubscriptions.cpp
@@ -283,6 +283,14 @@ void BlfSubscriptions::sweepExpired()
 		std::string dir, dialogId;
 		std::string state = computeDialogState(sub.targetAor, dir, dialogId);
 		auto notify = buildDialogNotify(sub, state, dir, dialogId, true, "timeout");
+		if (!notify)
+		{
+			// Keep the slot one more sweep rather than wiping it after silently
+			// dropping the terminal NOTIFY: without it the watcher never learns the
+			// subscription ended and its lamp stays frozen until it re-SUBSCRIBEs.
+			// The deadline has already passed, so the next sweep retries (#101A).
+			continue;
+		}
 		_env.enqueue(sub.addr, std::move(notify));
 		_env.log("BLF: subscription to " + sub.targetAor + " expired");
 		sub = DialogSubscription{};

--- a/src/SIP/ParkOrbit.cpp
+++ b/src/SIP/ParkOrbit.cpp
@@ -36,6 +36,7 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 		// ── PARK ── answer with an a=inactive hold SDP so the parked party is held.
 		const std::string holdSdp = sipwire::makeInactiveHoldSdp(activeIp);
 		auto ok = _env.messageFromPool(data->toString(), data->getSource());
+		if (!ok) return;   // pool exhausted: drop, peer retransmits (#101A)
 		ok->setHeader(SipMessageTypes::OK);
 		ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		ok->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -58,8 +59,12 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 		slot.parkedAt   = std::chrono::steady_clock::now();
 		_parkChanged    = true;
 
+		// Both the stand-in peer and the session are required to track the parked
+		// dialog; if either pool refuses, skip creating the session rather than
+		// registering one with no dest (#101A). Same tolerance the allocSession
+		// check already had — the slot is still parked and sweep() will time it out.
 		auto virt = _env.allocVirtualPeer(orbit, data->getSource());
-		if (auto session = _env.allocSession(std::string(data->getCallID()), caller))
+		if (auto session = virt ? _env.allocSession(std::string(data->getCallID()), caller) : nullptr)
 		{
 			session->setDest(virt);
 			session->setLocalTag(toTag);
@@ -79,10 +84,14 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 	const std::string retrieverSdp(data->getBody());
 
 	auto virt = _env.allocVirtualPeer(slot.parkedExt, slot.parkedAddr);
-	auto rsession = _env.allocSession(std::string(data->getCallID()), caller);
+	auto rsession = virt ? _env.allocSession(std::string(data->getCallID()), caller) : nullptr;
+	// `virt` folded into the same rejection as a missing session (#101A): a
+	// retrieve with no stand-in peer would bridge to nothing. Both are acquired
+	// before any state changes, per #71 — the orbit slot is left intact.
 	if (!rsession)
 	{
 		auto resp = _env.messageFromPool(data->toString(), data->getSource());
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 		resp->setHeader("SIP/2.0 503 Service Unavailable");
 		resp->clearBody();
 		resp->syncContentLength();
@@ -92,6 +101,7 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 	}
 
 	auto ok = _env.messageFromPool(data->toString(), data->getSource());
+	if (!ok) return;   // pool exhausted: drop, peer retransmits (#101A)
 	ok->setHeader(SipMessageTypes::OK);
 	ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	ok->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -146,6 +156,7 @@ void ParkOrbit::sendReinvite(ParkSlot& slot, const std::string& sdp)
 	   << sdp;
 
 	auto inv = _env.messageFromPool(ss.str(), slot.parkedAddr);
+	if (!inv) return;   // pool exhausted: drop, peer retransmits (#101A)
 	inv->enforceG711();
 	inv->syncContentLength();
 	_env.enqueue(slot.parkedAddr, std::move(inv));
@@ -197,6 +208,7 @@ void ParkOrbit::startRingback(ParkSlot& slot, const std::shared_ptr<SipClient>& 
 	   << slot.parkedSdp;
 
 	auto inv = _env.messageFromPool(ss.str(), addr);
+	if (!inv) return;   // pool exhausted: drop, peer retransmits (#101A)
 	inv->enforceG711();
 	inv->syncContentLength();
 	_env.enqueue(addr, std::move(inv));
@@ -255,7 +267,7 @@ bool ParkOrbit::handleOk(const std::shared_ptr<SipMessage>& data)
 			if (auto parker = _env.findRegistered(slot.parker))
 			{
 				auto virt = _env.allocVirtualPeer(slot.parkedExt, slot.parkedAddr);
-				if (auto rb = _env.allocSession(slot.rbCallID, parker))
+				if (auto rb = virt ? _env.allocSession(slot.rbCallID, parker) : nullptr)
 				{
 					rb->setDest(virt);
 					rb->setPeerCallID(slot.callID);

--- a/src/SIP/PbxEnv.hpp
+++ b/src/SIP/PbxEnv.hpp
@@ -29,9 +29,13 @@ struct PbxEnv
 	virtual ~PbxEnv() = default;
 
 	// Queue a message for sending once the current handle()/tick() pass unlocks.
+	// A null `msg` is dropped, so `enqueue(addr, messageFromPool(...))` is safe
+	// to write inline without a check (Issue #101(A)).
 	virtual void enqueue(const sockaddr_in& to, std::shared_ptr<SipMessage> msg) = 0;
 
-	// Draw a SipMessage from the fixed pool (heap fallback on exhaustion).
+	// Draw a SipMessage from the fixed pool. Falls back to a BOUNDED number of
+	// heap allocations and then returns nullptr (Issue #101(A)) — check it before
+	// dereferencing. The contract on refusal is to drop: the peer retransmits.
 	virtual std::shared_ptr<SipMessage> messageFromPool(std::string raw, sockaddr_in src) = 0;
 
 	// Append to the deferred log queue (flushed off-lock).
@@ -46,7 +50,9 @@ struct PbxEnv
 	// Look up a live registration binding; nullptr when `number` isn't registered.
 	virtual std::shared_ptr<SipClient> findRegistered(std::string_view number) = 0;
 	// Draw a transient virtual-peer SipClient (777/440/park leg) from the fixed
-	// pool (heap fallback on exhaustion — graceful, never a crash).
+	// pool. Falls back to a BOUNDED number of heap allocations and then returns
+	// nullptr (Issue #101(A)) — check it, and abandon the operation rather than
+	// wiring a session to a null dest.
 	virtual std::shared_ptr<SipClient> allocVirtualPeer(std::string number, const sockaddr_in& addr) = 0;
 	// Draw a Session from the fixed pool; nullptr on exhaustion. NOT yet visible
 	// to lookups — pair with insertSession once it is wired up.

--- a/src/SIP/PcapCapture.hpp
+++ b/src/SIP/PcapCapture.hpp
@@ -32,7 +32,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <deque>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -45,6 +44,13 @@
 // pools in PoolConfig.hpp — this bounds *count*, not a static footprint.
 // Compile-time tunable (-DPOCKETDIAL_PCAP_RING_SIZE=N); lower it to claw back
 // RAM on a constrained node.
+//
+// Issue #101(D): the ring still grows lazily, but it no longer shrinks — once a
+// slot has been used its buffer is recycled for the next packet to land there
+// rather than freed. So the high-water mark is what a busy node settles at, and
+// the steady-state capture path allocates nothing. Capture is unconditional
+// (there is no enable flag; see the record() sites in RequestsHandler), which is
+// what makes that worth doing rather than a micro-optimization.
 #ifndef POCKETDIAL_PCAP_RING_SIZE
 #define POCKETDIAL_PCAP_RING_SIZE 64
 #endif
@@ -59,15 +65,52 @@ public:
 	// _mutex, the same lock guarding everything else a packet touches).
 	void record(bool outbound, const sockaddr_in& peer, std::string_view bytes)
 	{
-		if (_entries.size() >= POCKETDIAL_PCAP_RING_SIZE)
+		recordInto(outbound, peer).assign(bytes.data(), bytes.size());
+	}
+
+	// Issue #101(D): as record(), but hands back the entry's byte buffer for the
+	// caller to serialize straight into instead of making it materialize a
+	// temporary std::string first. Both capture sites are on the SIP hot path and
+	// run under RequestsHandler::_mutex, and capture is unconditional, so that
+	// temporary was a malloc/free per packet inside the critical section — on top
+	// of the one this class used to do copying it in.
+	//
+	// The returned buffer is empty but keeps whatever capacity the evicted entry
+	// had, so once the ring has filled — the steady state — recording a packet
+	// allocates nothing at all. The reference is valid until the next
+	// recordInto()/record()/clear().
+	std::string& recordInto(bool outbound, const sockaddr_in& peer)
+	{
+		Entry* slot;
+		if (_entries.size() < POCKETDIAL_PCAP_RING_SIZE)
 		{
-			_entries.pop_front();
+			// Still filling: grow by one. The ring is deliberately grown lazily
+			// rather than reserved up front, so a node that never sees traffic
+			// never pays for slots it has not used (see the sizing note above).
+			_entries.emplace_back();
+			slot = &_entries.back();
 		}
-		_entries.push_back(Entry{_nextSeq++, outbound, peer, std::string(bytes), monotonicUs()});
+		else
+		{
+			// Full: overwrite the oldest entry in place and advance the ring head.
+			// No pop/push, so nothing is freed and nothing is allocated.
+			slot = &_entries[_head];
+			_head = (_head + 1) % _entries.size();
+		}
+		slot->seq      = _nextSeq++;
+		slot->outbound = outbound;
+		slot->peer     = peer;
+		slot->tsUs     = monotonicUs();
+		slot->bytes.clear();   // clear() keeps capacity; assign()/append() reuse it
+		return slot->bytes;
 	}
 
 	std::size_t size() const { return _entries.size(); }
-	void clear() { _entries.clear(); }
+	void clear()
+	{
+		_entries.clear();
+		_head = 0;
+	}
 
 	// Issue #32: current ring contents formatted for the dashboard's live SIP
 	// tracer, which polls GET /api/trace and appends whatever it hasn't already
@@ -85,11 +128,10 @@ public:
 	{
 		std::vector<TraceRecord> out;
 		out.reserve(_entries.size());
-		for (const auto& e : _entries)
-		{
+		forEachOldestFirst([&out](const Entry& e) {
 			out.push_back(TraceRecord{e.seq, e.tsUs, e.outbound,
 				sipwire::addrToIpPort(e.peer), e.bytes});
-		}
+		});
 		return out;
 	}
 
@@ -113,8 +155,7 @@ public:
 
 		const uint32_t localAddr = static_cast<uint32_t>(inet_addr(localIp.c_str()));
 
-		for (const auto& e : _entries)
-		{
+		forEachOldestFirst([&](const Entry& e) {
 			std::string frame = frameFor(e, localAddr, localPort);
 			const uint32_t sec  = static_cast<uint32_t>(e.tsUs / 1000000ULL);
 			const uint32_t usec = static_cast<uint32_t>(e.tsUs % 1000000ULL);
@@ -124,7 +165,7 @@ public:
 			appendU32LE(out, len);   // incl_len
 			appendU32LE(out, len);   // orig_len: never truncated, so equal
 			out.append(frame);
-		}
+		});
 		return out;
 	}
 
@@ -137,10 +178,27 @@ private:
 		std::string bytes;
 		uint64_t    tsUs;
 	};
-	std::deque<Entry> _entries;
+	// Ring buffer. Grows to POCKETDIAL_PCAP_RING_SIZE and then stops: entries are
+	// overwritten in place, so storage order stops matching capture order once it
+	// wraps. `_head` is the index of the OLDEST entry (0 while still filling);
+	// everything that reads the ring goes through forEachOldestFirst().
+	std::vector<Entry> _entries;
+	std::size_t _head = 0;
 	// Monotonic, never reused (even across evictions) so a client's high-water
 	// mark from traceRecords() stays meaningful after older entries roll off.
 	uint64_t _nextSeq = 0;
+
+	// Oldest-to-newest traversal. While the ring is still filling `_head` is 0 and
+	// this is plain in-order iteration; after it wraps it walks from `_head`.
+	template <typename F>
+	void forEachOldestFirst(F&& fn) const
+	{
+		const std::size_t n = _entries.size();
+		for (std::size_t i = 0; i < n; ++i)
+		{
+			fn(_entries[(_head + i) % n]);
+		}
+	}
 
 	static uint64_t monotonicUs()
 	{

--- a/src/SIP/PoolConfig.hpp
+++ b/src/SIP/PoolConfig.hpp
@@ -70,6 +70,32 @@
 #define POCKETDIAL_MSG_POOL (POCKETDIAL_MAX_CLIENTS + POCKETDIAL_MAX_SUBSCRIPTIONS + 4)
 #endif
 
+// Issue #101(A): ceiling on the heap fallback taken when the message pool above
+// is fully drawn. It used to be unbounded — a sustained retransmit flood could
+// churn the heap indefinitely, and on a no-MMU ESP32 the eventual failure mode
+// is a bad_alloc out of the middle of the SIP task, not graceful degradation.
+//
+// This caps messages ALIVE AT ONCE on the fallback path, not a rate: the count
+// drops again as each one is released, so a burst is absorbed and only sustained
+// over-subscription is refused. Past the cap, getMessageFromPool() returns
+// nullptr and the caller drops the packet.
+//
+// Dropping is the honest answer rather than 503: building a 503 would itself
+// need a message out of the very pool that just came up empty. SIP over UDP
+// retransmits (RFC 3261 §17 T1 backoff), so a dropped packet costs latency, not
+// the call — and shedding load is the point when the server is this far behind.
+#ifndef POCKETDIAL_MSG_HEAP_FALLBACK_MAX
+#define POCKETDIAL_MSG_HEAP_FALLBACK_MAX 8
+#endif
+
+// Same ceiling for the virtual-peer pool (park orbits / BLF presence stand-ins).
+// Smaller because a virtual peer is a long-lived per-park-slot object, not a
+// per-packet one: needing more than a handful past the pool means the orbit
+// table is already full.
+#ifndef POCKETDIAL_VPEER_HEAP_FALLBACK_MAX
+#define POCKETDIAL_VPEER_HEAP_FALLBACK_MAX 4
+#endif
+
 // Maximum number of concurrent server-originated "register beep" dialogs. Each new
 // REGISTER fires a brief signaling-only auto-answer INVITE (the phone's intercom
 // tone) that is ACK/BYE'd straight back down; this caps how many such short-lived

--- a/src/SIP/RegisterBeeper.cpp
+++ b/src/SIP/RegisterBeeper.cpp
@@ -127,7 +127,17 @@ bool RegisterBeeper::handleOk(const std::shared_ptr<SipMessage>& data)
 		auto ack = buildAck(*bd, data);
 		if (ack) _env.enqueue(bd->addr, std::move(ack));
 		auto bye = buildBye(*bd, data);
-		if (bye) _env.enqueue(bd->addr, std::move(bye));
+		if (!bye)
+		{
+			// The pool refused the BYE. Do NOT advance to AwaitingByeOk: sweep()
+			// would then free the slot on its deadline having never sent a BYE,
+			// leaving the phone off-hook in a call the PBX has forgotten. Staying
+			// in the current state lets the phone's 200 OK retransmit re-enter here
+			// and retry the teardown (#101A).
+			_env.log("Register beep: " + bd->ext + " — pool exhausted, BYE deferred", true);
+			return true;
+		}
+		_env.enqueue(bd->addr, std::move(bye));
 		bd->state    = BeepState::AwaitingByeOk;
 		// Re-arm the deadline so a phone that never 200s our BYE still frees its
 		// slot from sweep() rather than lingering until the original INVITE timeout.

--- a/src/SIP/RegisterBeeper.cpp
+++ b/src/SIP/RegisterBeeper.cpp
@@ -92,6 +92,7 @@ void RegisterBeeper::sendBeep(const std::shared_ptr<SipClient>& phone)
 	   << body;
 
 	auto invite = _env.messageFromPool(ss.str(), addr);
+	if (!invite) return;   // pool exhausted: drop, peer retransmits (#101A)
 	// Normalise the codec list and (re)derive Content-Length from the actual body —
 	// a wrong Content-Length silently breaks the offer on UDP (the 777-path bug).
 	invite->enforceG711();

--- a/src/SIP/Registrar.cpp
+++ b/src/SIP/Registrar.cpp
@@ -65,6 +65,7 @@ void Registrar::persistMode()
 void Registrar::sendChallenge(const std::shared_ptr<SipMessage>& data, bool stale)
 {
 	auto response = _env.messageFromPool(data->toString(), data->getSource());
+	if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 	response->setHeader("SIP/2.0 401 Unauthorized");
 	response->clearBody();
 	response->setVia(std::string(data->getVia()) + ";received=" + _env.localIp());
@@ -80,6 +81,7 @@ void Registrar::sendChallenge(const std::shared_ptr<SipMessage>& data, bool stal
 void Registrar::sendForbidden(const std::shared_ptr<SipMessage>& data, const std::string& reason)
 {
 	auto response = _env.messageFromPool(data->toString(), data->getSource());
+	if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 	response->setHeader("SIP/2.0 403 " + reason);
 	response->clearBody();
 	response->setVia(std::string(data->getVia()) + ";received=" + _env.localIp());

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -116,56 +116,151 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 	refreshDeviceSnapshot();
 }
 
-std::shared_ptr<SipMessage> RequestsHandler::findFreePoolSlot()
+// ── Message pool synchronization (Issue #101(A) / #101(E)) ──────────────────
+//
+// Leaf lock guarding the static _messagePool. LEAF means exactly that: nothing
+// inside its critical section may acquire another lock, ever. That is what makes
+// it safe to take whether or not the caller already holds _mutex, with no lock
+// ordering to reason about.
+//
+// It is needed because handing a slot out is a check-then-take (scan for
+// use_count()==1, then copy the shared_ptr) over a pool reachable from two
+// tasks at once:
+//
+//   * the UDP receive task (UdpServer.cpp:134) -> SipServer::onNewMessage ->
+//     SipMessageFactory::createMessage -> getMessageFromPool, holding NO lock —
+//     handle() only takes _mutex afterwards, on the already-allocated message;
+//   * the tick task (esp_main.cpp:192, or SipServer::tickLoop on desktop) ->
+//     tick() -> TransactionLayer::sweep -> messageFromPool, under _mutex.
+//
+// Unsynchronized, both could observe use_count()==1 on the same slot and both
+// take it, then reset() it concurrently — two owners writing the same
+// SipMessage, reallocating its strings under each other. _mutex on one side does
+// not help: a lock only excludes other holders of that same lock. Found by the
+// #101(E) audit, fixed here because it lives in the function #101(A) rewrites.
+static std::mutex s_msgPoolMutex;
+
+// Heap-fallback messages currently alive. Atomic because the decrement happens
+// in the deleter, which runs wherever the last reference happens to drop —
+// commonly on the socket-send path after the outbox is drained, outside every
+// lock we hold here.
+static std::atomic<std::size_t> s_msgHeapFallbacksInFlight{0};
+
+namespace
 {
+	// Releases a bounded heap-fallback message and gives its budget back.
+	//
+	// MUST NOT take s_msgPoolMutex (or any lock): the last reference can drop
+	// while that mutex is held — dropping a superseded message inside the pool
+	// critical section would self-deadlock on a non-recursive mutex. An atomic
+	// decrement is all this is allowed to do.
+	struct HeapFallbackDeleter
+	{
+		void operator()(SipMessage* p) const noexcept
+		{
+			delete p;
+			s_msgHeapFallbacksInFlight.fetch_sub(1, std::memory_order_relaxed);
+		}
+	};
+}
+
+// Same bounded-fallback bookkeeping for the virtual-peer pool. Separate budget:
+// a virtual peer is a long-lived per-park-slot stand-in, not a per-packet object.
+static std::atomic<std::size_t> s_vpeerHeapFallbacksInFlight{0};
+
+namespace
+{
+	// Same no-locking rule as HeapFallbackDeleter above.
+	struct VpeerFallbackDeleter
+	{
+		void operator()(SipClient* p) const noexcept
+		{
+			delete p;
+			s_vpeerHeapFallbacksInFlight.fetch_sub(1, std::memory_order_relaxed);
+		}
+	};
+}
+
+static void logPoolExhausted(const char* poolName, std::atomic<std::size_t>& warnCount)
+{
+	// Rate-limited 1-in-100: a flood that drains the pool would otherwise also
+	// flood the log pipe.
+	if ((warnCount.fetch_add(1, std::memory_order_relaxed) % 100) == 0)
+	{
+		std::cerr << "[WARNING] " << poolName << " pool exhausted! Dropping.\n";
+	}
+}
+
+std::shared_ptr<SipMessage> RequestsHandler::acquirePooledMessage()
+{
+	std::lock_guard<std::mutex> poolLock(s_msgPoolMutex);
+
 	for (auto& msg : _messagePool)
 	{
 		if (msg.use_count() == 1)
 		{
+			// Copy INSIDE the lock: the copy is what publishes use_count()==2 and
+			// so what makes this slot invisible to the other task's scan. Callers
+			// initialize it (reset() / operator=) after we return, by which point
+			// they own it exclusively — keeping the critical section to a scan.
 			return msg;
 		}
 	}
-	return nullptr;
-}
 
-static void logPoolExhausted(const char* poolName, size_t& warnCount)
-{
-	if ((warnCount++ % 100) == 0)
+	// Pool drawn down: fall back to the heap, but only up to a fixed number alive
+	// at once (Issue #101(A)). Past that, refuse and let the caller drop.
+	if (s_msgHeapFallbacksInFlight.load(std::memory_order_relaxed) >= POCKETDIAL_MSG_HEAP_FALLBACK_MAX)
 	{
-		std::cerr << "[WARNING] " << poolName << " pool exhausted (" << (warnCount)
-			<< " total)! Fallback to heap allocation.\n";
+		return nullptr;
+	}
+
+	SipMessage* raw = nullptr;
+	try
+	{
+		raw = new SipSdpMessage("", sockaddr_in{});
+	}
+	catch (const std::bad_alloc&)
+	{
+		return nullptr;   // budget untouched — nothing was handed out
+	}
+
+	s_msgHeapFallbacksInFlight.fetch_add(1, std::memory_order_relaxed);
+	try
+	{
+		return std::shared_ptr<SipMessage>(raw, HeapFallbackDeleter{});
+	}
+	catch (const std::bad_alloc&)
+	{
+		// The shared_ptr constructor takes ownership of `raw` before it can throw,
+		// and the standard requires it to run the deleter if it does. So `raw` is
+		// already deleted and the counter already decremented — undoing either
+		// here would be a double free / double decrement.
+		return nullptr;
 	}
 }
 
 std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(std::string message, sockaddr_in src)
 {
-	if (std::shared_ptr<SipMessage> msg = findFreePoolSlot())
+	std::shared_ptr<SipMessage> msg = acquirePooledMessage();
+	if (!msg)
 	{
-		msg->reset(std::move(message), src);
-		return msg;
+		static std::atomic<std::size_t> warnCount{0};
+		logPoolExhausted("SIP Message", warnCount);
+		return nullptr;
 	}
-	static size_t warnCount = 0;
-	logPoolExhausted("SIP Message", warnCount);
-	// ponytail: unbounded heap allocation, no cap, no reject-and-drop like the
-	// session-pool-full path ("440 media: session pool full") uses — a sustained
-	// retransmit flood could churn the heap indefinitely. Ceiling: none today.
-	// Upgrade path: once a small fallback-in-flight count is exceeded, drop the
-	// packet instead of allocating, mirroring allocateSession()'s 503-and-reject
-	// behavior. Tracked as Issue #101. See also allocateVirtualPeer() below.
-	return std::make_shared<SipSdpMessage>(std::move(message), src);
+	msg->reset(std::move(message), src);
+	return msg;
 }
 
 std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(const SipMessage& source)
 {
-	if (std::shared_ptr<SipMessage> msg = findFreePoolSlot())
+	std::shared_ptr<SipMessage> msg = acquirePooledMessage();
+	if (!msg)
 	{
-		*msg = source;
-		return msg;
+		static std::atomic<std::size_t> warnCount{0};
+		logPoolExhausted("SIP Message", warnCount);
+		return nullptr;
 	}
-	static size_t warnCount = 0;
-	logPoolExhausted("SIP Message", warnCount);
-	// ponytail: same unbounded-fallback ceiling as above (Issue #101).
-	std::shared_ptr<SipMessage> msg = std::make_shared<SipSdpMessage>("", sockaddr_in{});
 	*msg = source;
 	return msg;
 }
@@ -225,7 +320,9 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 		// signaling-research aid, not a wire-level DoS forensics tool, and
 		// capturing before the rate limiter would mean pulling the ring buffer
 		// out from under _mutex for every flood packet too.
-		_pcapCapture.record(/*outbound=*/false, request->getSource(), request->toString());
+		// Serialized straight into the ring slot — no per-packet temporary inside
+		// the critical section (Issue #101(D)).
+		request->toString(_pcapCapture.recordInto(/*outbound=*/false, request->getSource()));
 
 		auto client = findClientByAddress(request->getSource());
 		if (client.has_value())
@@ -310,6 +407,7 @@ void RequestsHandler::handle(std::shared_ptr<SipMessage> request)
 			// Always 200 OK a SIP INFO (RFC 6086 §4.2.1).
 			{
 				auto infoOk = getMessageFromPool(*request);
+				if (!infoOk) return;   // pool exhausted: drop, peer retransmits (#101A)
 				infoOk->setHeader(SipMessageTypes::OK);
 				std::string activeIp = _localIp;
 				infoOk->setVia(std::string(request->getVia()) + ";received=" + activeIp);
@@ -386,6 +484,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 	if (!isValidAor(fromNumber))
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader("SIP/2.0 400 Bad Request");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -466,6 +565,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 		{
 			// Server full: reply with 503 Service Unavailable
 			auto response = getMessageFromPool(*data);
+			if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 			response->setHeader("SIP/2.0 503 Service Unavailable");
 			response->clearBody();
 			std::string activeIp = _localIp;
@@ -476,6 +576,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 	}
 
 	auto response = getMessageFromPool(*data);
+	if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 	response->setHeader(SipMessageTypes::OK);
 	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -488,6 +589,7 @@ void RequestsHandler::onRegister(std::shared_ptr<SipMessage> data)
 void RequestsHandler::onOptions(std::shared_ptr<SipMessage> data)
 {
 	auto response = getMessageFromPool(*data);
+	if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 	response->setHeader(SipMessageTypes::OK);
 	std::string activeIp = _localIp;
 	response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -549,6 +651,7 @@ void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 			for (const auto& target : session.value()->getPendingTargets())
 			{
 				auto cancelMsg = getMessageFromPool(*data);
+				if (!cancelMsg) continue;   // pool exhausted: skip this target (#101A)
 				std::string targetIpPort = sipwire::addrToIpPort(target->getAddress());
 
 				cancelMsg->setHeader("CANCEL sip:" + target->getNumber() + "@" + targetIpPort + " SIP/2.0");
@@ -606,6 +709,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	if (!isValidAor(data->getFromNumber()) || !isValidAor(data->getToNumber()))
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader("SIP/2.0 400 Bad Request");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -619,6 +723,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	if (!caller.has_value())
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -632,6 +737,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	{
 		// SDP loopback echo test
 		auto ringing = getMessageFromPool(*data);
+		if (!ringing) return;   // pool exhausted: drop, peer retransmits (#101A)
 		ringing->setHeader("SIP/2.0 180 Ringing");
 		ringing->clearBody();
 		std::string activeIp = _localIp;
@@ -642,6 +748,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		_outbox.emplace_back(data->getSource(), std::move(ringing));
 
 		auto okResponse = getMessageFromPool(*data);
+		if (!okResponse) return;   // pool exhausted: drop, peer retransmits (#101A)
 		okResponse->setHeader(SipMessageTypes::OK);
 		okResponse->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		okResponse->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -682,6 +789,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		if (targets.empty())
 		{
 			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+			if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 			responseObj->setHeader(SipMessageTypes::NOT_FOUND);
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -712,6 +820,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 			if (targets.empty())
 			{
 				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+				if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 				responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
 				responseObj->clearBody();
 				responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -766,6 +875,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		if (members.empty())
 		{
 			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+			if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 			responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -784,6 +894,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		if (!newSession)
 		{
 			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+			if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 			responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -800,6 +911,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 
 		// 180 Ringing back to the caller while we walk the list.
 		auto ringing = getMessageFromPool(*data);
+		if (!ringing) return;   // pool exhausted: drop, peer retransmits (#101A)
 		ringing->setHeader("SIP/2.0 180 Ringing");
 		ringing->clearBody();
 		std::string activeIp = _localIp;
@@ -834,6 +946,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	if (isDndEnabled(destNumber))
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader("SIP/2.0 480 Temporarily Unavailable");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -849,6 +962,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	{
 		// Send "SIP/2.0 404 Not Found"
 		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+		if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 		responseObj->setHeader(SipMessageTypes::NOT_FOUND);
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -865,6 +979,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	{
 		queueLog("Couldn't get SDP from " + std::string(data->getFromNumber()) + "'s INVITE request.", true);
 		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+		if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 		responseObj->setHeader(SipMessageTypes::BAD_REQUEST);
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -876,6 +991,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	if (!newSession)
 	{
 		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+		if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 		responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller.value()->getNumber()));
@@ -901,6 +1017,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	}
 
 	auto response = getMessageFromPool(*data);
+	if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 	response->setContact(buildContact(caller.value()->getNumber()));
 	endHandle(data->getToNumber(), response);
 }
@@ -981,6 +1098,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	if (_rtpSender.isActive())
 	{
 		auto busy = getMessageFromPool(*data);
+		if (!busy) return;   // pool exhausted: drop, peer retransmits (#101A)
 		busy->setHeader("SIP/2.0 486 Busy Here");
 		busy->clearBody();
 		busy->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -996,6 +1114,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	if (!parseCallerRtp(data, destIp, destPort))
 	{
 		auto bad = getMessageFromPool(*data);
+		if (!bad) return;   // pool exhausted: drop, peer retransmits (#101A)
 		bad->setHeader(SipMessageTypes::BAD_REQUEST);
 		bad->clearBody();
 		bad->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1012,6 +1131,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	if (!_rtpSender.start(destIp, destPort, std::string(data->getCallID())))
 	{
 		auto err = getMessageFromPool(*data);
+		if (!err) return;   // pool exhausted: drop, peer retransmits (#101A)
 		err->setHeader("SIP/2.0 500 Server Internal Error");
 		err->clearBody();
 		err->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1034,6 +1154,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	{
 		_rtpSender.stop(std::string(data->getCallID()));
 		auto busy = getMessageFromPool(*data);
+		if (!busy) return;   // pool exhausted: drop, peer retransmits (#101A)
 		busy->setHeader("SIP/2.0 503 Service Unavailable");
 		busy->clearBody();
 		busy->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1058,6 +1179,7 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	// header/blank-line boundary intact; we then append Content-Type + the SDP and
 	// let syncContentLength() (invoked by enforceG711) fix the length.
 	auto ok = getMessageFromPool(*data);
+	if (!ok) return;   // pool exhausted: drop, peer retransmits (#101A)
 	ok->setHeader(SipMessageTypes::OK);
 	ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	ok->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -1216,6 +1338,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 	if (destNumber == "777")
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader(SipMessageTypes::OK);
 		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1230,6 +1353,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		// Call-ID), 200 OK the BYE, and end the session. Stream stop is idempotent.
 		_rtpSender.stop(std::string(data->getCallID()));
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader(SipMessageTypes::OK);
 		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1241,6 +1365,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 	if (destNumber == "999" || isPageZoneDialog(destNumber))
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader(SipMessageTypes::OK);
 		std::string activeIp = _localIp;
 		response->setVia(std::string(data->getVia()) + ";received=" + activeIp);
@@ -1252,6 +1377,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 			if (answeringClient)
 			{
 				auto byeFork = getMessageFromPool(*data);
+				if (!byeFork) return;   // pool exhausted: drop, peer retransmits (#101A)
 				std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 				std::string targetIpPort = sipwire::addrToIpPort(answeringClient->getAddress());
 
@@ -1371,6 +1497,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 					auto inviteMsg = session.value()->getInviteMessage();
 
 					auto response = getMessageFromPool(*data);
+					if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 					response->setContact(buildContact(answeringClient->getNumber()));
 
 					if (inviteMsg)
@@ -1398,6 +1525,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 							if (target->getNumber() != answeringClient->getNumber())
 							{
 								auto cancelMsg = getMessageFromPool(*inviteMsg);
+								if (!cancelMsg) continue;   // pool exhausted: skip this target (#101A)
 								std::string targetIpPort = sipwire::addrToIpPort(target->getAddress());
 
 								cancelMsg->setHeader("CANCEL sip:" + target->getNumber() + "@" + targetIpPort + " SIP/2.0");
@@ -1425,6 +1553,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 			{
 				queueLog("Couldn't get SDP from: " + client.value()->getNumber() + "'s OK message.", true);
 				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+				if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 				responseObj->setHeader(SipMessageTypes::BAD_REQUEST);
 				responseObj->clearBody();
 				responseObj->setContact(buildContact(data->getToNumber()));
@@ -1442,6 +1571,7 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 			session->get()->setRemoteSdp(std::string(data->getBody()));
 			armSessionTimer(session->get(), data);
 			auto response = getMessageFromPool(*data);
+			if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 			response->setContact(buildContact(data->getToNumber()));
 			endHandle(data->getFromNumber(), std::move(response));
 			return;
@@ -1475,6 +1605,7 @@ void RequestsHandler::onAck(std::shared_ptr<SipMessage> data)
 		if (answeringClient)
 		{
 			auto ackFork = getMessageFromPool(*data);
+			if (!ackFork) return;   // pool exhausted: drop, peer retransmits (#101A)
 			std::string activeIp = _localIp;
 			std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 			std::string targetIpPort = sipwire::addrToIpPort(answeringClient->getAddress());
@@ -1530,6 +1661,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 	{
 		// Unknown transferor: reject (consistent with onInvite's 403 for non-registered).
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -1573,6 +1705,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 	if (target.empty() || !isValidAor(target))
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader(SipMessageTypes::BAD_REQUEST);
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -1584,6 +1717,7 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 	// 202 Accepted to the transferor (RFC 3515 §2.4.4).
 	{
 		auto accepted = getMessageFromPool(*data);
+		if (!accepted) return;   // pool exhausted: drop, peer retransmits (#101A)
 		accepted->setHeader(SipMessageTypes::ACCEPTED);
 		accepted->clearBody();
 		std::string activeIp = _localIp;
@@ -1630,6 +1764,7 @@ void RequestsHandler::onMessage(std::shared_ptr<SipMessage> data)
 	// if we don't 200 them they retransmit. We do NOT interpret the body and the
 	// server never originates a MESSAGE. Simple stateless ack, mirroring onOptions().
 	auto response = getMessageFromPool(*data);
+	if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 	response->setHeader(SipMessageTypes::OK);
 	response->clearBody();
 	std::string activeIp = _localIp;
@@ -1644,6 +1779,7 @@ void RequestsHandler::buildInviteFork(const std::shared_ptr<SipMessage>& invite,
 	bool intercom)
 {
 	auto inviteFork = getMessageFromPool(*invite);
+	if (!inviteFork) return;   // pool exhausted: drop, peer retransmits (#101A)
 	inviteFork->setContact(buildContact(caller->getNumber()));
 
 	std::string activeIp = _localIp;
@@ -1680,6 +1816,7 @@ void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
 	if (!newSession)
 	{
 		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*invite);
+		if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
 		responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 		responseObj->clearBody();
 		responseObj->setContact(buildContact(caller->getNumber()));
@@ -1694,6 +1831,7 @@ void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
 	std::string contactExt = intercom ? std::string("999") : std::string(invite->getToNumber());
 
 	auto ringing = getMessageFromPool(*invite);
+	if (!ringing) return;   // pool exhausted: drop, peer retransmits (#101A)
 	ringing->setHeader("SIP/2.0 180 Ringing");
 	ringing->clearBody();
 	std::string activeIp = _localIp;
@@ -1770,6 +1908,7 @@ bool RequestsHandler::redirectInvite(const std::shared_ptr<SipMessage>& invite,
 		if (!session)
 		{
 			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*invite);
+			if (!responseObj) return false;   // pool exhausted: drop, peer retransmits (#101A)
 			responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller->getNumber()));
@@ -1831,6 +1970,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildCancel(const std::shared_ptr<S
 	std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 
 	auto cancelMsg = getMessageFromPool(*invite);
+	if (!cancelMsg) return nullptr;   // pool exhausted: propagate, caller drops (#101A)
 
 	std::string targetIpPort = sipwire::addrToIpPort(target->getAddress());
 
@@ -2144,6 +2284,7 @@ void RequestsHandler::endHandle(std::string_view destNumber, std::shared_ptr<Sip
 	{
 		// Clone the message so we don't mutate a shared object's header
 		auto notFound = getMessageFromPool(*message);
+		if (!notFound) return;   // pool exhausted: drop, peer retransmits (#101A)
 		notFound->setHeader(SipMessageTypes::NOT_FOUND);
 		notFound->clearBody();
 		auto src = message->getSource();
@@ -2677,6 +2818,7 @@ bool RequestsHandler::sendMessageTo(const std::string& ext, const std::string& t
 		   << body;
 
 		auto msg = getMessageFromPool(ss.str(), addr);
+		if (!msg) return false;   // pool exhausted: drop, peer retransmits (#101A)
 		msg->syncContentLength();
 		_outbox.emplace_back(addr, std::move(msg));
 		sent = true;
@@ -2775,6 +2917,7 @@ void RequestsHandler::tick()
 					if (invite && session->getSrc())
 					{
 						auto resp = getMessageFromPool(*invite);
+						if (!resp) continue;   // pool exhausted: skip this session's 480 (#101A)
 						resp->setHeader(SipMessageTypes::UNAVAILABLE);
 						resp->clearBody();
 						resp->setContact(buildContact(session->getGroupExt()));
@@ -2830,7 +2973,9 @@ void RequestsHandler::tick()
 			{
 				client->setLastPingTime(now);
 				auto ping = buildOptionsPing(client);
-				_outbox.emplace_back(client->getAddress(), std::move(ping));
+				// Skip this client's keepalive if the pool refused; the next tick
+				// re-pings, and a missed OPTIONS only delays liveness detection.
+				if (ping) _outbox.emplace_back(client->getAddress(), std::move(ping));
 			}
 		}
 
@@ -3600,6 +3745,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 		// CLASS service codes (*60/*72/…) have no '#', so they fall through to the
 		// per-subscriber feature handling below for any registered caller.
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader("SIP/2.0 403 Forbidden");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -3754,6 +3900,7 @@ void RequestsHandler::onReinvite(std::shared_ptr<SipMessage> data)
 	if (destNum == "777" || !src || !dest)
 	{
 		auto response = getMessageFromPool(*data);
+		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 		response->setHeader("SIP/2.0 488 Not Acceptable Here");
 		response->clearBody();
 		std::string activeIp = _localIp;
@@ -3815,6 +3962,7 @@ void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
 	if (!sessionOpt.has_value())
 	{
 		auto resp = getMessageFromPool(*data);
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 		resp->setHeader("SIP/2.0 481 Call/Transaction Does Not Exist");
 		resp->clearBody();
 		_outbox.emplace_back(data->getSource(), std::move(resp));
@@ -3827,6 +3975,7 @@ void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
 	{
 		// Bodiless UPDATE: session-timer refresh — 200 OK and reset expiry.
 		auto resp = getMessageFromPool(*data);
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 		resp->setHeader(SipMessageTypes::OK);
 		resp->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 		resp->clearBody();
@@ -3850,6 +3999,7 @@ void RequestsHandler::onUpdate(std::shared_ptr<SipMessage> data)
 	if (destNum == "777" || !src || !dest)
 	{
 		auto resp = getMessageFromPool(*data);
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
 		resp->setHeader("SIP/2.0 488 Not Acceptable Here");
 		resp->clearBody();
 		_outbox.emplace_back(data->getSource(), std::move(resp));
@@ -4082,7 +4232,7 @@ std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> RequestsHandler
 		// the retransmit registration above — every deferred message leaves
 		// through here regardless of which call site (handle(), tick(),
 		// sendMessageTo()) queued it.
-		_pcapCapture.record(/*outbound=*/true, addr, msg->toString());
+		msg->toString(_pcapCapture.recordInto(/*outbound=*/true, addr));
 	}
 
 	auto drained = std::move(_outbox);
@@ -4112,6 +4262,7 @@ std::shared_ptr<SipMessage> RequestsHandler::buildOkWithSdp(
 	const std::string& sdpBody)
 {
 	auto ok = getMessageFromPool(*inviteMsg);
+	if (!ok) return nullptr;   // pool exhausted: propagate, caller drops (#101A)
 	ok->setHeader(SipMessageTypes::OK);
 	ok->setVia(std::string(inviteMsg->getVia()) + ";received=" + activeIp);
 	ok->setTo(std::string(inviteMsg->getTo()) + ";tag=" + toTag);
@@ -4175,11 +4326,39 @@ std::shared_ptr<SipClient> RequestsHandler::allocateVirtualPeer(std::string numb
 			return peer;
 		}
 	}
-	// Pool drained: fall back to a one-off heap SipClient rather than failing the call.
-	// ponytail: same unbounded-fallback ceiling as getMessageFromPool above — no cap,
-	// no reject-and-drop under sustained pressure. See that function's comment for
-	// the upgrade path. Tracked as Issue #101.
-	static size_t warnCount = 0;
-	logPoolExhausted("Virtual-peer", warnCount);
-	return std::make_shared<SipClient>(std::move(number), address, expiresSeconds);
+	// Pool drained: fall back to the heap, bounded the same way the message pool
+	// is (Issue #101(A)). Past the ceiling this returns nullptr and the caller
+	// abandons the park/BLF operation rather than allocating without limit.
+	//
+	// No pool lock here, unlike acquirePooledMessage(): _virtualPeerPool is a
+	// per-instance member and every caller — the internal sites and ParkOrbit via
+	// PbxEnv::allocVirtualPeer — already runs under _mutex. The counter is still
+	// atomic because its decrement happens in the deleter, which runs wherever
+	// the owning Session finally releases it.
+	if (s_vpeerHeapFallbacksInFlight.load(std::memory_order_relaxed) >= POCKETDIAL_VPEER_HEAP_FALLBACK_MAX)
+	{
+		static std::atomic<std::size_t> warnCount{0};
+		logPoolExhausted("Virtual-peer", warnCount);
+		return nullptr;
+	}
+
+	SipClient* raw = nullptr;
+	try
+	{
+		raw = new SipClient(std::move(number), address, expiresSeconds);
+	}
+	catch (const std::bad_alloc&)
+	{
+		return nullptr;   // budget untouched
+	}
+	s_vpeerHeapFallbacksInFlight.fetch_add(1, std::memory_order_relaxed);
+	try
+	{
+		return std::shared_ptr<SipClient>(raw, VpeerFallbackDeleter{});
+	}
+	catch (const std::bad_alloc&)
+	{
+		// Constructor already ran the deleter on `raw` — freed and decremented.
+		return nullptr;
+	}
 }

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -181,13 +181,27 @@ namespace
 	};
 }
 
-static void logPoolExhausted(const char* poolName, std::atomic<std::size_t>& warnCount)
+// Two distinct signals, deliberately. `Fallback` fires the moment the fixed pool
+// runs dry and the heap fallback takes over — pressure building, nothing lost yet.
+// `Refused` fires once the fallback budget is spent too and packets are actually
+// being dropped. Collapsing them (as an earlier cut of #101(A) did) removes the
+// only early warning an operator gets and reports trouble solely after the damage.
+enum class PoolPressure { Fallback, Refused };
+
+static void logPoolExhausted(const char* poolName, PoolPressure level,
+	std::atomic<std::size_t>& warnCount)
 {
 	// Rate-limited 1-in-100: a flood that drains the pool would otherwise also
-	// flood the log pipe.
-	if ((warnCount.fetch_add(1, std::memory_order_relaxed) % 100) == 0)
+	// flood the log pipe. The running total is kept in the message so the sampling
+	// does not hide the true magnitude.
+	const std::size_t n = warnCount.fetch_add(1, std::memory_order_relaxed) + 1;
+	if ((n - 1) % 100 == 0)
 	{
-		std::cerr << "[WARNING] " << poolName << " pool exhausted! Dropping.\n";
+		std::cerr << "[WARNING] " << poolName << " pool exhausted ("
+			<< n << " total)! "
+			<< (level == PoolPressure::Fallback
+				? "Falling back to bounded heap allocation.\n"
+				: "Fallback budget spent — DROPPING packets.\n");
 	}
 }
 
@@ -199,6 +213,15 @@ std::shared_ptr<SipMessage> RequestsHandler::acquirePooledMessage()
 	{
 		if (msg.use_count() == 1)
 		{
+			// The mutex serializes TAKERS, but the previous owner released this
+			// slot outside it — typically on the send path once the drained outbox
+			// goes out of scope. use_count() is only an atomic load, so on its own
+			// it establishes no happens-before with that releasing thread, and the
+			// reset() we are about to authorize reads the message's existing string
+			// and vector internals before overwriting them. This fence pairs with
+			// the release the refcount decrement performs, so those writes are
+			// visible before we hand the slot on.
+			std::atomic_thread_fence(std::memory_order_acquire);
 			// Copy INSIDE the lock: the copy is what publishes use_count()==2 and
 			// so what makes this slot invisible to the other task's scan. Callers
 			// initialize it (reset() / operator=) after we return, by which point
@@ -208,11 +231,17 @@ std::shared_ptr<SipMessage> RequestsHandler::acquirePooledMessage()
 	}
 
 	// Pool drawn down: fall back to the heap, but only up to a fixed number alive
-	// at once (Issue #101(A)). Past that, refuse and let the caller drop.
+	// at once (Issue #101(A)). Past that, refuse and let the caller drop. Both
+	// transitions are logged, from here rather than the callers, so the two
+	// getMessageFromPool overloads share one rate-limit counter per pool instead
+	// of each sampling 1-in-100 independently under the same label.
+	static std::atomic<std::size_t> msgWarnCount{0};
 	if (s_msgHeapFallbacksInFlight.load(std::memory_order_relaxed) >= POCKETDIAL_MSG_HEAP_FALLBACK_MAX)
 	{
+		logPoolExhausted("SIP Message", PoolPressure::Refused, msgWarnCount);
 		return nullptr;
 	}
+	logPoolExhausted("SIP Message", PoolPressure::Fallback, msgWarnCount);
 
 	SipMessage* raw = nullptr;
 	try
@@ -242,12 +271,7 @@ std::shared_ptr<SipMessage> RequestsHandler::acquirePooledMessage()
 std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(std::string message, sockaddr_in src)
 {
 	std::shared_ptr<SipMessage> msg = acquirePooledMessage();
-	if (!msg)
-	{
-		static std::atomic<std::size_t> warnCount{0};
-		logPoolExhausted("SIP Message", warnCount);
-		return nullptr;
-	}
+	if (!msg) return nullptr;   // acquirePooledMessage() already logged the pressure
 	msg->reset(std::move(message), src);
 	return msg;
 }
@@ -255,12 +279,7 @@ std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(std::string mess
 std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(const SipMessage& source)
 {
 	std::shared_ptr<SipMessage> msg = acquirePooledMessage();
-	if (!msg)
-	{
-		static std::atomic<std::size_t> warnCount{0};
-		logPoolExhausted("SIP Message", warnCount);
-		return nullptr;
-	}
+	if (!msg) return nullptr;   // acquirePooledMessage() already logged the pressure
 	*msg = source;
 	return msg;
 }
@@ -1163,6 +1182,21 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 		queueLog("440 media: session pool full, rejected " + std::string(data->getFromNumber()), true);
 		return;
 	}
+	// The 200 OK is drawn BEFORE the session is published, because past
+	// _sessions.emplace() + Connected there is no clean way back: the caller's
+	// INVITE retransmit would hit the _rtpSender.isActive() guard at the top of
+	// this function and be answered 486 Busy Here, with the tone still streaming
+	// to a peer that never got an answer. Unwinding the stream here — the same
+	// thing the session-pool-full path above does — leaves the retransmit a clean
+	// retry (#101A).
+	auto ok = getMessageFromPool(*data);
+	if (!ok)
+	{
+		_rtpSender.stop(std::string(data->getCallID()));
+		queueLog("440 media: message pool exhausted, stream unwound", true);
+		return;
+	}
+
 	newSession->setDest(dummy440);
 	_sessions.emplace(data->getCallID(), newSession);
 	newSession->setState(Session::State::Connected);
@@ -1178,8 +1212,6 @@ void RequestsHandler::onMediaInvite(std::shared_ptr<SipMessage> data,
 	// Assemble the OK from the INVITE's headers + our body. clearBody() leaves the
 	// header/blank-line boundary intact; we then append Content-Type + the SDP and
 	// let syncContentLength() (invoked by enforceG711) fix the length.
-	auto ok = getMessageFromPool(*data);
-	if (!ok) return;   // pool exhausted: drop, peer retransmits (#101A)
 	ok->setHeader(SipMessageTypes::OK);
 	ok->setVia(std::string(data->getVia()) + ";received=" + activeIp);
 	ok->setTo(std::string(data->getTo()) + ";tag=" + toTag);
@@ -1376,8 +1408,14 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 			auto answeringClient = session.value()->getDest();
 			if (answeringClient)
 			{
+				// NOT a `return` on refusal: the caller's 200 OK is already queued
+				// above, so it has its final response and will never retransmit this
+				// BYE. Bailing here would skip endCall() below and leak the session
+				// with no CDR. Losing the fork only leaves the paged phone to time
+				// out its own dialog; losing the teardown is unrecoverable (#101A).
 				auto byeFork = getMessageFromPool(*data);
-				if (!byeFork) return;   // pool exhausted: drop, peer retransmits (#101A)
+				if (byeFork)
+				{
 				std::string serverIpPort = activeIp + ":" + std::to_string(_serverPort);
 				std::string targetIpPort = sipwire::addrToIpPort(answeringClient->getAddress());
 
@@ -1389,6 +1427,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 				byeFork->setTo(newTo);
 
 				_outbox.emplace_back(answeringClient->getAddress(), std::move(byeFork));
+				}
 			}
 		}
 		endCall(data->getCallID(), data->getFromNumber(), destNumber);
@@ -1490,14 +1529,20 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 						return;
 					}
 
+					// Drawn BEFORE the session is advanced: the branch above only
+					// re-enters while the state is still Invited, so refusing after
+					// setState(Connected) would strand the call permanently — the
+					// answering phone's 200 OK retransmit could never get back in
+					// here. Acquire first, mutate second (#101A).
+					auto response = getMessageFromPool(*data);
+					if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
+
 					session->get()->setDest(answeringClient);
 					session->get()->setState(Session::State::Connected);
 					session->get()->clearRingTimer();   // hunt answered: disarm timeout
 
 					auto inviteMsg = session.value()->getInviteMessage();
 
-					auto response = getMessageFromPool(*data);
-					if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
 					response->setContact(buildContact(answeringClient->getNumber()));
 
 					if (inviteMsg)
@@ -1773,13 +1818,17 @@ void RequestsHandler::onMessage(std::shared_ptr<SipMessage> data)
 	_outbox.emplace_back(data->getSource(), std::move(response));
 }
 
-void RequestsHandler::buildInviteFork(const std::shared_ptr<SipMessage>& invite,
+bool RequestsHandler::buildInviteFork(const std::shared_ptr<SipMessage>& invite,
 	const std::shared_ptr<SipClient>& caller,
 	const std::shared_ptr<SipClient>& target,
 	bool intercom)
 {
 	auto inviteFork = getMessageFromPool(*invite);
-	if (!inviteFork) return;   // pool exhausted: drop, peer retransmits (#101A)
+	// Returns bool because callers report success on this function's behalf —
+	// huntRingNext arms a 20 s no-answer timer, redirectInvite NOTIFYs the
+	// transferor. A silent void return had them announcing an INVITE that was
+	// never sent (#101A).
+	if (!inviteFork) return false;
 	inviteFork->setContact(buildContact(caller->getNumber()));
 
 	std::string activeIp = _localIp;
@@ -1801,6 +1850,7 @@ void RequestsHandler::buildInviteFork(const std::shared_ptr<SipMessage>& invite,
 	}
 	inviteFork->enforceG711();
 	_outbox.emplace_back(target->getAddress(), std::move(inviteFork));
+	return true;
 }
 
 void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
@@ -1823,15 +1873,21 @@ void RequestsHandler::startBroadcastFork(std::shared_ptr<SipMessage> invite,
 		_outbox.emplace_back(invite->getSource(), std::move(responseObj));
 		return;
 	}
+	std::string contactExt = intercom ? std::string("999") : std::string(invite->getToNumber());
+
+	// Drawn BEFORE the session is published. Refusing after _sessions.emplace()
+	// would register a session under this Call-ID with no target ever invited and
+	// — unlike the hunt path — no ring timer for tick() to sweep, so it would sit
+	// there permanently; the INVITE retransmit's duplicate emplace() is a silent
+	// no-op, so it would not replace the zombie either (#101A).
+	auto ringing = getMessageFromPool(*invite);
+	if (!ringing) return;   // pool exhausted: drop, peer retransmits (#101A)
+
 	newSession->setBroadcast(true);
 	newSession->setPendingTargets(targets);
 	newSession->setInviteMessage(invite);
 	_sessions.emplace(invite->getCallID(), newSession);
 
-	std::string contactExt = intercom ? std::string("999") : std::string(invite->getToNumber());
-
-	auto ringing = getMessageFromPool(*invite);
-	if (!ringing) return;   // pool exhausted: drop, peer retransmits (#101A)
 	ringing->setHeader("SIP/2.0 180 Ringing");
 	ringing->clearBody();
 	std::string activeIp = _localIp;
@@ -1871,7 +1927,13 @@ bool RequestsHandler::huntRingNext(const std::shared_ptr<Session>& session)
 		}
 
 		session->setPendingTargets({ mc.value() });
-		buildInviteFork(invite, caller, mc.value(), /*intercom=*/false);
+		if (!buildInviteFork(invite, caller, mc.value(), /*intercom=*/false))
+		{
+			// Nothing was rung, so do NOT arm the no-answer timer — that would burn
+			// the full NO_ANSWER_TIMEOUT waiting on a member that never got an
+			// INVITE. Try the next member instead (#101A).
+			continue;
+		}
 		session->armRingTimer(std::chrono::steady_clock::now() + NO_ANSWER_TIMEOUT);
 		return true;
 	}
@@ -1908,7 +1970,13 @@ bool RequestsHandler::redirectInvite(const std::shared_ptr<SipMessage>& invite,
 		if (!session)
 		{
 			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*invite);
-			if (!responseObj) return false;   // pool exhausted: drop, peer retransmits (#101A)
+			// true, not false, even though nothing was sent. false here means
+			// "target not registered — fall through", which on the CFU path would
+			// ring the extension the subscriber explicitly forwarded away from, and
+			// on the REFER path would report "target not registered" for a target
+			// that is. The target WAS resolved; we just could not serve it. Same
+			// answer as the 503 branch below (#101A).
+			if (!responseObj) return true;
 			responseObj->setHeader("SIP/2.0 503 Service Unavailable");
 			responseObj->clearBody();
 			responseObj->setContact(buildContact(caller->getNumber()));
@@ -2971,11 +3039,17 @@ void RequestsHandler::tick()
 			if (client->getNumber().empty()) continue;
 			if (now - client->getLastPingTime() >= std::chrono::seconds(5))
 			{
-				client->setLastPingTime(now);
 				auto ping = buildOptionsPing(client);
-				// Skip this client's keepalive if the pool refused; the next tick
-				// re-pings, and a missed OPTIONS only delays liveness detection.
-				if (ping) _outbox.emplace_back(client->getAddress(), std::move(ping));
+				// Stamp the ping time only once one actually exists. Stamping first
+				// would re-arm the interval gate for a ping that was never sent, so
+				// a refusal would cost a whole keepalive interval instead of being
+				// retried on the next tick — worst behavior exactly when the box is
+				// already overloaded (#101A).
+				if (ping)
+				{
+					client->setLastPingTime(now);
+					_outbox.emplace_back(client->getAddress(), std::move(ping));
+				}
 			}
 		}
 
@@ -4335,12 +4409,13 @@ std::shared_ptr<SipClient> RequestsHandler::allocateVirtualPeer(std::string numb
 	// PbxEnv::allocVirtualPeer — already runs under _mutex. The counter is still
 	// atomic because its decrement happens in the deleter, which runs wherever
 	// the owning Session finally releases it.
+	static std::atomic<std::size_t> vpeerWarnCount{0};
 	if (s_vpeerHeapFallbacksInFlight.load(std::memory_order_relaxed) >= POCKETDIAL_VPEER_HEAP_FALLBACK_MAX)
 	{
-		static std::atomic<std::size_t> warnCount{0};
-		logPoolExhausted("Virtual-peer", warnCount);
+		logPoolExhausted("Virtual-peer", PoolPressure::Refused, vpeerWarnCount);
 		return nullptr;
 	}
+	logPoolExhausted("Virtual-peer", PoolPressure::Fallback, vpeerWarnCount);
 
 	SipClient* raw = nullptr;
 	try

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -422,7 +422,9 @@ private:
 	// Build and queue a single INVITE fork toward one target, re-pointing the
 	// request line / To at that target. `intercom` toggles the auto-answer headers.
 	// Caller holds _mutex.
-	void buildInviteFork(const std::shared_ptr<SipMessage>& invite,
+	// false when the message pool refused: no INVITE was sent, so the caller must
+	// not report success on its behalf (#101A).
+	bool buildInviteFork(const std::shared_ptr<SipMessage>& invite,
 		const std::shared_ptr<SipClient>& caller,
 		const std::shared_ptr<SipClient>& target,
 		bool intercom);

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -48,6 +48,12 @@ public:
 	RequestsHandler(std::string serverIp, int serverPort,
 		OnHandledEvent onHandledEvent);
 
+	// RETURNS NULL under sustained pressure — check it. The pool is bounded and
+	// its heap fallback is now bounded too (Issue #101(A)); once both are spent
+	// this refuses rather than allocating without limit. The contract for a
+	// caller that gets nullptr is to DROP: it cannot answer 503, because building
+	// the 503 would need a message out of the same empty pool. SIP over UDP
+	// retransmits, so a dropped packet costs latency, not the call.
 	static std::shared_ptr<SipMessage> getMessageFromPool(std::string message, sockaddr_in src);
 	// Clones an already-parsed message into a free pool slot via a direct field
 	// copy (SipMessage's copy assignment is a plain owned-string/vector copy —
@@ -58,8 +64,12 @@ public:
 	static std::shared_ptr<SipMessage> getMessageFromPool(const SipMessage& source);
 
 private:
-	// Returns a free (use_count()==1) pool slot, or nullptr if the pool is exhausted.
-	static std::shared_ptr<SipMessage> findFreePoolSlot();
+	// Hands out an uninitialized message the caller exclusively owns: a free
+	// (use_count()==1) pool slot, else a bounded heap fallback, else nullptr once
+	// POCKETDIAL_MSG_HEAP_FALLBACK_MAX are already alive (Issue #101(A)).
+	// Internally synchronized on a leaf mutex — the pool is reachable from the
+	// UDP receive task and the tick task at once. See the definition.
+	static std::shared_ptr<SipMessage> acquirePooledMessage();
 
 public:
 	// ── Media beachhead static helpers (pure; host-unit-tested) ──────────────────
@@ -266,6 +276,12 @@ private:
 	// holds _mutex, same as the direct members they forward to.
 	void enqueue(const sockaddr_in& to, std::shared_ptr<SipMessage> msg) override
 	{
+		// A null here means messageFromPool() refused (pool + bounded heap
+		// fallback both spent, Issue #101(A)). Dropping it centrally keeps the
+		// decomposed machines' `enqueue(addr, messageFromPool(...))` one-liners
+		// safe without a check at each, and guarantees drainOutbox() — which
+		// dereferences every entry — never sees a null.
+		if (!msg) return;
 		_outbox.emplace_back(to, std::move(msg));
 	}
 	std::shared_ptr<SipMessage> messageFromPool(std::string raw, sockaddr_in src) override

--- a/src/SIP/SipMessage.cpp
+++ b/src/SIP/SipMessage.cpp
@@ -132,6 +132,9 @@ SipMessage::SipMessage(const std::string& message, sockaddr_in src) : _src(src)
 // the comment on _bodyGen. Keep this in sync if a member is ever added; the
 // alternative (`= default`) silently reintroduces the stale-cache bug the
 // generation counter exists to prevent.
+// cppcheck flags _bodyGen as unassigned in operator=; the bump above IS the
+// correct semantics, so the check is suppressed rather than satisfied.
+// cppcheck-suppress operatorEqVarError
 SipMessage& SipMessage::operator=(const SipMessage& other)
 {
 	if (this == &other) return *this;   // no body change, so no generation bump

--- a/src/SIP/SipMessage.cpp
+++ b/src/SIP/SipMessage.cpp
@@ -128,6 +128,23 @@ SipMessage::SipMessage(const std::string& message, sockaddr_in src) : _src(src)
 	splitMessage(message, _startLine, _headerLines, _body);
 }
 
+// Member-wise copy of everything EXCEPT _bodyGen, which advances instead — see
+// the comment on _bodyGen. Keep this in sync if a member is ever added; the
+// alternative (`= default`) silently reintroduces the stale-cache bug the
+// generation counter exists to prevent.
+SipMessage& SipMessage::operator=(const SipMessage& other)
+{
+	if (this == &other) return *this;   // no body change, so no generation bump
+
+	_hasSdp      = other._hasSdp;
+	_startLine   = other._startLine;
+	_headerLines = other._headerLines;
+	_body        = other._body;
+	_src         = other._src;
+	++_bodyGen;
+	return *this;
+}
+
 void SipMessage::reset(const std::string& message, sockaddr_in src)
 {
 	_src = src;
@@ -135,6 +152,7 @@ void SipMessage::reset(const std::string& message, sockaddr_in src)
 	// splitMessage() clear()s _headerLines rather than reassigning it, so a
 	// pooled message's vector capacity survives across reset() calls.
 	splitMessage(message, _startLine, _headerLines, _body);
+	++_bodyGen;   // this is the pool-recycle path — see bodyGeneration()
 }
 
 // NOTE (audit #68): setType() was removed. It was dead code (zero call sites,
@@ -230,6 +248,7 @@ void SipMessage::enforceG711()
 	}
 	// Rewriting the codec list changed the SDP body size; resync Content-Length
 	// so the answer isn't dropped as malformed on UDP.
+	++_bodyGen;   // unconditional: cheaper than tracking whether the m= line matched
 	syncContentLength();
 }
 
@@ -250,6 +269,7 @@ void SipMessage::syncContentLength()
 void SipMessage::clearBody()
 {
 	_body.clear();
+	++_bodyGen;
 	syncContentLength();
 }
 
@@ -287,12 +307,25 @@ std::string_view SipMessage::getBody() const
 void SipMessage::setBody(const std::string& body)
 {
 	_body = body;
+	++_bodyGen;
 	syncContentLength();   // keep Content-Length honest (the 777-bug class)
 }
 
 std::string SipMessage::toString() const
 {
 	std::string out;
+	toString(out);
+	return out;
+}
+
+// Issue #101(D): serialize into a caller-owned buffer so a caller that
+// serializes the same message repeatedly — or one per packet on the hot path,
+// like the /api/pcap capture — can reuse one allocation instead of paying for a
+// fresh temporary every time. `out` is cleared first; clear() keeps its capacity,
+// which is the whole point.
+void SipMessage::toString(std::string& out) const
+{
+	out.clear();
 	out.reserve(_startLine.size() + 2 + _body.size() + 64);
 	out += _startLine;
 	out += "\r\n";
@@ -303,7 +336,6 @@ std::string SipMessage::toString() const
 	}
 	out += "\r\n";
 	out += _body;
-	return out;
 }
 
 bool SipMessage::isValidMessage() const

--- a/src/SIP/SipMessage.hpp
+++ b/src/SIP/SipMessage.hpp
@@ -139,7 +139,7 @@ protected:
 	//
 	// Not atomic, and not internally synchronized: like the rest of SipMessage,
 	// a given message is only ever touched under RequestsHandler::_mutex.
-	uint32_t bodyGeneration() const { return _bodyGen; }
+	uint64_t bodyGeneration() const { return _bodyGen; }
 
 	bool _hasSdp = false;
 
@@ -176,7 +176,13 @@ private:
 	// The copy CONSTRUCTOR does copy it, which is correct — there is no
 	// pre-existing cache in a brand-new object to go stale, and the copied body
 	// and copied cache describe the same bytes.
-	uint32_t                 _bodyGen = 1;
+	// 64-bit, not 32: it only ever increments, and a pooled slot on a
+	// long-lived device bumps it several times per handled message. A 32-bit
+	// counter would eventually wrap onto a value a derived cache had already
+	// recorded — reviving a stale SDP parse against a different call's body, the
+	// exact hazard this exists to prevent — or onto 0, the fresh-cache sentinel.
+	// At even 10k bumps/second a 64-bit counter outlives the hardware.
+	uint64_t                 _bodyGen = 1;
 
 	sockaddr_in _src{};
 

--- a/src/SIP/SipMessage.hpp
+++ b/src/SIP/SipMessage.hpp
@@ -33,7 +33,13 @@ public:
 	// member-wise copy of the owned start line / header lines / body is already
 	// correct.
 	SipMessage(const SipMessage& other) = default;
-	SipMessage& operator=(const SipMessage& other) = default;
+	// NOT `= default`, for one reason: _bodyGen must advance rather than be
+	// adopted from `other`. See the comment on _bodyGen — assigning a different
+	// message over this one replaces the body, and a derived class's body cache
+	// has to be able to notice that. Defaulting this operator broke exactly that
+	// (see tests/SipSdpMessage_cache_test.cpp, the pool-style base-subobject
+	// assignment case).
+	SipMessage& operator=(const SipMessage& other);
 
 	// setType() removed (audit #68): dead, and conflated a header-relative offset
 	// with a replace() length. Use setHeader() to rewrite the full start line.
@@ -108,10 +114,32 @@ public:
 	virtual bool hasSdp() const { return _hasSdp; }
 
 	std::string toString() const;
+	// Same serialization into a caller-owned buffer, so a per-packet caller can
+	// reuse one allocation instead of a fresh temporary each time (Issue #101(D)).
+	// `out` is cleared first, retaining its capacity.
+	void toString(std::string& out) const;
 	bool isValidMessage() const;
 
 protected:
 	std::string_view extractNumber(std::string_view header) const;
+
+	// Issue #101(B): monotonic counter bumped by every mutation of _body, so a
+	// derived class can cache a parse of the body and know when it went stale
+	// WITHOUT this class having to know that any such cache exists. Messages are
+	// pooled and recycled (reset() on a slot handed back out), so "the body I
+	// parsed" and "the body this object holds now" can differ across calls that
+	// look identical from the outside — the counter is what makes that visible.
+	// Deliberately not a dirty *flag*: a flag would have to be cleared by the
+	// cache owner, which puts the base class and every derived cache in a
+	// two-way handshake. A number only ever goes up, so a stale reader can only
+	// ever conclude "re-parse", never "still fresh".
+	//
+	// Starts at 1, never 0: a cache initialized to generation 0 is therefore
+	// stale on first use without needing a separate valid/empty flag.
+	//
+	// Not atomic, and not internally synchronized: like the rest of SipMessage,
+	// a given message is only ever touched under RequestsHandler::_mutex.
+	uint32_t bodyGeneration() const { return _bodyGen; }
 
 	bool _hasSdp = false;
 
@@ -122,9 +150,33 @@ private:
 	// in sync: named getters look their header up by name on every call (a
 	// handful of short string compares against _headerLines, not a rescan of
 	// the whole message), so nothing needs a reparse step after a mutation.
+	//
+	// The body is the one exception, and it is a derived-class concern: an SDP
+	// body IS worth parsing once (SipSdpMessage, Issue #101(B)). This class does
+	// not hold that cache — it only publishes _bodyGen via bodyGeneration() so
+	// the cache's owner can tell when its parse went stale.
 	std::string              _startLine;
 	std::vector<std::string> _headerLines;
 	std::string              _body;
+	// Bumped by every _body mutation — see bodyGeneration().
+	//
+	// This value is meaningful only WITHIN one object: it is that object's
+	// private, monotonically-increasing body timeline, never a global version.
+	// Two different messages sharing the value 7 means nothing.
+	//
+	// Which is why operator= bumps it instead of copying it. The pool assigns
+	// through a base reference (`*msg = source` on a shared_ptr<SipMessage>,
+	// RequestsHandler.cpp), so ONLY this subobject is assigned and a derived
+	// cache is left untouched — if the destination also adopted the source's
+	// generation, the two could coincide and the stale cache would look fresh.
+	// Bumping keeps the invariant local and airtight: a cache's recorded
+	// generation only ever holds a value from ITS OWN object's timeline, so
+	// "recorded == current" can only mean "parsed from exactly these bytes".
+	//
+	// The copy CONSTRUCTOR does copy it, which is correct — there is no
+	// pre-existing cache in a brand-new object to go stale, and the copied body
+	// and copied cache describe the same bytes.
+	uint32_t                 _bodyGen = 1;
 
 	sockaddr_in _src{};
 

--- a/src/SIP/SipSdpMessage.cpp
+++ b/src/SIP/SipSdpMessage.cpp
@@ -5,58 +5,19 @@
 #include <iostream>
 #include <cctype>
 
-namespace
-{
-	// The six SDP fields SipSdpMessage exposes, extracted in a single pass over
-	// the body. Mirrors the old parseSdp() line-splitting exactly (primary
-	// "\r\n" delimiter, bare "\n" fallback) so behavior on mixed/malformed line
-	// endings is unchanged.
-	struct SdpFields
-	{
-		std::string_view version, originator, sessionName, connectionInformation, time, media;
-	};
-
-	SdpFields parseSdpFields(std::string_view body)
-	{
-		SdpFields f;
-		size_t pos_start = 0;
-		while (pos_start < body.size())
-		{
-			size_t pos_end = body.find("\r\n", pos_start);
-			size_t next_start = pos_end + 2;
-			if (pos_end == std::string_view::npos)
-			{
-				pos_end = body.find('\n', pos_start);
-				next_start = pos_end + 1;
-			}
-
-			std::string_view line;
-			if (pos_end == std::string_view::npos)
-			{
-				line = body.substr(pos_start);
-				pos_start = body.size();
-			}
-			else
-			{
-				line = body.substr(pos_start, pos_end - pos_start);
-				pos_start = next_start;
-			}
-
-			if (line.empty()) continue;
-
-			if (line.compare(0, 2, "v=") == 0)      f.version = line;
-			else if (line.compare(0, 2, "o=") == 0) f.originator = line;
-			else if (line.compare(0, 2, "s=") == 0) f.sessionName = line;
-			else if (line.compare(0, 2, "c=") == 0) f.connectionInformation = line;
-			else if (line.compare(0, 2, "t=") == 0) f.time = line;
-			else if (line.compare(0, 2, "m=") == 0) f.media = line;
-		}
-		return f;
-	}
-}
-
 SipSdpMessage::SipSdpMessage(const std::string& message, sockaddr_in src) : SipMessage(message, src)
 {
+}
+
+SipSdpMessage& SipSdpMessage::operator=(const SipSdpMessage& other)
+{
+	if (this == &other) return *this;
+
+	SipMessage::operator=(other);   // copies the body, advances _bodyGen
+	// Deliberately NOT copying _spans/_spansGen — see the header. Generation 0
+	// is never a live body generation, so this forces a re-parse on next access.
+	_spansGen = 0;
+	return *this;
 }
 
 void SipSdpMessage::setMedia(std::string value)
@@ -89,34 +50,111 @@ void SipSdpMessage::setMedia(std::string value)
 	// was no media line to replace.
 }
 
+// Issue #101(B): one single-pass parse of the body, cached until the body
+// changes. Line splitting mirrors the old per-accessor parseSdpFields() exactly
+// (primary "\r\n" delimiter, bare "\n" fallback) so behavior on mixed/malformed
+// line endings is unchanged, as is last-one-wins when a body repeats a field.
+const SipSdpMessage::SdpSpans& SipSdpMessage::ensureParsed() const
+{
+	const uint32_t gen = bodyGeneration();
+	if (_spansGen == gen)
+	{
+		return _spans;   // body has not been touched since the last parse
+	}
+
+	const std::string_view body = getBody();
+
+	// Rebuilt from scratch rather than updated in place: a field present in the
+	// PREVIOUS body and absent from this one must not survive in the cache. This
+	// is the recycled-pool-slot case (reset() hands the same object back out with
+	// a different call's SDP), which is precisely what makes a stale cache here
+	// dangerous rather than merely wrong.
+	SdpSpans spans;
+
+	size_t pos_start = 0;
+	while (pos_start < body.size())
+	{
+		const size_t lineStart = pos_start;
+		size_t pos_end = body.find("\r\n", pos_start);
+		size_t next_start = pos_end + 2;
+		if (pos_end == std::string_view::npos)
+		{
+			pos_end = body.find('\n', pos_start);
+			next_start = pos_end + 1;
+		}
+
+		std::string_view line;
+		if (pos_end == std::string_view::npos)
+		{
+			line = body.substr(pos_start);
+			pos_start = body.size();
+		}
+		else
+		{
+			line = body.substr(pos_start, pos_end - pos_start);
+			pos_start = next_start;
+		}
+
+		if (line.empty()) continue;
+
+		const FieldSpan span{static_cast<uint32_t>(lineStart), static_cast<uint32_t>(line.size())};
+		if (line.compare(0, 2, "v=") == 0)      spans.version = span;
+		else if (line.compare(0, 2, "o=") == 0) spans.originator = span;
+		else if (line.compare(0, 2, "s=") == 0) spans.sessionName = span;
+		else if (line.compare(0, 2, "c=") == 0) spans.connectionInformation = span;
+		else if (line.compare(0, 2, "t=") == 0) spans.time = span;
+		else if (line.compare(0, 2, "m=") == 0) spans.media = span;
+	}
+
+	_spans    = spans;
+	_spansGen = gen;
+	return _spans;
+}
+
+std::string_view SipSdpMessage::viewOf(const FieldSpan& span) const
+{
+	if (span.len == 0) return {};   // field absent — same empty view as before
+
+	// Belt-and-braces: ensureParsed() guarantees the span indexes the body it was
+	// parsed from, so an out-of-range span means the generation counter missed a
+	// mutation. Report the field absent rather than let substr() throw
+	// std::out_of_range out of the middle of a SIP handler — exceptions are
+	// enabled in the ESP-IDF build (CONFIG_COMPILER_CXX_EXCEPTIONS=y) but nothing
+	// up the call stack catches, so the throw would take the SIP task with it.
+	// The invariant is still enforced by the tests, not by this clamp.
+	const std::string_view body = getBody();
+	if (span.pos > body.size() || span.len > body.size() - span.pos) return {};
+	return body.substr(span.pos, span.len);
+}
+
 std::string_view SipSdpMessage::getVersion() const
 {
-	return parseSdpFields(getBody()).version;
+	return viewOf(ensureParsed().version);
 }
 
 std::string_view SipSdpMessage::getOriginator() const
 {
-	return parseSdpFields(getBody()).originator;
+	return viewOf(ensureParsed().originator);
 }
 
 std::string_view SipSdpMessage::getSessionName() const
 {
-	return parseSdpFields(getBody()).sessionName;
+	return viewOf(ensureParsed().sessionName);
 }
 
 std::string_view SipSdpMessage::getConnectionInformation() const
 {
-	return parseSdpFields(getBody()).connectionInformation;
+	return viewOf(ensureParsed().connectionInformation);
 }
 
 std::string_view SipSdpMessage::getTime() const
 {
-	return parseSdpFields(getBody()).time;
+	return viewOf(ensureParsed().time);
 }
 
 std::string_view SipSdpMessage::getMedia() const
 {
-	return parseSdpFields(getBody()).media;
+	return viewOf(ensureParsed().media);
 }
 
 int SipSdpMessage::getRtpPort() const

--- a/src/SIP/SipSdpMessage.cpp
+++ b/src/SIP/SipSdpMessage.cpp
@@ -56,7 +56,7 @@ void SipSdpMessage::setMedia(std::string value)
 // line endings is unchanged, as is last-one-wins when a body repeats a field.
 const SipSdpMessage::SdpSpans& SipSdpMessage::ensureParsed() const
 {
-	const uint32_t gen = bodyGeneration();
+	const uint64_t gen = bodyGeneration();
 	if (_spansGen == gen)
 	{
 		return _spans;   // body has not been touched since the last parse

--- a/src/SIP/SipSdpMessage.hpp
+++ b/src/SIP/SipSdpMessage.hpp
@@ -77,7 +77,7 @@ private:
 	// Generation of the body _spans was parsed from. 0 is never a live body
 	// generation (SipMessage::_bodyGen starts at 1), so a fresh or freshly-copied
 	// message re-parses on first access without needing a separate valid flag.
-	mutable uint32_t _spansGen = 0;
+	mutable uint64_t _spansGen = 0;
 
 	// Re-parses the body iff it has changed since the last parse.
 	const SdpSpans& ensureParsed() const;

--- a/src/SIP/SipSdpMessage.hpp
+++ b/src/SIP/SipSdpMessage.hpp
@@ -1,12 +1,28 @@
 #ifndef SIP_SDP_MESSAGE_HPP
 #define SIP_SDP_MESSAGE_HPP
 
+#include <cstdint>
+
 #include "SipMessage.hpp"
 
 class SipSdpMessage : public SipMessage
 {
 public:
 	SipSdpMessage(const std::string& message, sockaddr_in src);
+
+	// The copy CONSTRUCTOR is safe defaulted: it takes both the body generation
+	// and the cache generation from the same object, so a fresh cache stays
+	// fresh and a stale one stays stale.
+	SipSdpMessage(const SipSdpMessage& other) = default;
+
+	// Copy ASSIGNMENT is not. The implicit one would bump THIS object's body
+	// generation (via SipMessage::operator=) and then overwrite the cache
+	// generation with the SOURCE's — mixing two objects' private timelines, which
+	// is exactly what SipMessage::_bodyGen's contract forbids. Where the two
+	// happen to collide, this object's stale spans would be read as current
+	// against a body they were never parsed from. Assignment therefore drops the
+	// cache rather than copying it.
+	SipSdpMessage& operator=(const SipSdpMessage& other);
 
 	// Issue #42: see SipMessage::hasSdp(). This concrete type always carries SDP.
 	bool hasSdp() const override { return _hasSdp; }
@@ -22,6 +38,51 @@ public:
 	int getRtpPort() const;
 
 private:
+	// Issue #101(B): the six accessors above used to re-parse the whole SDP body
+	// on every call — getRtpPort() alone walks it twice (once for m=, once to cut
+	// the port out), and call setup touches several of them per INVITE. They now
+	// share one single-pass parse, cached until the body changes.
+	//
+	// The cache stores (offset, length) spans into the base class's body, NOT
+	// string_views. That is the whole trick, and it is deliberate: SipMessage is
+	// copyable by design and the message pool recycles slots with `*msg = source`
+	// (RequestsHandler.cpp), so a cached string_view would be copied verbatim and
+	// left pointing into the SOURCE message's body — dangling the moment that
+	// message is itself recycled. Offsets are position-independent, so the
+	// defaulted copy stays correct and SipMessage.hpp's "no string_view to fix up
+	// after a copy" property survives intact.
+	//
+	// len == 0 means "field absent": every line we match starts with a two-char
+	// prefix, so a matched span is never shorter than 2 and the sentinel is
+	// unambiguous. Absent fields return an empty view, exactly as before.
+	struct FieldSpan
+	{
+		uint32_t pos = 0;
+		uint32_t len = 0;
+	};
+	struct SdpSpans
+	{
+		FieldSpan version, originator, sessionName, connectionInformation, time, media;
+	};
+
+	// mutable: the accessors are const and observably still pure — a re-parse is
+	// invisible to the caller. Note this does make the const accessors WRITE, so
+	// unlike before they are not safe to call concurrently on one message.
+	// Verified survivable: the only call sites outside this class are the two in
+	// RequestsHandler::parseCallerRtp (getRtpPort / getConnectionInformation),
+	// reached solely from onMediaInvite, which runs under RequestsHandler::_mutex
+	// like every other handler. Re-check this if an SDP accessor is ever called
+	// from the HTTP/dashboard task or a media task.
+	mutable SdpSpans _spans{};
+	// Generation of the body _spans was parsed from. 0 is never a live body
+	// generation (SipMessage::_bodyGen starts at 1), so a fresh or freshly-copied
+	// message re-parses on first access without needing a separate valid flag.
+	mutable uint32_t _spansGen = 0;
+
+	// Re-parses the body iff it has changed since the last parse.
+	const SdpSpans& ensureParsed() const;
+	std::string_view viewOf(const FieldSpan& span) const;
+
 	int extractRtpPort(std::string_view data) const;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,14 @@ include_directories(${gtest_SOURCE_DIR}/include ../src/SIP ../src/Helpers)
 add_executable(sip_parser_tests
     SipMessage_test.cpp
     SipMessage_header_test.cpp
+    # Issue #101(B): SDP parse-once cache. Covers every body-mutation path that
+    # must invalidate it — including reset() and `*msg = source`, the two ways
+    # the message pool recycles a slot into a different call.
+    SipSdpMessage_cache_test.cpp
+    # Issue #101(A)/(E): message-pool backpressure (bounded heap fallback, then
+    # refuse) and the concurrent-handout invariant. Draws on the process-global
+    # pool, so each test releases what it holds before it ends.
+    RequestsHandler_pool_test.cpp
     SipStatus_test.cpp
     SipDigest_test.cpp
     ArpLookup_test.cpp

--- a/tests/PcapCapture_test.cpp
+++ b/tests/PcapCapture_test.cpp
@@ -212,3 +212,105 @@ TEST(PcapCapture, RequestsHandlerGetTraceRecordsMirrorsGetPcapCapture)
 	EXPECT_EQ(recs[0].peer, "192.168.4.50:5060");
 	EXPECT_NE(recs[0].text.find("REGISTER sip:server"), std::string::npos);
 }
+
+// ── Issue #101(D): the capture path must stop allocating once the ring is full ──
+//
+// Capture is unconditional and runs under RequestsHandler::_mutex, so a
+// per-packet malloc/free sat inside the SIP critical section. The fix recycles
+// each evicted entry's buffer in place. These tests assert that recycling
+// directly rather than trusting the comment: a freshly-constructed std::string
+// would come back with small-string capacity and a different data pointer.
+
+TEST(PcapCapture, RecordIntoRecyclesEvictedBufferInsteadOfReallocating) {
+	PcapCapture cap;
+	const sockaddr_in peer = addr("10.0.0.9", 5060);
+	// Comfortably past any small-string optimization, so the buffer is a real
+	// heap allocation whose identity we can track.
+	const std::string big(1200, 'x');
+
+	// Fill the ring exactly once.
+	for (size_t i = 0; i < POCKETDIAL_PCAP_RING_SIZE; ++i)
+	{
+		cap.recordInto(false, peer).assign(big);
+	}
+	ASSERT_EQ(cap.size(), POCKETDIAL_PCAP_RING_SIZE);
+
+	// The next record wraps onto the oldest slot. Its buffer must be the one that
+	// slot already owned: emptied, but with its capacity — and its address — kept.
+	std::string& wrapped = cap.recordInto(false, peer);
+	const char* recycledData = wrapped.data();
+	EXPECT_EQ(wrapped.size(), 0u);
+	EXPECT_GE(wrapped.capacity(), big.size());
+	wrapped.assign(big);
+
+	// Come all the way around again: the same slot, hence the same buffer, with
+	// no reallocation in between.
+	for (size_t i = 0; i < POCKETDIAL_PCAP_RING_SIZE - 1; ++i)
+	{
+		cap.recordInto(false, peer).assign(big);
+	}
+	std::string& sameSlot = cap.recordInto(false, peer);
+	EXPECT_EQ(sameSlot.data(), recycledData);
+	EXPECT_GE(sameSlot.capacity(), big.size());
+}
+
+// The ring must not grow past its cap, and must not shrink back either — a slot
+// that has been used keeps its buffer for the next packet that lands there.
+TEST(PcapCapture, RingSizeSaturatesAtCapacityAndClearResetsOrdering) {
+	PcapCapture cap;
+	const sockaddr_in peer = addr("10.0.0.9", 5060);
+
+	for (size_t i = 0; i < POCKETDIAL_PCAP_RING_SIZE * 3; ++i)
+	{
+		cap.record(false, peer, "PING " + std::to_string(i));
+	}
+	EXPECT_EQ(cap.size(), POCKETDIAL_PCAP_RING_SIZE);
+
+	// Still oldest-first after multiple wraps, and holding the LAST ring-size
+	// packets — storage order and capture order have diverged by now, so this is
+	// really checking that every reader goes through the ring head.
+	auto recs = cap.traceRecords();
+	ASSERT_EQ(recs.size(), POCKETDIAL_PCAP_RING_SIZE);
+	const size_t firstKept = POCKETDIAL_PCAP_RING_SIZE * 3 - POCKETDIAL_PCAP_RING_SIZE;
+	for (size_t i = 0; i < recs.size(); ++i)
+	{
+		EXPECT_EQ(recs[i].text, "PING " + std::to_string(firstKept + i)) << "index " << i;
+		if (i > 0) EXPECT_GT(recs[i].seq, recs[i - 1].seq) << "index " << i;
+	}
+
+	// clear() has to reset the head too, or the next fill reads out rotated.
+	cap.clear();
+	EXPECT_EQ(cap.size(), 0u);
+	cap.record(false, peer, "AFTER-CLEAR-0");
+	cap.record(false, peer, "AFTER-CLEAR-1");
+	auto after = cap.traceRecords();
+	ASSERT_EQ(after.size(), 2u);
+	EXPECT_EQ(after[0].text, "AFTER-CLEAR-0");
+	EXPECT_EQ(after[1].text, "AFTER-CLEAR-1");
+}
+
+// The pcap file itself must also come out in capture order after a wrap: the
+// serializer walks the same ring and writes one record per entry, oldest first.
+TEST(PcapCapture, PcapFileStaysInCaptureOrderAfterWrap) {
+	PcapCapture cap;
+	const sockaddr_in peer = addr("10.0.0.9", 5060);
+	for (size_t i = 0; i < POCKETDIAL_PCAP_RING_SIZE + 3; ++i)
+	{
+		cap.record(false, peer, "SEQ" + std::to_string(i) + "-payload");
+	}
+
+	const std::string file = cap.toPcapFile("10.0.0.1", 5060);
+	// Oldest surviving packet is #3; it must appear before #4, and so on.
+	size_t prev = 0;
+	for (size_t i = 3; i < POCKETDIAL_PCAP_RING_SIZE + 3; ++i)
+	{
+		const std::string needle = "SEQ" + std::to_string(i) + "-payload";
+		const size_t at = file.find(needle);
+		ASSERT_NE(at, std::string::npos) << needle << " missing from pcap";
+		EXPECT_GT(at, prev) << needle << " out of capture order";
+		prev = at;
+	}
+	// And the evicted ones are gone.
+	EXPECT_EQ(file.find("SEQ0-payload"), std::string::npos);
+	EXPECT_EQ(file.find("SEQ2-payload"), std::string::npos);
+}

--- a/tests/RequestsHandler_pool_test.cpp
+++ b/tests/RequestsHandler_pool_test.cpp
@@ -192,8 +192,14 @@ TEST(RequestsHandlerPool, HandlerDropsPacketsWhilePoolIsStarvedAndRecovers) {
 		handler.handle(RequestsHandler::getMessageFromPool(registerRaw("starved"), poolAddr()));
 
 		// Nothing was produced, and nothing captured — the packet never existed.
+		// Both views of the ring are checked: a bare header (24 bytes, no packet
+		// records) pins that no partial capture leaked in either direction, which
+		// getTraceRecords().empty() alone would not catch if only the outbound
+		// side had been recorded.
 		EXPECT_TRUE(handler.getTraceRecords().empty())
 			<< "a dropped packet must not reach the capture ring";
+		EXPECT_EQ(handler.getPcapCapture().size(), 24u)
+			<< "pcap ring must hold nothing but the global header";
 	}
 
 	// Capacity restored: the same packet now gets a response.

--- a/tests/RequestsHandler_pool_test.cpp
+++ b/tests/RequestsHandler_pool_test.cpp
@@ -1,0 +1,207 @@
+// Issue #101(A) + #101(E): message-pool backpressure and the handout race.
+//
+// Two properties are under test here, and they are easy to conflate:
+//
+//   A. Exhaustion is BOUNDED and RECOVERABLE. Past the pool plus
+//      POCKETDIAL_MSG_HEAP_FALLBACK_MAX live heap fallbacks, getMessageFromPool()
+//      refuses instead of allocating without limit; releasing messages restores
+//      capacity, which is also the only way to observe that the fallback
+//      deleter gives its budget back.
+//
+//   E. Every draw hands out a DISTINCT message. The pool is a process-global
+//      static scanned for use_count()==1 from the UDP receive task (off-lock)
+//      and the tick task (under _mutex) at once, so the scan-then-take was a
+//      data race: both could take the same slot and reset() it concurrently.
+//
+// NOTE: because the pool is process-global and shared with every other test in
+// this binary, each test here must release everything it holds before it ends.
+// The scoped vectors below are load-bearing, not style.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "PoolConfig.hpp"
+#include "RequestsHandler.hpp"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	sockaddr_in poolAddr()
+	{
+		sockaddr_in a{};
+		a.sin_family = AF_INET;
+		a.sin_port   = htons(5060);
+		::inet_pton(AF_INET, "192.168.4.77", &a.sin_addr);
+		return a;
+	}
+
+	std::string registerRaw(const std::string& callId)
+	{
+		return "REGISTER sip:server SIP/2.0\r\n"
+		       "Via: SIP/2.0/UDP 192.168.4.77:5060;branch=z9hG4bK" + callId + "\r\n"
+		       "From: <sip:101@server>;tag=t" + callId + "\r\n"
+		       "To: <sip:101@server>\r\n"
+		       "Call-ID: " + callId + "\r\n"
+		       "CSeq: 1 REGISTER\r\n"
+		       "Contact: <sip:101@192.168.4.77:5060>;expires=3600\r\n"
+		       "Content-Length: 0\r\n\r\n";
+	}
+
+	// Pool depth plus the fallback ceiling: the total this process can ever have
+	// in flight at once.
+	constexpr size_t kCeiling = POCKETDIAL_MSG_POOL + POCKETDIAL_MSG_HEAP_FALLBACK_MAX;
+
+	// The static _messagePool is populated lazily by the first RequestsHandler
+	// constructed in the process. A test that draws from the pool without one in
+	// existence measures only the heap fallback and silently proves nothing, so
+	// every test here holds one — and does not depend on another test having run
+	// first to fill it.
+	RequestsHandler makeHandler()
+	{
+		return RequestsHandler("192.168.4.1", 5060,
+			[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	}
+}
+
+// Draw until refused, then confirm the refusal is at the documented ceiling and
+// that releasing restores capacity.
+TEST(RequestsHandlerPool, RefusesPastBoundedFallbackThenRecovers) {
+	RequestsHandler handler = makeHandler();   // populates the static pool
+	{
+		std::vector<std::shared_ptr<SipMessage>> held;
+		held.reserve(kCeiling);
+
+		// Well past the ceiling: this must terminate on its own, which is the
+		// whole point — the old code would have allocated every time.
+		for (size_t i = 0; i < kCeiling * 4; ++i)
+		{
+			auto msg = RequestsHandler::getMessageFromPool(registerRaw("c" + std::to_string(i)), poolAddr());
+			if (!msg) break;
+			held.push_back(std::move(msg));
+		}
+
+		EXPECT_LE(held.size(), kCeiling)
+			<< "handed out more than pool + bounded fallback";
+		EXPECT_GE(held.size(), static_cast<size_t>(POCKETDIAL_MSG_POOL))
+			<< "refused before even the pool was drawn down";
+		EXPECT_EQ(RequestsHandler::getMessageFromPool(registerRaw("over"), poolAddr()), nullptr)
+			<< "must keep refusing while everything is still held";
+	}
+
+	// Everything released: the fallback deleter must have returned its budget,
+	// so the very next draw succeeds again. A leaked counter shows up here.
+	auto after = RequestsHandler::getMessageFromPool(registerRaw("recovered"), poolAddr());
+	EXPECT_NE(after, nullptr) << "pool did not recover after all references were dropped";
+}
+
+// The clone overload draws from the same pool and must refuse the same way,
+// rather than falling through to an unbounded allocation.
+TEST(RequestsHandlerPool, CloneOverloadHonoursTheSameCeiling) {
+	RequestsHandler handler = makeHandler();   // populates the static pool
+	auto seed = RequestsHandler::getMessageFromPool(registerRaw("seed"), poolAddr());
+	ASSERT_NE(seed, nullptr);
+	{
+		std::vector<std::shared_ptr<SipMessage>> held;
+		for (size_t i = 0; i < kCeiling * 4; ++i)
+		{
+			auto msg = RequestsHandler::getMessageFromPool(*seed);
+			if (!msg) break;
+			held.push_back(std::move(msg));
+		}
+		EXPECT_LE(held.size() + 1, kCeiling);
+		EXPECT_EQ(RequestsHandler::getMessageFromPool(*seed), nullptr);
+	}
+	EXPECT_NE(RequestsHandler::getMessageFromPool(*seed), nullptr);
+}
+
+// #101(E): every concurrent draw must yield a distinct message. Under the old
+// unsynchronized scan two threads could both see use_count()==1 on one slot and
+// both take it — this is the assertion that trips when that happens. It cannot
+// prove the race is gone, but it pins the invariant and reproduces the real
+// topology (desktop runs a tick thread alongside the receive path, same as the
+// device's tick task alongside the UDP task).
+TEST(RequestsHandlerPool, ConcurrentDrawsNeverHandOutTheSameMessageTwice) {
+	RequestsHandler handler = makeHandler();   // populates the static pool
+	constexpr int kThreads = 4;
+	constexpr int kPerThread = 6;
+
+	std::vector<std::vector<std::shared_ptr<SipMessage>>> perThread(kThreads);
+	std::atomic<bool> go{false};
+	std::vector<std::thread> threads;
+
+	for (int t = 0; t < kThreads; ++t)
+	{
+		threads.emplace_back([&, t] {
+			while (!go.load(std::memory_order_acquire)) { /* line them up */ }
+			for (int i = 0; i < kPerThread; ++i)
+			{
+				auto msg = RequestsHandler::getMessageFromPool(
+					registerRaw("t" + std::to_string(t) + "-" + std::to_string(i)), poolAddr());
+				if (msg) perThread[t].push_back(std::move(msg));
+			}
+		});
+	}
+	go.store(true, std::memory_order_release);
+	for (auto& th : threads) th.join();
+
+	std::set<const SipMessage*> seen;
+	size_t total = 0;
+	for (const auto& bucket : perThread)
+	{
+		for (const auto& msg : bucket)
+		{
+			++total;
+			EXPECT_TRUE(seen.insert(msg.get()).second)
+				<< "same SipMessage handed to two concurrent callers";
+		}
+	}
+	EXPECT_EQ(seen.size(), total);
+	EXPECT_GT(total, 0u);
+	// perThread goes out of scope here, returning everything to the pool.
+}
+
+// End to end: with the pool starved, a packet arriving at handle() must be
+// dropped cleanly — no crash, no half-built response — and normal service must
+// resume once capacity comes back.
+TEST(RequestsHandlerPool, HandlerDropsPacketsWhilePoolIsStarvedAndRecovers) {
+	RequestsHandler handler("192.168.4.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+
+	{
+		std::vector<std::shared_ptr<SipMessage>> held;
+		for (size_t i = 0; i < kCeiling * 4; ++i)
+		{
+			auto msg = RequestsHandler::getMessageFromPool(registerRaw("s" + std::to_string(i)), poolAddr());
+			if (!msg) break;
+			held.push_back(std::move(msg));
+		}
+		ASSERT_FALSE(held.empty());
+
+		// This is the real inbound shape: SipMessageFactory hands handle() whatever
+		// the pool returned, which is nullptr right now. handle() already dropped
+		// nulls, so the highest-volume path needed no new code.
+		handler.handle(RequestsHandler::getMessageFromPool(registerRaw("starved"), poolAddr()));
+
+		// Nothing was produced, and nothing captured — the packet never existed.
+		EXPECT_TRUE(handler.getTraceRecords().empty())
+			<< "a dropped packet must not reach the capture ring";
+	}
+
+	// Capacity restored: the same packet now gets a response.
+	auto revived = RequestsHandler::getMessageFromPool(registerRaw("revived"), poolAddr());
+	ASSERT_NE(revived, nullptr);
+	handler.handle(std::move(revived));
+
+	auto recs = handler.getTraceRecords();
+	ASSERT_FALSE(recs.empty()) << "handler stopped responding after pool recovery";
+	EXPECT_NE(recs[0].text.find("REGISTER sip:server"), std::string::npos);
+}

--- a/tests/SipSdpMessage_cache_test.cpp
+++ b/tests/SipSdpMessage_cache_test.cpp
@@ -1,0 +1,346 @@
+// Issue #101(B): SipSdpMessage caches one single-pass parse of the SDP body
+// instead of re-parsing it on every accessor call. The cache is keyed on
+// SipMessage's body generation counter, so these tests are really about one
+// question: does every path that changes the body make the cache notice?
+//
+// The dangerous path is the pool one. RequestsHandler pre-allocates
+// POCKETDIAL_MSG_POOL SipSdpMessages and hands the same objects out over and
+// over via reset() and `*msg = source`. A cache that survives either of those
+// serves the PREVIOUS call's SDP to the current call — a wrong c= line or m=
+// port means media set up against the wrong endpoint, which is far worse than
+// the re-parse cost this change removes.
+
+#include <gtest/gtest.h>
+
+#include "SipSdpMessage.hpp"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	sockaddr_in localAddr()
+	{
+		sockaddr_in s{};
+		s.sin_family      = AF_INET;
+		s.sin_addr.s_addr = inet_addr("127.0.0.1");
+		s.sin_port        = htons(5060);
+		return s;
+	}
+
+	// A complete INVITE with an SDP offer, Content-Length kept honest so the
+	// message parses the same way one off the wire would.
+	std::string inviteWith(const std::string& body)
+	{
+		return "INVITE sip:200@server SIP/2.0\r\n"
+		       "Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bK1\r\n"
+		       "From: <sip:100@server>;tag=a\r\n"
+		       "To: <sip:200@server>\r\n"
+		       "Call-ID: call-one\r\n"
+		       "CSeq: 1 INVITE\r\n"
+		       "Content-Type: application/sdp\r\n"
+		       "Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+	}
+
+	const char* kBodyA =
+		"v=0\r\n"
+		"o=- 111 111 IN IP4 192.168.1.10\r\n"
+		"s=call-a\r\n"
+		"c=IN IP4 192.168.1.10\r\n"
+		"t=0 0\r\n"
+		"m=audio 4000 RTP/AVP 0 8 101\r\n"
+		"a=rtpmap:0 PCMU/8000\r\n";
+
+	// Deliberately a DIFFERENT SHAPE from kBodyA, not just different values: every
+	// line has a different length, so the two bodies' field offsets do not line
+	// up. That matters because the cache stores offsets — if body B's lines sat at
+	// body A's offsets, a cache that was never invalidated would read B at A's
+	// offsets and still return B's correct text, and every invalidation test here
+	// would pass while testing nothing. (Confirmed by mutation: with same-shape
+	// bodies, ResetInvalidatesCache passes against a cache that never
+	// invalidates. With these, it fails.)
+	const char* kBodyB =
+		"v=0\r\n"
+		"o=- 22 22 IN IP4 10.1.1.7\r\n"
+		"s=b\r\n"
+		"c=IN IP4 10.1.1.7\r\n"
+		"t=1 2\r\n"
+		"m=audio 5678 RTP/AVP 8\r\n";
+}
+
+// Baseline: the cached parse must return exactly what the old per-call parse
+// did, including on repeat reads.
+TEST(SipSdpMessageCache, AccessorsReturnParsedFieldsAndAreStableAcrossCalls) {
+	SipSdpMessage m(inviteWith(kBodyA), localAddr());
+
+	EXPECT_EQ(std::string(m.getVersion()), "v=0");
+	EXPECT_EQ(std::string(m.getOriginator()), "o=- 111 111 IN IP4 192.168.1.10");
+	EXPECT_EQ(std::string(m.getSessionName()), "s=call-a");
+	EXPECT_EQ(std::string(m.getConnectionInformation()), "c=IN IP4 192.168.1.10");
+	EXPECT_EQ(std::string(m.getTime()), "t=0 0");
+	EXPECT_EQ(std::string(m.getMedia()), "m=audio 4000 RTP/AVP 0 8 101");
+	EXPECT_EQ(m.getRtpPort(), 4000);
+
+	// Second pass reads from the cache — same answers, not empty views.
+	EXPECT_EQ(std::string(m.getVersion()), "v=0");
+	EXPECT_EQ(std::string(m.getConnectionInformation()), "c=IN IP4 192.168.1.10");
+	EXPECT_EQ(m.getRtpPort(), 4000);
+}
+
+// A body with no SDP at all: every field absent, and asking twice must not
+// somehow populate it.
+TEST(SipSdpMessageCache, AbsentFieldsReturnEmptyViews) {
+	SipSdpMessage m(inviteWith(""), localAddr());
+
+	EXPECT_TRUE(m.getVersion().empty());
+	EXPECT_TRUE(m.getMedia().empty());
+	EXPECT_TRUE(m.getConnectionInformation().empty());
+	EXPECT_EQ(m.getRtpPort(), 0);
+	EXPECT_TRUE(m.getMedia().empty());
+}
+
+// setBody() is the park path's tool (ParkOrbit.cpp swaps each leg's SDP onto
+// the opposite dialog). Reading before the swap must not pin the old answer.
+TEST(SipSdpMessageCache, SetBodyInvalidatesCache) {
+	SipSdpMessage m(inviteWith(kBodyA), localAddr());
+	ASSERT_EQ(m.getRtpPort(), 4000);                        // prime the cache
+	ASSERT_EQ(std::string(m.getSessionName()), "s=call-a");
+
+	m.setBody(kBodyB);
+
+	EXPECT_EQ(std::string(m.getSessionName()), "s=b");
+	EXPECT_EQ(std::string(m.getConnectionInformation()), "c=IN IP4 10.1.1.7");
+	EXPECT_EQ(std::string(m.getMedia()), "m=audio 5678 RTP/AVP 8");
+	EXPECT_EQ(m.getRtpPort(), 5678);
+}
+
+// setMedia() rewrites only the m= line, in place, via setBody().
+TEST(SipSdpMessageCache, SetMediaInvalidatesCache) {
+	SipSdpMessage m(inviteWith(kBodyA), localAddr());
+	ASSERT_EQ(m.getRtpPort(), 4000);
+
+	m.setMedia("m=audio 9999 RTP/AVP 8");
+
+	EXPECT_EQ(std::string(m.getMedia()), "m=audio 9999 RTP/AVP 8");
+	EXPECT_EQ(m.getRtpPort(), 9999);
+	// Neighbouring fields still resolve — the spans after the edited line moved,
+	// so this also catches offsets that were not recomputed.
+	EXPECT_EQ(std::string(m.getConnectionInformation()), "c=IN IP4 192.168.1.10");
+}
+
+// enforceG711() rewrites the codec list on the m= line — a body mutation that
+// does NOT go through setBody().
+TEST(SipSdpMessageCache, EnforceG711InvalidatesCache) {
+	SipSdpMessage m(inviteWith(kBodyA), localAddr());
+	ASSERT_EQ(std::string(m.getMedia()), "m=audio 4000 RTP/AVP 0 8 101");
+
+	m.enforceG711();
+
+	EXPECT_EQ(std::string(m.getMedia()), "m=audio 4000 RTP/AVP 0 8 101");
+	EXPECT_EQ(m.getRtpPort(), 4000);
+
+	// And again on a body whose codec list actually changes length, so the
+	// trailing spans shift.
+	SipSdpMessage wide(inviteWith(
+		"v=0\r\n"
+		"o=- 1 1 IN IP4 10.0.0.5\r\n"
+		"s=wide\r\n"
+		"c=IN IP4 10.0.0.5\r\n"
+		"t=0 0\r\n"
+		"m=audio 4002 RTP/AVP 0 8 9 18 101\r\n"
+		"a=rtpmap:0 PCMU/8000\r\n"), localAddr());
+	ASSERT_EQ(std::string(wide.getMedia()), "m=audio 4002 RTP/AVP 0 8 9 18 101");
+
+	wide.enforceG711();
+
+	EXPECT_EQ(std::string(wide.getMedia()), "m=audio 4002 RTP/AVP 0 8 101");
+	EXPECT_EQ(wide.getRtpPort(), 4002);
+}
+
+// Note on this one: with the body emptied, viewOf()'s out-of-range guard would
+// also report every field absent even if the generation counter had missed the
+// mutation, so this asserts the observable contract rather than isolating the
+// invalidation. The clearBody() bump is kept anyway — leaning on the guard for
+// correctness is precisely the fragility this change exists to remove.
+TEST(SipSdpMessageCache, ClearBodyInvalidatesCache) {
+	SipSdpMessage m(inviteWith(kBodyA), localAddr());
+	ASSERT_EQ(m.getRtpPort(), 4000);
+
+	m.clearBody();
+
+	EXPECT_TRUE(m.getMedia().empty());
+	EXPECT_TRUE(m.getVersion().empty());
+	EXPECT_EQ(m.getRtpPort(), 0);
+
+	// Repopulating must work too — a cache left marked-valid over the empty body
+	// would report the new SDP as absent.
+	m.setBody(kBodyB);
+	EXPECT_EQ(std::string(m.getSessionName()), "s=b");
+	EXPECT_EQ(m.getRtpPort(), 5678);
+}
+
+// THE pool landmine. getMessageFromPool() recycles a slot with reset(); if the
+// cache survived that, a new call would read the previous call's c= / m= lines.
+TEST(SipSdpMessageCache, ResetInvalidatesCache) {
+	SipSdpMessage m(inviteWith(kBodyA), localAddr());
+	ASSERT_EQ(std::string(m.getConnectionInformation()), "c=IN IP4 192.168.1.10");
+	ASSERT_EQ(m.getRtpPort(), 4000);
+
+	m.reset(inviteWith(kBodyB), localAddr());   // slot handed back out
+
+	EXPECT_EQ(std::string(m.getVersion()), "v=0");
+	EXPECT_EQ(std::string(m.getOriginator()), "o=- 22 22 IN IP4 10.1.1.7");
+	EXPECT_EQ(std::string(m.getSessionName()), "s=b");
+	EXPECT_EQ(std::string(m.getConnectionInformation()), "c=IN IP4 10.1.1.7");
+	EXPECT_EQ(std::string(m.getTime()), "t=1 2");
+	EXPECT_EQ(std::string(m.getMedia()), "m=audio 5678 RTP/AVP 8");
+	EXPECT_EQ(m.getRtpPort(), 5678);
+}
+
+// A field present in the old body and absent from the new one must not survive
+// in the cache — the parse rebuilds from scratch rather than updating in place.
+//
+// The replacement body is padded to be LONGER than kBodyA on purpose. A short
+// one would put every stale span out of range, where viewOf()'s guard reports
+// them absent and the test would pass against a cache that never invalidated.
+// Padded, the stale spans stay in range and resolve to filler text, so only real
+// invalidation produces the empty views asserted below.
+TEST(SipSdpMessageCache, FieldDroppedByNewBodyDoesNotSurvive) {
+	SipSdpMessage m(inviteWith(kBodyA), localAddr());
+	ASSERT_EQ(std::string(m.getSessionName()), "s=call-a");
+	ASSERT_FALSE(m.getMedia().empty());
+
+	m.reset(inviteWith(
+		"v=0\r\n"
+		"a=filler-aaaaaaaaaaaaaaaaaaaaaaaaaa\r\n"
+		"a=filler-bbbbbbbbbbbbbbbbbbbbbbbbbb\r\n"
+		"t=0 0\r\n"
+		"a=filler-cccccccccccccccccccccccccc\r\n"), localAddr());
+
+	EXPECT_EQ(std::string(m.getVersion()), "v=0");
+	EXPECT_TRUE(m.getSessionName().empty());
+	EXPECT_TRUE(m.getMedia().empty());
+	EXPECT_TRUE(m.getConnectionInformation().empty());
+	EXPECT_EQ(m.getRtpPort(), 0);
+}
+
+// The other recycle path: getMessageFromPool(const SipMessage&) does
+// `*msg = source`. The cache is stored as offsets, not string_views, precisely
+// so this defaulted copy stays correct — the destination must read its OWN body
+// and must not be left pointing into the source's, which is about to be reused.
+TEST(SipSdpMessageCache, CopyAssignedSlotReadsItsOwnBody) {
+	SipSdpMessage source(inviteWith(kBodyA), localAddr());
+	SipSdpMessage slot(inviteWith(kBodyB), localAddr());
+
+	ASSERT_EQ(source.getRtpPort(), 4000);
+	ASSERT_EQ(slot.getRtpPort(), 5678);   // both caches primed, and they disagree
+
+	slot = source;
+
+	EXPECT_EQ(std::string(slot.getSessionName()), "s=call-a");
+	EXPECT_EQ(std::string(slot.getConnectionInformation()), "c=IN IP4 192.168.1.10");
+	EXPECT_EQ(slot.getRtpPort(), 4000);
+
+	// Now recycle the source out from under the copy. If the copy's cache were
+	// string_views into source's body, this is where it would dangle.
+	source.reset(inviteWith(kBodyB), localAddr());
+	ASSERT_EQ(source.getRtpPort(), 5678);
+
+	EXPECT_EQ(std::string(slot.getSessionName()), "s=call-a");
+	EXPECT_EQ(std::string(slot.getConnectionInformation()), "c=IN IP4 192.168.1.10");
+	EXPECT_EQ(slot.getRtpPort(), 4000);
+}
+
+// The path the pool ACTUALLY takes, and the one the two-SipSdpMessage-lvalues
+// test above does NOT exercise. RequestsHandler holds shared_ptr<SipMessage>, so
+// getMessageFromPool(const SipMessage&)'s `*msg = source` binds both sides as
+// SipMessage — a base-subobject assignment. Only SipMessage's members are
+// assigned; the derived cache is left exactly as the slot's PREVIOUS call left
+// it. If the base assignment does not invalidate, the slot answers the new call
+// with the old call's c=/m= lines: media negotiated against the wrong endpoint.
+TEST(SipSdpMessageCache, PoolStyleBaseSubobjectAssignmentInvalidatesCache) {
+	SipSdpMessage source(inviteWith(kBodyA), localAddr());
+	SipSdpMessage slot(inviteWith(kBodyB), localAddr());
+
+	ASSERT_EQ(source.getRtpPort(), 4000);
+	ASSERT_EQ(slot.getRtpPort(), 5678);   // slot's cache primed with the old call
+
+	SipMessage&       slotBase   = slot;
+	const SipMessage& sourceBase = source;
+	slotBase = sourceBase;                // literally what the pool does
+
+	EXPECT_EQ(std::string(slot.getSessionName()), "s=call-a");
+	EXPECT_EQ(std::string(slot.getConnectionInformation()), "c=IN IP4 192.168.1.10");
+	EXPECT_EQ(std::string(slot.getMedia()), "m=audio 4000 RTP/AVP 0 8 101");
+	EXPECT_EQ(slot.getRtpPort(), 4000);
+}
+
+// The subtler sibling of the test above: assignment between two SipSdpMessages,
+// where the SOURCE's own cache is stale. The implicit operator= would bump this
+// object's body generation (through SipMessage::operator=) and then overwrite
+// its cache generation with the source's — two private counters crossed. Where
+// they collide, the destination reads the source's OLD spans against the body it
+// just received.
+//
+// That collision is arithmetic, so this sweeps a range of prior-mutation counts
+// on both objects rather than hand-picking the pair that happens to line up
+// today; a test tuned to today's exact counter values would stop covering this
+// the moment a mutation path is added or removed.
+TEST(SipSdpMessageCache, AssignmentFromStaleSourceDoesNotAdoptItsCache) {
+	for (int destMutations = 0; destMutations < 6; ++destMutations)
+	{
+		for (int sourceMutations = 0; sourceMutations < 6; ++sourceMutations)
+		{
+			SipSdpMessage source(inviteWith(kBodyA), localAddr());
+			for (int i = 0; i < sourceMutations; ++i) source.setBody(kBodyA);
+			ASSERT_EQ(source.getRtpPort(), 4000);   // prime it...
+			source.setBody(kBodyB);                 // ...then strand it
+
+			SipSdpMessage dest(inviteWith(kBodyA), localAddr());
+			for (int i = 0; i < destMutations; ++i) dest.setBody(kBodyA);
+
+			dest = source;
+
+			const std::string where = "dest=" + std::to_string(destMutations) +
+			                          " source=" + std::to_string(sourceMutations);
+			EXPECT_EQ(std::string(dest.getSessionName()), "s=b") << where;
+			EXPECT_EQ(std::string(dest.getConnectionInformation()), "c=IN IP4 10.1.1.7") << where;
+			EXPECT_EQ(dest.getRtpPort(), 5678) << where;
+		}
+	}
+}
+
+// Same for the copy constructor.
+TEST(SipSdpMessageCache, CopyConstructedMessageReadsItsOwnBody) {
+	SipSdpMessage source(inviteWith(kBodyA), localAddr());
+	ASSERT_EQ(source.getRtpPort(), 4000);
+
+	SipSdpMessage copy(source);
+	source.reset(inviteWith(kBodyB), localAddr());
+
+	EXPECT_EQ(std::string(copy.getSessionName()), "s=call-a");
+	EXPECT_EQ(copy.getRtpPort(), 4000);
+	EXPECT_EQ(source.getRtpPort(), 5678);
+}
+
+// Line-ending handling is unchanged from the old per-accessor parse: "\r\n"
+// primary, bare "\n" fallback, and last-one-wins on a repeated field.
+TEST(SipSdpMessageCache, LineEndingAndDuplicateFieldBehaviorUnchanged) {
+	SipSdpMessage lf(inviteWith(
+		"v=0\n"
+		"o=- 3 3 IN IP4 10.0.0.7\n"
+		"c=IN IP4 10.0.0.7\n"
+		"m=audio 1234 RTP/AVP 0\n"), localAddr());
+	EXPECT_EQ(std::string(lf.getConnectionInformation()), "c=IN IP4 10.0.0.7");
+	EXPECT_EQ(lf.getRtpPort(), 1234);
+
+	SipSdpMessage dup(inviteWith(
+		"v=0\r\n"
+		"m=audio 1111 RTP/AVP 0\r\n"
+		"m=audio 2222 RTP/AVP 0\r\n"), localAddr());
+	EXPECT_EQ(std::string(dup.getMedia()), "m=audio 2222 RTP/AVP 0");
+	EXPECT_EQ(dup.getRtpPort(), 2222);
+}


### PR DESCRIPTION
Closes #101 — items **A**, **B**, **D**, **E** fixed; **C** re-examined and formally declined.

## The one to look at first: a data race, found by the E audit

`findFreePoolSlot()` scanned the **static** `_messagePool` for `use_count()==1` and then copied the `shared_ptr`. That is a check-then-take with no synchronization, and it is reachable from two tasks at once:

- the **UDP receive task** (`UdpServer.cpp:134` → `SipServer::onNewMessage` → `SipMessageFactory::createMessage` → `getMessageFromPool`) — holding **no lock**, because `handle()` only takes `_mutex` afterwards, on the already-allocated message;
- the **tick task** (`esp_main.cpp:192`, or `SipServer::tickLoop` on desktop) → `TransactionLayer::sweep` → `messageFromPool` — under `_mutex`.

Both could observe `use_count()==1` on the same slot, both take it, and both `reset()` it — two owners writing one `SipMessage` and reallocating its strings under each other. Holding `_mutex` on one side does not help: a lock only excludes other holders of that same lock. It fires under exactly the load item A exists to harden against (retransmit sweep running while packets arrive).

Fixed with a dedicated **leaf** mutex around the scan-and-take. Nothing inside that critical section may take another lock, so it is safe whether or not the caller already holds `_mutex`; message initialization stays outside it. The fallback deleter is documented as never taking it — the last reference can drop while it is held, so a locking deleter could self-deadlock.

I originally planned to record this and not fix it. It turned out to live in the same ten lines item A rewrites, so shipping A around it was not defensible.

## A — pool-exhaustion backpressure

`getMessageFromPool()` / `allocateVirtualPeer()` fell back to **unbounded** heap allocation. Both now allow a bounded number of fallbacks alive at once (`POCKETDIAL_MSG_HEAP_FALLBACK_MAX` = 8, `POCKETDIAL_VPEER_HEAP_FALLBACK_MAX` = 4), tracked by an atomic the `shared_ptr` deleter decrements, and refuse past that. A ceiling on concurrent use, not a rate — bursts are absorbed, only sustained over-subscription is refused.

**On refusal the contract is drop, not 503.** Building a 503 would need a message out of the pool that just came up empty, so `allocateSession()`'s reject-and-503 pattern isn't available here. UDP SIP retransmits, so a drop costs latency rather than the call.

67 call sites updated, failure action matched to context — `return` in void handlers, `continue` in fork/sweep loops so one refusal skips a target instead of aborting a broadcast, `nullptr` propagation out of builders — and resources acquired before state is mutated, so a refusal never leaves a half-built session (the ordering discipline #71 established).

Two things kept that from being 67 hand-written checks:
- `enqueue()` now drops nulls centrally, covering every inline `enqueue(addr, messageFromPool(...))` and guaranteeing `drainOutbox()` never dereferences one;
- the **highest-volume path needed no new code** — `createMessage()` already returned `nullopt` and `handle()` already dropped it, so an unrepresentable inbound packet dies at the earliest possible point.

One behavioral subtlety worth review: `BlfSubscriptions` no longer banks `lastState` when the NOTIFY it just built was refused. Recording a state that was never sent would suppress the retry and strand that watcher's busy-lamp until the target changed state *again*.

## B — SDP parse-once cache

The six accessors re-parsed the whole body on every call. Now one cached single-pass parse, invalidated by a `_bodyGen` counter on `SipMessage` bumped by every body mutation.

The cache stores **offsets, not `string_view`s** — messages are pooled and copied, and views would be copied verbatim into a destination pointing at the source's body. Both `SipMessage::operator=` and `SipSdpMessage::operator=` are hand-written rather than `= default`, so a copied generation can never make a stale cache look fresh; the comments explain why each one is not defaultable.

## D — PcapCapture allocation under the caller's lock

The ring no longer pops and pushes; once full it overwrites the oldest entry in place and recycles its buffer, so the steady-state path allocates nothing (it still grows lazily, so a quiet node pays for nothing it hasn't used). `recordInto()` plus a new `SipMessage::toString(std::string&)` lets both capture sites serialize straight into the slot, removing the per-packet temporary they were building *before* `record()` even copied it. Worth doing properly because **capture is unconditional** — no enable flag, so this ran on every message under `_mutex`.

## C — declined

The four blocks in `maybeTrack()` each copy a different `string_view` into a different fixed `char[]` and share only their shape. Folding them into a helper trades four obvious bounds-safe copies for one indirection, on the retransmit path, for no behavioral gain. Recorded in `ISSUES.md` so it isn't re-litigated.

## Verification

- **188/188** host tests (168 before).
- **Mutation-verified.** With each fix reverted in turn, the new tests fail. This mattered — two tests initially passed against knowingly broken code and had to be rewritten: same-shape SDP bodies let stale offsets land on correct text, and assigning two `SipSdpMessage` lvalues does not reproduce the pool's base-subobject assignment (finding that is what surfaced the `operator=` defect).
- **Device**: all seven edited translation units compile clean for ESP32-S3 under `-Wall -Wextra`, and the full `idf.py build` links.

**Not covered:** no on-hardware or QEMU run. The concurrency fix is argued from the code and pinned by a host-thread uniqueness test; it has not been observed under real dual-task load. Given what it touches, a smoke test on the board before merge is worth it.

The rest of the E audit came back clean: RTP endianness is byte-wise big-endian with no packed structs, the retransmit-timer path does no blocking I/O, and every long-running loop blocks or yields each iteration (no watchdog starvation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
