### PR TITLE
docs: verify #41 SIP platform guards, confirm #80 JC3248W535 SD pinout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,42 @@ linked, unsigned test binaries partway through this session:
 - **cppcheck 2.21.0**, built from source on both a Windows cross-compile and a
   real WSL/Linux build, run against the final tree with the workflow's exact
   invocation: `EXIT=0`, zero findings, on both.
+## Unreleased (issue-41-80-verification) - 2026-08-19
+
+Verification pass on two "verification needed" tracker issues, neither of which had
+a committed bug repro. No firmware code changed — see the linked GitHub comments for
+the full writeups.
+
+### Docs
+
+- `docs/HARDWARE.md` §2 (Guition JC3248W535): added the microSD pin table
+  (Issue #80's blocker). SD_MMC (SDIO) 1-bit mode, CLK/CMD/D0 = GPIO 12/11/13,
+  cross-referenced against the vendor's own Arduino demo `pincfg.h`, the sibling
+  `jc3248-display-driver` bring-up repo, and this repo's own hardware-verified
+  `esp_main_display.cpp` comment (three independent sources, all agreeing) — and
+  checked for GPIO conflicts against the panel/touch/battery pins already in the
+  table (none found). Left open: whether the physical slot is populated on a given
+  board (the vendor spec sheet calls it "reserved" and its rear-connector photo
+  shows no slot), so no `esp_vfs_fat_*` mounting code was written against this —
+  see the GitHub comment on #80 for the recommended next step (a continuity probe).
+
+- Issue #41 (Arduino IDE platform-detection guards): re-audited every `#if`/`#ifdef`
+  touched by the original change (`src/Helpers/UdpServer.hpp/.cpp`,
+  `src/SIP/RequestsHandler.hpp`, `src/SIP/SipClient.hpp`, `src/SIP/SipMessage.hpp`)
+  plus the guards a prior audit (see `ISSUES.md`) already fixed elsewhere
+  (`SipMessage.hpp`, `TelephonyApiConfig.cpp`). No new bug found: the
+  `#undef INADDR_NONE` in `SipClient.hpp`/`SipMessage.hpp` is preprocessor-scoped to
+  the translation unit that includes it (confirmed nothing in `src/`, `main/`, or
+  `sketches/` reads `INADDR_NONE` afterward), and `SipServer.cpp`'s
+  `#if defined(ARDUINO) ... #elif defined(ESP_PLATFORM)` mDNS-header selection
+  correctly prioritizes `ARDUINO` (needed because Arduino-ESP32 3.x builds through
+  the IDF build system and can define both). Host build re-verified clean
+  (`cmake --build`, no warnings); `ctest` could not be executed in this environment
+  (a Device Guard / application-control policy blocks running newly-built,
+  unsigned executables here — confirmed with the exact toolchain-build binary, not
+  a stale cache). Arduino IDE / `arduino-cli` compile and physical-hardware runtime
+  test remain unverified, as before — full details posted as a GitHub comment on
+  #41 rather than duplicated here.
 
 ## Unreleased (issue-101-closeout) - 2026-08-17
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -62,6 +62,42 @@ The Guition JC3248W535 is an all-in-one Smart Display powered by an ESP32-S3. It
 > [!TIP]
 > **PSRAM Configuration**: This board uses an ESP32-S3R8 chip containing 8MB of Octal PSRAM. In `sdkconfig`, PSRAM **must** be enabled in Octal mode at 80MHz, and LVGL double-frame buffers (320 * 480 * 2 bytes = 307.2 KB each) must be allocated in `MALLOC_CAP_SPIRAM` to prevent internal SRAM exhaustion.
 
+### microSD (Issue #80 — pinout research)
+
+The board's microSD slot is **SD_MMC (SDIO), 1-bit mode only** — CLK/CMD/D0 are the
+only lines broken out (D1–D3 aren't wired, which is fortunate: on this board they'd
+land on GPIO 48/40/39, the QSPI panel's `TFT_D1`/`TFT_D2`/`TFT_D3`). Not SPI mode.
+
+| Signal | ESP32-S3 GPIO |
+| :--- | :---: |
+| `SD_MMC_CLK` | **GPIO 12** |
+| `SD_MMC_CMD` | **GPIO 11** |
+| `SD_MMC_D0`  | **GPIO 13** |
+
+**Sources** (three independent, all agreeing): the vendor's own Arduino demo bundle
+(`NorthernMan54/JC3248W535EN`, `.../Demo_Arduino/DEMO_PIC/pincfg.h`:
+`SD_MMC_CLK`/`SD_MMC_CMD`/`SD_MMC_D0` = 12/11/13); the `GlomarGadaffi/jc3248-display-
+driver` bring-up repo's `main/board.h` + `docs/Pinout-and-Hardware.md` (same three
+pins, documented as "verified against the board's own pinout sheet"); and this
+repo's own `main/esp_main_display.cpp` comment (added in `17459fa`, hardware-flashed
+on COM4), which independently arrived at GPIO 11/12 being the microSD CMD/CLK lines
+while fixing an unrelated touch-pin mis-assignment.
+
+**Conflict check against this table**: clean. GPIO 11/12/13 don't collide with
+`TFT_*` (45/47/21/48/40/39/1/38), `TOUCH_*` (4/8), or `BATTERY_ADC` (5).
+
+**Still open** (needs the physical board — this is the issue's blocker, narrowed but
+not closed):
+- The vendor spec sheet (`JC3248W535C_I_Y`) describes the TF card interface as
+  *"reserve[d]"* and its labeled rear-connector photo shows no SD slot at all
+  (Boot, Reset, Type-C, battery/power JSTs, 8P IO, HC1.0 4P, Speak — no card slot).
+  Whether the slot is actually populated on a given unit needs a look at the board.
+- `pincfg.h` and the sibling repo disagree with this repo's touch pin comment on one
+  unrelated line (`TOUCH_PIN_NUM_INT` 3 vs. this board's documented NC) — a reminder
+  that these are a close but not necessarily identical board revision, so a
+  continuity check (multimeter, slot pads to GPIO 12/11/13) before wiring is still
+  the safer first step, per the issue.
+
 ---
 
 ## 3. Waveshare ESP32-S3-ETH + PoE Module


### PR DESCRIPTION
Addresses #41 (partial — Arduino IDE compile and on-hardware runtime test still unverified; no toolchain in this environment).
Addresses #80 (partial — SD pinout confirmed and cited; slot population on the physical unit and all runtime acceptance criteria still need the board).

Both #41 and #80 are "verification needed" tracker issues with no committed bug repro. Neither needed a firmware code change — this PR is docs + the two GitHub comments carrying the actual findings.

## #41 — SIP core platform-detection guards

A prior audit (see the `ISSUES.md` entry for #41) already fixed the guards that were actually inconsistent (`SipMessage.hpp`, `TelephonyApiConfig.cpp` widened to the 3-way `ESP_PLATFORM || ESP32 || ARDUINO` form). This round re-audited everything from scratch and found no new bugs, but surfaced two things worth recording:

- `#undef INADDR_NONE` in `SipClient.hpp`/`SipMessage.hpp` cannot leak across translation units — `#undef` is preprocessor state local to whichever `.cpp` is compiling. The only real risk is within the *same* TU, downstream of the header; grepped `src/`, `main/`, `sketches/` for `INADDR_NONE` and the only hits are the two `#undef` lines themselves, so it's currently inert.
- `SipServer.cpp`'s `#if defined(ARDUINO) ... #elif defined(ESP_PLATFORM)` mDNS-header selection has the right *order*: Arduino-ESP32 3.x builds through the IDF build system and can define both macros, so checking `ARDUINO` first is what correctly picks `ESPmDNS.h` over raw `mdns.h`. Not a bug — worth noting so it isn't mis-flagged as inconsistent later.
- Flagged (not fixed, out of scope): `HttpServer.hpp`'s socket includes still gate on `ESP_PLATFORM` alone, and every sketch's header comment says to compile `HttpServer.cpp` into the Arduino build. It currently survives only because `HttpServer.cpp` transitively pulls in `RequestsHandler.hpp`'s broadened `lwip/sockets.h` arm before first use. Exactly the failure class this issue asks about, one file outside its named list.

**Verification:** host build re-verified clean (`cmake --build`, MSVC, no warnings). Could **not** run `ctest` this round — a Device Guard / application-control policy in this sandbox blocks executing newly-built, unsigned binaries (confirmed with the actual built `sip_parser_tests.exe`, including after copying it to a different directory, so it isn't path-specific). A previous comment on the issue already reported 168/168 passing under a working toolchain, and nothing in this round touched test-covered code. Full writeup: https://github.com/GlomarGadaffi/pocket-dial/issues/41#issuecomment-5448117829

## #80 — JC3248W535 microSD pinout

Found the SD interface from three independent sources that all agree:

| Signal | GPIO |
|---|---|
| `SD_MMC_CLK` | 12 |
| `SD_MMC_CMD` | 11 |
| `SD_MMC_D0`  | 13 |

SD_MMC (SDIO) 1-bit mode, not SPI — D1–D3 aren't wired (and couldn't be: they'd land on the QSPI panel's `TFT_D1`/`D2`/`D3`, GPIO 48/40/39).

1. The vendor's own Arduino demo bundle (`NorthernMan54/JC3248W535EN`, `DEMO_PIC/pincfg.h`).
2. `GlomarGadaffi/jc3248-display-driver`, a sibling bring-up repo for this exact board (`board.h` + `docs/Pinout-and-Hardware.md`, "verified against the board's own pinout sheet," plus a working hardware-verified `demo_sdcard.c`).
3. This repo's own `esp_main_display.cpp` comment (added in `17459fa`, flashed on COM4), which independently landed on the same two of the three pins while fixing an unrelated touch mis-assignment.

Checked for conflicts against the panel/touch/battery GPIOs already in `docs/HARDWARE.md` §2 and grepped `main/`+`src/` for any existing use of GPIO 11/12/13 — clean, no collisions.

**Why no `esp_vfs_fat_*` code was written:** the vendor spec sheet calls the TF interface "reserved" and its labeled rear-connector photo shows no card slot at all, so whether the slot is actually populated on a given unit is still an open question the issue's own premise ("card present") assumes but I can't confirm. `pincfg.h` also disagrees with this repo's touch-pin comment on one unrelated signal, so treat this as a close-but-not-identical board revision, not an exact match. Every one of the issue's acceptance criteria (mounts on boot, survives the LVGL/STA workload without regressing the watchdog fix, one persistence feature works) is a runtime claim I can't check without the board — writing the mount call now would add an unverified boot-path change to the one target with watchdog history, for no verification benefit. Documented the pinout + open items instead. Full writeup: https://github.com/GlomarGadaffi/pocket-dial/issues/80#issuecomment-5448118778

## Changes

| File | Change |
|---|---|
| `docs/HARDWARE.md` | New microSD pin table + citations + open-items note under JC3248W535 (§2) |
| `CHANGELOG.md` | New Unreleased section summarizing both verification passes |

## Verification

- Host build: clean (`cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && cmake --build build --config Release`).
- `ctest`: could not execute — Device Guard blocks running freshly-built binaries in this sandbox (see #41 comment for the exact error and how I ruled out a path-specific cause). No test-covered code changed in this PR (docs only), so this is a sandbox limitation, not a gap in this diff.

## Notes for the reviewer

- Neither issue is closed by this PR — both need the physical board (#80) or an Arduino toolchain (#41) to actually finish. `ISSUES.md` was left untouched since neither is being closed here (its existing #41 entry from a prior audit already stands).
- Filed a product-feedback note separately about the Device Guard block, since it silently defeats this repo's own documented validation step (`ctest`) for any agent working in an affected sandbox.
