### PR TITLE
fix(provisioning): reject CR/LF in the extension before it reaches the .cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,42 @@ Issue #101 item **B**.
 - Device build: all seven edited translation units compile clean for ESP32-S3
   under `-Wall -Wextra`, and the full `idf.py build` links (see the closeout
   section above).
+## Unreleased (issue-107-provisioning-crlf) - 2026-08-17
+
+Closes Issue #107. Defense in depth around the zero-touch provisioning config
+served by `GET /config/<mac>.cfg` (Issue #35, commit `b79570c`).
+
+### Fixed — config-line injection via the provisioned extension (#107)
+
+- `provisioning::yealinkConfigFor()` interpolates the extension into
+  `key = value\r\n` lines. An extension carrying a CR or LF would have appended
+  config keys nobody wrote — `account.1.password` being the interesting one —
+  to the file the handset parses. The builder now refuses outright (returns an
+  empty config) when the extension contains CR or LF, and `sendConfigCfg()`
+  treats an empty build as a 404 rather than serving a 200 with an empty body.
+
+- `RequestsHandler::findProvisioningInfo()` re-checks the adopted extension
+  against `isValidAor()` before handing it to the builder, so provisioning
+  fails closed instead of depending on a gate three call layers away.
+
+**Reachability, since the issue left it open:** not reachable today. Every path
+that writes `DeviceRecord::extension` is downstream of `onRegister()`'s
+`isValidAor()` check — `admitLearn()`'s adopt (`Registrar.cpp:177`) and
+re-extension (`:189`) paths both are — and that charset (alnum plus `. - _ + * #`)
+excludes CR/LF. The remaining writer, `loadDevices()` (`:348`), restores from an
+NVS blob whose own field/record delimiters are tab/newline, so a CR/LF-bearing
+extension could not have round-tripped through it either. Both guards are
+therefore backstops, not a live-hole patch: they keep the property local to the
+code that depends on it, for future callers wiring in less-trusted input.
+
+Deliberately *not* narrowed to `[0-9A-Za-z]` as the issue suggested — that
+would silently mangle `*55`, `+15551234`, and the rest of the AOR charset the
+registrar already accepts. Only CR/LF, the actual injection vector, is rejected.
+
+Covered by 3 new tests in `tests/ProvisioningConfig_test.cpp`
+(mutation-verified: with the guard removed the injected
+`account.1.password = hunter2` line appears 5x in the served config).
+Full host suite: 171/171 passing.
 
 ## Unreleased (post-100-review-followups) - 2026-08-09
 

--- a/src/Helpers/HttpServer.cpp
+++ b/src/Helpers/HttpServer.cpp
@@ -1079,6 +1079,13 @@ void HttpServer::sendConfigCfg(int sock, const std::string& mac)
 	std::string activeIp = (_ip == "0.0.0.0") ? getPrimaryLocalIP() : _ip;
 	std::string cfg = provisioning::yealinkConfigFor(info->extension, activeIp, 5060,
 		info->authRequired);
+	if (cfg.empty())
+	{
+		// The builder refused the extension (CR/LF -- Issue #107). There is no safe
+		// partial config to serve, so this is a miss, not a 200 with an empty body.
+		send404(sock);
+		return;
+	}
 	sendResponse(sock, 200, "OK", "text/plain", cfg);
 }
 

--- a/src/SIP/ProvisioningConfig.hpp
+++ b/src/SIP/ProvisioningConfig.hpp
@@ -36,6 +36,18 @@ namespace provisioning
 	inline std::string yealinkConfigFor(const std::string& extension,
 		const std::string& serverIp, int serverPort, bool authRequired)
 	{
+		// Every value below lands in a `key = value\r\n` line, so a CR or LF in the
+		// extension would inject config lines into the file the handset parses
+		// (Issue #107). Callers hand over an AOR-validated extension -- this is the
+		// format-level backstop for the ones that forget, and for future callers
+		// wiring in less-trusted input. Only CR/LF is rejected, not the whole AOR
+		// charset: '*55' and '+15551234' are legitimate extensions and provision fine.
+		if (extension.find('\r') != std::string::npos ||
+			extension.find('\n') != std::string::npos)
+		{
+			return {};
+		}
+
 		std::string out;
 		out.reserve(512);
 		out += "#!version:1.0.0.1\r\n";

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -2486,6 +2486,19 @@ std::optional<RequestsHandler::ProvisioningInfo> RequestsHandler::findProvisioni
 	{
 		if (d.mac == mac)
 		{
+			// Defense in depth (Issue #107): the .cfg served for this device
+			// interpolates the extension into `key = value\r\n` lines, so a CR/LF in
+			// it would inject config lines nobody wrote. Every path that adopts an
+			// extension today goes through onRegister()'s isValidAor() gate, whose
+			// charset excludes CR/LF -- this re-checks that invariant at the point of
+			// use so provisioning does not silently depend on a gate three call layers
+			// away. Fails closed: no info -> the endpoint 404s.
+			if (!isValidAor(d.extension))
+			{
+				queueLog("Provisioning refused for " + mac +
+					": adopted extension fails the AOR charset", true);
+				return std::nullopt;
+			}
 			const bool authRequired = (d.state == Registrar::DeviceState::Secured) ||
 				(_registrar.getMode() == Registrar::Mode::Secure);
 			return ProvisioningInfo{d.extension, authRequired};

--- a/tests/ProvisioningConfig_test.cpp
+++ b/tests/ProvisioningConfig_test.cpp
@@ -64,3 +64,48 @@ TEST(ProvisioningConfig, FindProvisioningInfoReturnsNulloptForUnknownMac)
 		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
 	EXPECT_FALSE(handler.findProvisioningInfo("805ec079c37f").has_value());
 }
+
+// ── Config-line injection via the extension (Issue #107) ──────────────────────
+//
+// yealinkConfigFor() interpolates the extension into `key = value\r\n` lines. An
+// extension carrying a CR or LF could therefore append config keys the admin
+// never wrote -- `account.1.password` being the interesting one. onRegister()
+// gates every adopted extension through isValidAor(), whose charset excludes
+// CR/LF, so this is not reachable today; these pin the format-level backstop so
+// it stays unreachable if a future caller feeds the builder from somewhere else.
+
+TEST(ProvisioningConfig, BuilderRefusesExtensionCarryingCrlfInjection)
+{
+	std::string cfg = provisioning::yealinkConfigFor(
+		"101\r\naccount.1.password = hunter2", "192.168.4.1", 5060,
+		/*authRequired=*/false);
+
+	EXPECT_TRUE(cfg.empty())
+		<< "a CRLF-bearing extension must produce no config at all, rather than "
+		   "one carrying the injected line: " << cfg;
+}
+
+TEST(ProvisioningConfig, BuilderRefusesBareCrAndBareLf)
+{
+	EXPECT_TRUE(provisioning::yealinkConfigFor("101\naccount.1.password = x",
+		"192.168.4.1", 5060, false).empty()) << "bare LF";
+	EXPECT_TRUE(provisioning::yealinkConfigFor("101\raccount.1.password = x",
+		"192.168.4.1", 5060, false).empty()) << "bare CR";
+	// Trailing, not just embedded -- a lone terminator still opens the next line.
+	EXPECT_TRUE(provisioning::yealinkConfigFor("101\r\n",
+		"192.168.4.1", 5060, false).empty()) << "trailing CRLF";
+}
+
+TEST(ProvisioningConfig, BuilderStillAcceptsTheRestOfTheAorCharset)
+{
+	// The guard rejects CR/LF only. Star codes, '+', and the RFC 3261 user-part
+	// punctuation isValidAor() allows are legitimate extensions and must still
+	// provision -- a stricter [0-9A-Za-z] strip would silently mangle these.
+	for (const char* ext : {"*55", "+15551234", "1_0.1-a", "#77"})
+	{
+		std::string cfg = provisioning::yealinkConfigFor(ext, "192.168.4.1", 5060,
+			/*authRequired=*/false);
+		EXPECT_NE(cfg.find(std::string("account.1.user_name = ") + ext), std::string::npos)
+			<< "extension '" << ext << "' should provision unchanged: " << cfg;
+	}
+}


### PR DESCRIPTION
Closes #107.

## The question the issue left open

#107 flagged that it hadn't verified whether the AOR charset policy is enforced on *every* path that can set a registry extension. It is — **this is not reachable today**:

- `onRegister()` gates on `isValidAor(fromNumber)` (`RequestsHandler.cpp:388`) before `admitLearn()` (`:413`), and that charset (alnum plus `. - _ + * #`) excludes CR/LF.
- Both writers of `DeviceRecord::extension` sit downstream of it: the TOFU adopt (`Registrar.cpp:177`) and the re-extension path (`:189`).
- The remaining writer, `loadDevices()` (`:348`), restores from an NVS blob whose own field/record delimiters are tab/newline, so a CR/LF-bearing extension could not have round-tripped through it either.

So these guards are backstops, matching the issue's own "Low as-is" read. They keep the property local to the code that depends on it instead of resting on a gate three call layers away.

## Changes

| Layer | Change |
|---|---|
| `ProvisioningConfig.hpp` | `yealinkConfigFor()` returns an empty config if the extension contains CR or LF |
| `HttpServer.cpp` | `sendConfigCfg()` treats an empty build as a 404, not a 200 with an empty body |
| `RequestsHandler.cpp` | `findProvisioningInfo()` re-checks the adopted extension against `isValidAor()`, failing closed |

Deliberately **not** narrowed to `[0-9A-Za-z]` as the issue suggested — that would silently mangle `*55`, `+15551234`, and the rest of the charset the registrar already accepts. Only CR/LF, the actual injection vector, is rejected, and a test pins that.

## Verification

- **Host suite: 171/171 passing** (3 new tests in `ProvisioningConfig_test.cpp`).
- **Mutation-verified** on the builder guard: with it removed, the injected `account.1.password = hunter2` line appears **5x** in the served config and both injection tests fail.
- The `findProvisioningInfo()` guard is **not** host-reachable — populating the device registry needs an ARP lookup, a nullopt stub off-device (as `DashboardSnapshot_test.cpp:61` already notes) — so it is asserted by inspection, not by test.
- Both changed translation units compile clean for ESP32-S3 under `-Wall -Werror -Wextra`.

## Notes for the reviewer

- **CHANGELOG conflicts with #109.** Both prepend a new `## Unreleased` section at line 3. Trivial to resolve, but it will conflict.
- **Unrelated pre-existing breakage on `main`:** the firmware build stops at ~1430/1462 on `main/esp_main_eth_lan8720.cpp:44`, which includes `esp_eth_phy_lan87xx.h` — a header the installed IDF (v6.0.2-838) no longer ships, since LAN87xx folded into the generic `esp_eth_phy_802_3.h` API. Untouched by this PR and present identically on `main`; worth its own issue.
- **#102 looks already fixed by #109** — its defect (unlocked free-slot scan in `findFreePoolSlot()`) is exactly what that PR's changelog describes fixing. Probably close it as part of the #109 merge rather than working it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
