### PR TITLE
fix: BLF self-call, RegisterBeeper CANCEL-pool-fail, RtpSender RNG, cppcheck pin (#106, #104, #108, #112)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ jobs:
   build-and-test-host:
     name: Host Build & Simulation Testing
     runs-on: ubuntu-latest
+    env:
+      # Pinned analyzer version (Issue #112) -- bump deliberately, not via a
+      # runner-image update. 2.21.0 is the version this pin was verified
+      # against: every `// cppcheck-suppress ...` comment landed alongside
+      # this pin (SipStatus.cpp, PcapCapture.hpp, RequestsHandler.hpp/.cpp,
+      # AnchorClient.hpp, DnsServer.cpp, esp_main_eth*.cpp) was added because
+      # 2.21.0 flags it and the prior floating apt version (2.13.0) did not.
+      # Bumping this version is expected to surface new findings to triage,
+      # not to fail silently -- do not bump without re-running locally first.
+      CPPCHECK_VERSION: 2.21.0
 
     steps:
       - name: Checkout Repository
@@ -20,10 +30,38 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential cppcheck clang-tidy jq curl
+          sudo apt-get install -y cmake build-essential clang-tidy jq curl
+
+      - name: Cache pinned cppcheck build
+        id: cppcheck-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/cppcheck-install
+          key: ${{ runner.os }}-cppcheck-${{ env.CPPCHECK_VERSION }}
+
+      - name: Build & Install cppcheck (pinned version)
+        # Issue #112: the apt package tracks ubuntu-latest's own image, so the
+        # analyzer version (and therefore what it finds) floats with every
+        # runner-image bump -- a future bump can turn a green PR red on code
+        # nobody touched. cppcheck ships no prebuilt Linux binary, so the
+        # version is pinned by building it from its own tagged source instead
+        # (cached above, keyed on the version, so this only runs once per bump).
+        if: steps.cppcheck-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sSL -o cppcheck.tar.gz \
+            "https://github.com/danmar/cppcheck/archive/refs/tags/${CPPCHECK_VERSION}.tar.gz"
+          tar xzf cppcheck.tar.gz
+          cmake -S "cppcheck-${CPPCHECK_VERSION}" -B cppcheck-build \
+                -DCMAKE_BUILD_TYPE=Release -DUSE_MATCHCOMPILER=ON \
+                -DBUILD_TESTS=OFF -DBUILD_GUI=OFF \
+                -DCMAKE_INSTALL_PREFIX="$HOME/cppcheck-install"
+          cmake --build cppcheck-build -j"$(nproc)"
+          cmake --install cppcheck-build
 
       - name: Run Static Analysis (cppcheck)
         run: |
+          export PATH="$HOME/cppcheck-install/bin:$PATH"
+          cppcheck --version
           cppcheck --error-exitcode=1 \
                    --enable=warning,performance \
                    --inline-suppr \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,229 @@
 # Changelog
 
+## Unreleased (issue-106-104-108-112-misc-bugs) - 2026-08-19
+
+Four small, independently-filed correctness bugs plus one CI hygiene fix,
+bundled into one PR per the triage bucket. Full host suite: 196/196 passing
+(WSL/Linux — see Verification).
+
+### Fixed — BLF `forEachSessionInvolving` drops the Callee leg on a self-call (#106)
+
+- `RequestsHandler::forEachSessionInvolving()` (the production `PbxEnv`
+  implementation) used an `if (isSrc) ... else if (isDest) ...` chain, a
+  regression from commit `f0446d9`'s refactor away from independent flags. When
+  a session's src *and* dest are both the watched extension (an extension
+  calling itself, or a hunt/ring group where the caller is also a member), the
+  `else if` meant only the Caller role ever fired — `BlfSubscriptions::
+  computeDialogState` never saw the Callee leg, so a watcher's dialog-info XML
+  reported the wrong role/state for that dialog. Restored to two independent
+  `if`s so both roles fire when both match — matching the pre-`f0446d9`
+  behavior where the visitor received both flags at once.
+
+- `tests/FakePbxEnv.hpp`'s `forEachSessionInvolving()` (the test double every
+  `BlfSubscriptions`/`RegisterBeeper`/`ParkOrbit` host test drives) carried the
+  identical bug, since it was written to mirror the production method. Fixed
+  identically.
+
+  `RequestsHandler::forEachSessionInvolving()` itself is a private `PbxEnv`
+  override (`RequestsHandler` privately inherits `PbxEnv`) and so isn't
+  directly host-testable in isolation; the fake mirrors it exactly and is
+  covered by two new tests in `tests/BlfSubscriptions_test.cpp`: one asserts
+  the callback fires twice (once per `DialogRole`) for a self-call session,
+  the other drives the real `BlfSubscriptions::computeDialogState` end-to-end
+  through the fake and confirms a ringing self-call reports the higher-ranked
+  Callee leg (`early`/`recipient`) rather than getting stuck on the
+  lower-ranked Caller leg (`trying`/`initiator`) — which is exactly the
+  externally-observable symptom the `else if` bug produced.
+
+### Fixed — `RegisterBeeper::sweep` claims "cancelled" when the CANCEL was never built (#104)
+
+Real-hardware evidence (see the issue's comment thread): a LilyGO T-ETH-Elite
+S3 logged `"Register beep: no answer from 321, cancelled"` immediately
+alongside `"[tx] pool exhausted — INVITE sent without retransmit tracking"` —
+i.e. `buildCancel()` failing under the exact message-pool pressure Issue
+#101(A) bounds, not a hypothetical.
+
+- `sweep()`'s `AwaitingInviteOk` branch unconditionally logged `"cancelled"`
+  and advanced to `AwaitingCancelDone` even when `buildCancel(i)` returned
+  `nullptr` (pool exhausted). `AwaitingCancelDone` means "a CANCEL is in
+  flight, keep matching this Call-ID for a raced 200 OK" — asserting that when
+  no CANCEL went out is both a misleading log during exactly the flood an
+  operator would be reading it in, and leaves the dialog in a half-cancelled
+  limbo state that nothing ever revisits (the phone was never actually
+  CANCELled, and the dialog no longer looks like it needs to be).
+
+  Now: on `buildCancel()` failure the dialog stays in `AwaitingInviteOk` with a
+  short (1s) deadline, logs a distinct "cancel build failed — will retry"
+  message, and the next `sweep()` tick retries — succeeding once pool pressure
+  eases, at which point it follows the original cancelled/`AwaitingCancelDone`
+  path unchanged.
+
+- Per the issue's own caution ("don't leave it stuck forever either"): added a
+  bounded retry count (`BeepDialog::cancelRetries`, capped at
+  `RegisterBeeper::kMaxCancelRetries` = 5). If pool pressure hasn't eased after
+  five consecutive retry ticks, `sweep()` gives up and frees the slot outright
+  (logged as an error) instead of retrying indefinitely under sustained
+  exhaustion — the phone simply rings out on its own INVITE timeout instead of
+  ever being CANCELled, which is strictly better than pinning a beeper slot
+  forever.
+
+  Covered by two new tests in `tests/RegisterBeeper_test.cpp`: one forces
+  `buildCancel()` to fail once (via a new `FakePbxEnv::messagePoolAvailable`
+  toggle, matching the existing `sessionPoolAvailable` pattern) and asserts the
+  log/state behavior plus a successful retry once the pool recovers; the other
+  forces ten consecutive failures and asserts sweep gives up and frees the slot
+  rather than retrying forever.
+
+### Fixed — `RtpSender` SSRC/sequence/timestamp seeded from `std::rand()` (#108)
+
+- RFC 3550 §3 wants the RTP SSRC genuinely random so colliding streams can be
+  told apart, and the initial sequence/timestamp random so a receiver can
+  detect restarts. The host/Linux `rand32()` used `std::rand()` — a single
+  process-wide stream, shared and correlated across every caller, which is the
+  opposite of what SSRC randomness needs. Replaced with a `thread_local
+  std::mt19937` seeded from `std::random_device`, one generator per thread
+  rather than one shared global stream. The ESP branch is unchanged
+  (`esp_random()`, the hardware RNG, was already correct).
+
+- **Destructor join, investigated and found already correct on `main`:** the
+  issue flagged "no destructor is visible in the patch" (referring to commit
+  `af5fd24`'s Linux media path). `~RtpSender()` does exist — it predates
+  `af5fd24` (added with the original media feature, commit `119ca84`) and was
+  carried through unchanged — and its non-ESP branch unconditionally calls
+  `stop("")`. On Linux, `stop()` sets `_stopRequested` and **joins
+  `_senderThread` synchronously** before returning (see `stop()`'s own
+  comment), so a joinable `std::thread` is never left running when the object
+  is destroyed; on the plain host stub there is no real thread to join at all.
+  No code change was needed for this half — only a comment update, since the
+  destructor's comment still called it a "host stub" after `af5fd24` gave the
+  same code path a real Linux thread to join. Verified directly: built and ran
+  the host test suite under WSL/Linux (`__linux__`, the real thread path, not
+  the Windows host-stub one) with a new test that starts a stream and lets the
+  `RtpSender` destruct without calling `stop()` first — the process completes
+  cleanly rather than calling `std::terminate()`. New test in `tests/Rtp_test.cpp`.
+
+### Fixed — cppcheck version floats with `ubuntu-latest`; scope grew during verification (#112)
+
+- **The suppression half is landed here; the version-pin half needs a
+  follow-up push.** This session's `gh` token lacks the `workflow` OAuth
+  scope GitHub requires to push a change under `.github/workflows/`, so the
+  `ci.yml` diff that actually pins cppcheck to 2.21.0 (built from its own
+  tagged source — no official Linux binary, and pip's `cppcheck` package is
+  an unrelated 1.5.1-vintage wrapper — cached by version via `actions/cache`
+  so a version bump is deliberate, not a runner-image surprise) could not be
+  pushed to this branch. It's fully written and verified (see below) and sits
+  on the local `backup-with-ci-workflow-change` branch; someone with that
+  scope needs to cherry-pick it onto this PR (or push that branch and merge
+  it) before this issue is truly closed. Until then CI keeps running the
+  floating apt 2.13.0, which is a no-op with respect to every suppression
+  below (2.13.0 reports none of these findings), so nothing regresses in the
+  meantime — the pin is additive, not a prerequisite for the rest of this PR.
+
+- **The issue's own count was verified and found incomplete.** The issue
+  documented exactly 4 findings 2.21.0 has that 2.13.0 doesn't. To pin
+  responsibly this needed verifying on the real toolchain rather than trusted
+  at face value, so both versions were built from source and run **twice**:
+  once on this Windows sandbox's cross-compiled cppcheck (caught the
+  discrepancy) and once on a real Linux build via WSL Debian (gcc 14, matching
+  the actual `ubuntu-latest` job) to rule out a Windows-build artifact.
+  Confirmed on Linux: 2.13.0 finds **zero** issues on `main`; 2.21.0 finds
+  **13**, across six categories, not four. The other nine are the identical
+  false-positive shape as the issue's own `SipStatus.cpp` example — plain
+  aggregates cppcheck now flags per-scalar-member (`uninitMemberVarNoCtor`)
+  even though every construction site brace-initializes or immediately
+  overwrites the field before any read — plus a third, previously-unreported
+  `ESP_IDF_VERSION_VAL` `syntaxError` site and one `performance` finding.
+  Pinning to 2.21.0 without addressing all thirteen would have made the pin
+  itself the next red-CI surprise, so all thirteen are resolved here:
+
+  - **The two `syntaxError` findings the issue asked to investigate "for
+    real"** (`main/esp_main_eth.cpp:36`, `main/esp_main_eth_lan8720.cpp:43`,
+    both `#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(...)`) — plus a third,
+    identical, previously-unreported instance found during verification
+    (`src/SIP/RequestsHandler.cpp:3734`, inside the DTMF NTP-resync
+    handler) — are **not** a real parse defect: `esp_idf_version.h` is a real
+    ESP-IDF header that a genuine `idf.py` build (Job 2 of this workflow)
+    resolves fine. The host lint job's include path (`-I src/Helpers -I
+    src/SIP -I main`) has no ESP-IDF tree on it, so cppcheck can't expand
+    `ESP_IDF_VERSION_VAL` and aborts that `#if`. Suppressed with inline
+    `// cppcheck-suppress syntaxError` comments at each site (verified this
+    scopes to just that line and doesn't blind cppcheck to the rest of the
+    file — confirmed with a standalone repro before applying), rather than
+    the issue's suggested whole-file `--suppress=syntaxError:<path>`, which
+    would have silenced *any* future syntax error anywhere in
+    `RequestsHandler.cpp` — the codebase's largest, most-frequently-changed
+    file, and precisely the "dangerous" outcome the issue was warning about,
+    just from the flag rather than from the finding itself.
+  - **`SipStatus.cpp:11` `uninitMemberVarNoCtor`** (and, found during
+    verification, the same struct's `code` field at line 9 — cppcheck flags
+    each scalar member individually, not once per struct): `StatusEntry` is a
+    deliberate plain aggregate; its only instance, the constexpr
+    `kStatusTable`, brace-initializes every field. Suppressed inline with the
+    issue's own rationale.
+  - **`main/wifi/DnsServer.cpp:113,141` `dangerousTypeCast`**: the standard
+    BSD-sockets `(struct sockaddr *)&x` idiom for `bind()`/`recvfrom()`.
+    Suppressed inline with the issue's own rationale.
+  - **`src/SIP/PcapCapture.hpp` `uninitMemberVarNoCtor` ×6**
+    (`TraceRecord::seq/tsUs/outbound`, `Entry::seq/outbound/tsUs`, found during
+    verification, not in the issue): `TraceRecord`'s one construction site
+    brace-initializes every field; `Entry`'s one populator (`recordInto()`)
+    assigns every field immediately after the `emplace_back()`/slot-reuse that
+    default-constructs it, before any read. Suppressed inline.
+  - **`src/SIP/RequestsHandler.hpp` `uninitMemberVarNoCtor` ×2**
+    (`ProvisioningInfo::authRequired`, `RateBucket::tokens`, found during
+    verification): both are always fully brace-initialized or immediately
+    overwritten at their one construction site each
+    (`findProvisioningInfo()`'s return; `_rateBuckets[ip] = {40.0, now}`).
+    Suppressed inline.
+  - **`src/SIP/AnchorClient.hpp` `uninitMemberVarNoCtor` ×1** (`CallEvent::
+    type`, found during verification): every `CallEvent` construction site in
+    `LoopbackAnchorClient.cpp` brace-initializes all four fields. Suppressed
+    inline.
+  - **`src/SIP/RequestsHandler.hpp:160` `performance: returnByReference`**
+    (`getAdminExt()`, found during verification) — deliberately **declined**,
+    not applied: `_adminExt` is mutated by `saveAdminExt()`/`loadAdminExt()`
+    from call paths that don't share a lock with this getter (callers read it
+    off the SIP thread, e.g. the dashboard/HTTP plane). Returning by value at
+    least hands the caller an independent copy the instant this call returns;
+    returning `const std::string&` as suggested would additionally let that
+    reference dangle/tear if a concurrent save reallocates the string while
+    the caller still holds it — strictly worse, not a free performance win.
+    Suppressed inline with that rationale.
+
+### Verification
+
+Full host suite built and run on **two** toolchains for this bucket, since
+issue #112's own build was cross-verified on real Linux (see above) and the
+Windows sandbox's Smart App Control policy (enterprise code-integrity
+enforcement, unrelated to this change) began blocking execution of freshly-
+linked, unsigned test binaries partway through this session:
+
+- **Windows, MSVC 19.44 (Visual Studio 17 2022)**: for #106 and #104,
+  temporarily reverted just the production fix (`RequestsHandler.hpp`,
+  `RegisterBeeper.cpp`, and the `forEachSessionInvolving()` half of
+  `FakePbxEnv.hpp`) with the new tests left in place, confirming all three new
+  tests fail against the pre-fix behavior, then restored the fix and confirmed
+  they pass. Full suite (171 pre-existing + new tests) passing on the fixed
+  tree, prior to the Smart App Control block described below.
+- **WSL Debian, gcc 14.2.0** (matches the CI runner's OS/toolchain family):
+  configured, built, and ran the fixed tree's full suite — **196/196
+  passing**, including the `RtpSender` destructor test running the real
+  `__linux__` `std::thread` path (not the Windows host-stub no-op path, which
+  would have proven nothing about the join fix).
+- **Windows, MSVC 19.44 (Visual Studio 17 2022)**: built clean through
+  `RegisterBeeper.cpp`, `RequestsHandler.hpp`/`.cpp`, `RtpSender.cpp`,
+  `AnchorClient.hpp`, `PcapCapture.hpp`, `SipStatus.cpp`, and all touched test
+  files with no new warnings; test *execution* is currently blocked on this
+  machine by Smart App Control (`CodeIntegrity` event log:
+  "did not meet the Enterprise signing level requirements") for any
+  freshly-rebuilt, unsigned `sip_parser_tests.exe` — confirmed unrelated to
+  these changes (the already-built `SipServer.exe` runs fine; only newly
+  re-linked test binaries are affected) and not something fixable from within
+  this session.
+- **cppcheck 2.21.0**, built from source on both a Windows cross-compile and a
+  real WSL/Linux build, run against the final tree with the workflow's exact
+  invocation: `EXIT=0`, zero findings, on both.
+
 ## Unreleased (issue-101-closeout) - 2026-08-17
 
 Closes Issue #101: items **A**, **B**, **D** and **E** are fixed, **C** is

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -155,6 +155,61 @@ until a fork (or a future pass here) adds the routing policy.
 
 ## Resolved Issues
 
+### 🟡 Issue #112: Pin cppcheck in CI: version floats with ubuntu-latest, and 2.21 already finds 4 issues 2.13 doesn't
+* **Status**: 🟡 Partially resolved 2026-08-19 — all findings suppressed/fixed and verified against a real 2.21.0 build, but the `ci.yml` pin itself couldn't be pushed this session (missing `workflow` OAuth scope — see below) and needs a follow-up push
+* **Labels**: `cleanup`
+
+#### Resolution
+Wrote and verified the CI workflow change that pins the host job's cppcheck to **2.21.0**, built from its own tagged source (no official Linux binary, and pip's `cppcheck` package is an unrelated 1.5.1-vintage wrapper) rather than the `apt` package that floats with `ubuntu-latest`, cached by version via `actions/cache` — but this session's `gh` token lacks the `workflow` scope GitHub requires to push a `.github/workflows/*` change, so that diff could not be pushed to the PR branch. It sits, committed, on the local `backup-with-ci-workflow-change` branch and needs someone with that scope to push it or cherry-pick it onto the PR. Everything the pin would newly surface is already fixed/suppressed in source (below) and merged into the PR, so applying the pin once pushed should be a no-op against a clean CI run — it is not blocked on anything further.
+
+Before pinning, the issue's claimed 4 findings were verified rather than trusted — both 2.13.0 and 2.21.0 were built from source and run twice: once cross-compiled on Windows (surfaced a discrepancy), and once on a real Linux build via WSL Debian (gcc 14) to confirm it wasn't a Windows-build artifact. On Linux: 2.13.0 finds **zero** issues on `main`; 2.21.0 finds **13**, across six categories. The other nine beyond the issue's four are the identical false-positive shape as its own `SipStatus.cpp` example (plain aggregates now flagged per-scalar-member even though every construction site brace-initializes or immediately overwrites the field), plus a third, previously-unreported `ESP_IDF_VERSION_VAL` `syntaxError` site inside `RequestsHandler.cpp`, and one `performance` suggestion. All thirteen resolved — pinning without addressing all of them would have made the pin itself the next red-CI surprise:
+
+- The three `syntaxError` sites (`main/esp_main_eth.cpp:36`, `main/esp_main_eth_lan8720.cpp:43`, `src/SIP/RequestsHandler.cpp:3734`, all `#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(...)`) were investigated as the issue asked ("the dangerous one") rather than blind-suppressed: confirmed not a real parse defect — a genuine `idf.py` build resolves `esp_idf_version.h` fine; the host lint job's include path just has no ESP-IDF tree on it. Fixed with inline `// cppcheck-suppress syntaxError` at each site (verified with a standalone repro that this scopes to just that line, not the whole file) rather than the issue's suggested whole-file `--suppress=syntaxError:<path>`, which on `RequestsHandler.cpp` — the codebase's largest, most-frequently-changed file — would have silenced any future real syntax error there too.
+- `SipStatus.cpp` (both its `code` and `softFail` fields — cppcheck flags each scalar member individually), `DnsServer.cpp`, `PcapCapture.hpp` (×6), `RequestsHandler.hpp` (×2) got inline `// cppcheck-suppress` comments with per-site false-positive rationale.
+- `RequestsHandler.hpp`'s `getAdminExt()` performance suggestion (return by reference) was deliberately **declined**: `_adminExt` is mutated from call paths that don't share a lock with this getter, so returning a reference would let it dangle under a concurrent write — worse, not better.
+
+Verified clean (`EXIT=0`, zero findings) with the exact CI invocation on both a Windows cross-build and a real WSL/Linux build of cppcheck 2.21.0. Full detail: https://github.com/GlomarGadaffi/pocket-dial/issues/112
+
+---
+
+### 🟢 Issue #108: RtpSender Linux: no destructor join for the sender thread; SSRC/seq seeded from std::rand
+* **Status**: ✅ Resolved 2026-08-19 — SSRC/seq fixed; destructor was already correct on `main`
+* **Labels**: `bug`, `desktop`
+
+#### Resolution
+Two items:
+
+1. **SSRC/sequence/timestamp seeded from `std::rand()`.** Fixed: the host/Linux `rand32()` now uses a `thread_local std::mt19937` seeded from `std::random_device`, rather than a single process-wide `std::rand()` stream shared and correlated across every caller. The ESP branch (`esp_random()`, the hardware RNG) was already correct and is unchanged.
+2. **No destructor join.** Investigated and found **already correct** on `main` — the issue's "no destructor is visible in the patch" referred to commit `af5fd24` (the Linux media path) not adding one, but `~RtpSender()` predates that commit (added with the original media feature, `119ca84`) and its non-ESP branch already calls `stop("")` unconditionally, which on Linux sets `_stopRequested` and joins `_senderThread` synchronously before returning. No joinable thread is ever left running when the object is destroyed. Only the destructor's stale comment (still calling it a "host stub" after `af5fd24` gave that code path a real Linux thread) was updated — no behavior change. Verified by building and running the host suite under WSL/Linux (the real `__linux__` thread path, not the Windows host-stub no-op) with a new test that starts a stream and lets the object destruct without calling `stop()` first: completes cleanly, no `std::terminate()`.
+
+New/updated tests: `tests/Rtp_test.cpp` (`DestructorStopsActiveStreamWithoutCrash`). Full detail: https://github.com/GlomarGadaffi/pocket-dial/issues/108
+
+---
+
+### 🟢 Issue #106: BLF forEachSessionInvolving else-if drops the Callee leg when an extension calls itself
+* **Status**: ✅ Resolved 2026-08-19
+* **Labels**: `bug`
+
+#### Resolution
+`RequestsHandler::forEachSessionInvolving()` used an `if (isSrc) ... else if (isDest) ...` chain (a regression from commit `f0446d9`'s refactor), so a session whose src *and* dest are both the watched extension — a self-call, or a hunt/ring group where the caller is also a member — only ever reported the Caller role; the Callee leg was silently dropped from `BlfSubscriptions`' dialog-info XML. Restored to two independent `if`s so both roles fire when both match, as the pre-`f0446d9` visitor did.
+
+`tests/FakePbxEnv.hpp`'s `forEachSessionInvolving()` — the test double every BLF/beeper/park host test drives, since the production method is a private `PbxEnv` override and not directly host-testable — carried the identical bug and was fixed identically. Covered by two new tests in `tests/BlfSubscriptions_test.cpp`: one asserts the callback fires twice (once per role) for a self-call session, the other confirms `BlfSubscriptions::computeDialogState` reports the higher-ranked Callee leg rather than getting stuck on the Caller leg for a ringing self-call. Full detail: https://github.com/GlomarGadaffi/pocket-dial/issues/106
+
+---
+
+### 🟢 Issue #104: RegisterBeeper::sweep logs 'cancelled' and enters AwaitingCancelDone even when buildCancel fails
+* **Status**: ✅ Resolved 2026-08-19
+* **Labels**: `bug`
+
+#### Resolution
+Confirmed as a live bug via real-hardware evidence in the issue's comment thread (a LilyGO T-ETH-Elite S3 logging "cancelled" for a beep dialog in the same breath as message-pool exhaustion). `sweep()`'s `AwaitingInviteOk` branch unconditionally logged "cancelled" and advanced to `AwaitingCancelDone` even when `buildCancel()` returned `nullptr` under pool pressure — misrepresenting what happened, and leaving the dialog in a state that claims a CANCEL is in flight when none was sent.
+
+Fixed: on `buildCancel()` failure the dialog stays in `AwaitingInviteOk` with a short retry deadline and a distinct "cancel build failed — will retry" log; the next `sweep()` tick retries, succeeding once pool pressure eases. Per the issue's own caution against getting stuck forever either, added a bounded retry count (`BeepDialog::cancelRetries`, capped at 5) — after five consecutive failures `sweep()` gives up and frees the slot rather than retrying indefinitely under sustained exhaustion.
+
+Covered by two new tests in `tests/RegisterBeeper_test.cpp` (a new `FakePbxEnv::messagePoolAvailable` toggle forces `buildCancel()` to fail, matching the existing `sessionPoolAvailable` pattern): one confirms the retry-then-succeed path, the other confirms the bounded give-up-and-free path under sustained pressure. Full detail: https://github.com/GlomarGadaffi/pocket-dial/issues/104
+
+---
+
 ### 🟢 Issue #101: Pool-exhaustion backpressure, SDP re-parse, PcapCapture alloc-under-lock, incomplete firmware audit
 * **Status**: ✅ Resolved 2026-08-17 — **A**, **B**, **D**, **E** fixed; **C** formally declined (see below)
 * **Labels**: `performance`, `reliability`, `memory-safety`, `cleanup`, `refactoring`, `esp32`

--- a/main/esp_main_eth.cpp
+++ b/main/esp_main_eth.cpp
@@ -33,6 +33,12 @@
 // ETH_W5500_DEFAULT_CONFIG, esp_eth_mac_new_w5500, esp_eth_phy_new_w5500) is
 // declared by esp_eth.h above, and these headers do not exist — including them
 // unconditionally is what broke the `eth` CI matrix on v5.1.2/v5.2.1.
+//
+// cppcheck (Issue #112): the host lint job's include path (-I src/Helpers
+// -I src/SIP -I main) has no ESP-IDF tree on it, so it can't see the real
+// `esp_idf_version.h` that defines ESP_IDF_VERSION_VAL — a genuine ESP-IDF
+// build (idf.py, Job 2 of this workflow) has it and evaluates this #if fine.
+// cppcheck-suppress syntaxError
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #include "esp_eth_mac_w5500.h"
 #include "esp_eth_phy_w5500.h"

--- a/main/esp_main_eth_lan8720.cpp
+++ b/main/esp_main_eth_lan8720.cpp
@@ -40,6 +40,11 @@
 // ships this dedicated header. On v5.x esp_eth.h itself declared
 // esp_eth_phy_new_lan87xx and this header does not exist, so the include (and the
 // managed-component dependency in idf_component.yml) is gated to v6.0+.
+//
+// cppcheck (Issue #112): same analysis-path gap as esp_main_eth.cpp — the host
+// lint job's include path has no ESP-IDF tree, so it can't resolve the real
+// ESP_IDF_VERSION_VAL from esp_idf_version.h. A genuine idf.py build has it.
+// cppcheck-suppress syntaxError
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #include "esp_eth_phy_lan87xx.h"
 #endif

--- a/main/wifi/DnsServer.cpp
+++ b/main/wifi/DnsServer.cpp
@@ -110,6 +110,11 @@ void DnsServer::dns_task(void* pvParameters) {
     tv.tv_usec = 500000;   // 500 ms
     setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
+    // Standard BSD-sockets idiom: bind()/recvfrom() take `struct sockaddr *`,
+    // and casting the concrete `sockaddr_in` up to it is how every sockets API
+    // is used in C/C++ -- not the raw-memory reinterpretation dangerousTypeCast
+    // is built to catch. False positive.
+    // cppcheck-suppress dangerousTypeCast
     int err = bind(sock, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
     if (err < 0) {
         ESP_LOGE(TAG, "Socket unable to bind: errno %d", errno);
@@ -138,6 +143,9 @@ void DnsServer::dns_task(void* pvParameters) {
     }
 
     while (self->_running.load(std::memory_order_acquire)) {
+        // Same BSD-sockets idiom as the bind() above -- recvfrom() also takes
+        // `struct sockaddr *`. False positive.
+        // cppcheck-suppress dangerousTypeCast
         int len = recvfrom(sock, rx_buffer, sizeof(rx_buffer), 0, (struct sockaddr *)&source_addr, &socklen);
         if (len < 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {

--- a/src/SIP/AnchorClient.hpp
+++ b/src/SIP/AnchorClient.hpp
@@ -22,6 +22,10 @@ public:
 		// via makeCall). Incoming is the inverse: an external system is delivering an
 		// inbound call to a DN this device monitors; ring a local extension, then call
 		// answerCall() to accept it. callerId carries the caller's number/name (best-effort).
+		// cppcheck flags `type` as uninitMemberVarNoCtor. False positive: every
+		// CallEvent is constructed at its call sites (LoopbackAnchorClient.cpp)
+		// with all four fields brace-initialised.
+		// cppcheck-suppress uninitMemberVarNoCtor
 		enum Type { Ringing, Answered, Dropped, Dtmf, Incoming } type;
 		std::string participantId;
 		std::string dtmfDigit;

--- a/src/SIP/PcapCapture.hpp
+++ b/src/SIP/PcapCapture.hpp
@@ -116,10 +116,16 @@ public:
 	// tracer, which polls GET /api/trace and appends whatever it hasn't already
 	// shown (`seq` is monotonic and never reused, so the client can track a
 	// high-water mark instead of the server tracking per-client state).
+	// cppcheck flags the scalar members below (uninitMemberVarNoCtor). False
+	// positive: TraceRecord is a plain aggregate, and its one construction
+	// site (traceRecords() below) always brace-initialises every field.
 	struct TraceRecord
 	{
+		// cppcheck-suppress uninitMemberVarNoCtor
 		uint64_t    seq;
+		// cppcheck-suppress uninitMemberVarNoCtor
 		uint64_t    tsUs;
+		// cppcheck-suppress uninitMemberVarNoCtor
 		bool        outbound;
 		std::string peer;   // "ip:port", via sipwire::addrToIpPort
 		std::string text;
@@ -170,12 +176,20 @@ public:
 	}
 
 private:
+	// cppcheck flags the scalar members below (uninitMemberVarNoCtor). False
+	// positive: recordInto() above is Entry's only populator, and every field
+	// (seq/outbound/peer/tsUs) is assigned there immediately after the
+	// emplace_back()/reuse that default-constructs the slot, before any of
+	// them is ever read.
 	struct Entry
 	{
+		// cppcheck-suppress uninitMemberVarNoCtor
 		uint64_t    seq;
+		// cppcheck-suppress uninitMemberVarNoCtor
 		bool        outbound;
 		sockaddr_in peer;
 		std::string bytes;
+		// cppcheck-suppress uninitMemberVarNoCtor
 		uint64_t    tsUs;
 	};
 	// Ring buffer. Grows to POCKETDIAL_PCAP_RING_SIZE and then stops: entries are

--- a/src/SIP/RegisterBeeper.cpp
+++ b/src/SIP/RegisterBeeper.cpp
@@ -183,10 +183,42 @@ void RegisterBeeper::sweep(std::chrono::steady_clock::time_point now)
 			// has no Session to key off, so we just fall through to the same
 			// bounded fallback below rather than acting on it there too.
 			auto cancel = buildCancel(i);
-			if (cancel) _env.enqueue(bd.addr, std::move(cancel));
-			_env.log("Register beep: no answer from " + bd.ext + ", cancelled");
-			bd.state    = BeepState::AwaitingCancelDone;
-			bd.deadline = now + std::chrono::seconds(5);
+			if (cancel)
+			{
+				_env.enqueue(bd.addr, std::move(cancel));
+				_env.log("Register beep: no answer from " + bd.ext + ", cancelled");
+				bd.state    = BeepState::AwaitingCancelDone;
+				bd.deadline = now + std::chrono::seconds(5);
+			}
+			else if (++bd.cancelRetries < kMaxCancelRetries)
+			{
+				// buildCancel() couldn't get a pool slot (Issue #101(A) territory —
+				// precisely the flood conditions under which an operator reads these
+				// logs). Do NOT claim a CANCEL went out, and do NOT advance to
+				// AwaitingCancelDone: that state means "a CANCEL is in flight, keep
+				// matching this Call-ID for a raced 200 OK", which would be a lie
+				// here and would abandon the dialog in a half-cancelled limbo where
+				// nothing ever CANCELs it and the phone rings forever. Stay in
+				// AwaitingInviteOk so the next sweep() retries the CANCEL — once pool
+				// pressure eases the retry succeeds and follows the normal path
+				// above. Retry after a short, bounded delay (not every tick) so
+				// sustained pool exhaustion doesn't spin this slot.
+				_env.log("Register beep: no answer from " + bd.ext +
+					", cancel build failed — will retry");
+				bd.deadline = now + std::chrono::seconds(1);
+			}
+			else
+			{
+				// kMaxCancelRetries consecutive failures: pool pressure hasn't let
+				// up in ~5s of retrying. Give up on this slot rather than retrying
+				// forever — free it like any other abandoned dialog. The phone
+				// never got CANCELled, but it will simply ring out on its own
+				// timeout; better than pinning a beeper slot indefinitely under
+				// sustained load.
+				_env.log("Register beep: no answer from " + bd.ext +
+					", cancel build failed repeatedly — giving up, slot freed", true);
+				bd = BeepDialog{};
+			}
 			continue;
 		}
 		bd = BeepDialog{};   // AwaitingByeOk / AwaitingCancelDone fallback: free the slot

--- a/src/SIP/RegisterBeeper.hpp
+++ b/src/SIP/RegisterBeeper.hpp
@@ -74,6 +74,12 @@ private:
 		std::string ext;           // target extension (phone number)
 		sockaddr_in addr{};        // phone's contact address
 		std::chrono::steady_clock::time_point deadline{};
+		// Issue #104: counts consecutive buildCancel() failures (message-pool
+		// exhaustion) in AwaitingInviteOk. sweep() retries on a short delay
+		// rather than freeing the slot immediately, but bounded — past
+		// kMaxCancelRetries the slot is freed like any other abandoned dialog
+		// instead of retrying forever under sustained pool pressure.
+		int cancelRetries = 0;
 	};
 
 	BeepDialog* findByCallID(std::string_view callID);
@@ -83,6 +89,11 @@ private:
 	std::shared_ptr<SipMessage> buildAck(const BeepDialog& bd, const std::shared_ptr<SipMessage>& ok);
 	std::shared_ptr<SipMessage> buildBye(const BeepDialog& bd, const std::shared_ptr<SipMessage>& ok);
 	std::shared_ptr<SipMessage> buildCancel(std::size_t slot);
+
+	// Issue #104: cap on consecutive buildCancel() retries (see BeepDialog::
+	// cancelRetries) before sweep() gives up and frees the slot outright rather
+	// than retrying forever under sustained message-pool pressure.
+	static constexpr int kMaxCancelRetries = 5;
 
 	// Bounded outbound-UAC dialog table. Tiny fixed footprint; if all slots are
 	// busy a new registration just skips its beep.

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -3731,6 +3731,11 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 			{
 				// NTP resync (esp_sntp_restart is ESP-IDF v5+; fall back to log if absent)
 #if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+				// cppcheck (Issue #112): same ESP_IDF_VERSION_VAL analysis-path
+				// gap as esp_main_eth.cpp/esp_main_eth_lan8720.cpp -- the host
+				// lint job has no ESP-IDF tree on its include path to resolve
+				// esp_idf_version.h from. A genuine idf.py build has it.
+				// cppcheck-suppress syntaxError
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 				esp_sntp_restart();
 #else

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -120,6 +120,10 @@ public:
 	struct ProvisioningInfo
 	{
 		std::string extension;
+		// cppcheck flags this as uninitMemberVarNoCtor. False positive:
+		// ProvisioningInfo's only construction site (findProvisioningInfo's
+		// return) always brace-initialises both fields.
+		// cppcheck-suppress uninitMemberVarNoCtor
 		bool authRequired;
 	};
 	std::optional<ProvisioningInfo> findProvisioningInfo(const std::string& mac);
@@ -157,6 +161,15 @@ public:
 	// ── Admin extension (Task 2B) ─────────────────────────────────────────────────
 	// NVS-persisted extension identity for the administrative endpoint.
 	// Default "1001". Loaded from NVS namespace "pbxcfg", key "admin_ext" at boot.
+	// cppcheck suggests returning `const std::string&` here (returnByReference).
+	// Deliberately not applied: _adminExt is mutated by saveAdminExt()/
+	// loadAdminExt() from other call paths with no lock of its own (callers of
+	// this getter are not required to hold _mutex — dashboard/HTTP reads go
+	// through here off the SIP thread). Returning by value at least keeps the
+	// caller's copy independent once this call returns; a reference would
+	// additionally dangle/tear if a concurrent save reallocates the string
+	// while the caller still holds it.
+	// cppcheck-suppress returnByReference
 	std::string getAdminExt() const;
 
 	// ── Admin HTTP-open deadline (PLAN_ADMIN_HTTP_ONLY.md Phase 2) ────────────────
@@ -640,6 +653,11 @@ private:
 	// Issue #38: token bucket keyed by source IPv4 (network-order s_addr).
 	struct RateBucket
 	{
+		// cppcheck flags this as uninitMemberVarNoCtor. False positive: every
+		// RateBucket is created via `_rateBuckets[ip] = { 40.0, now }` (below),
+		// so `tokens` is overwritten immediately and is never read from the
+		// briefly-default-constructed instance operator[] creates first.
+		// cppcheck-suppress uninitMemberVarNoCtor
 		double tokens;
 		std::chrono::steady_clock::time_point last;
 	};

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -335,7 +335,7 @@ private:
 			if (!session) continue;
 			if (session->getSrc() && session->getSrc()->getNumber() == aor)
 				fn(callID, *session, DialogRole::Caller);
-			else if (session->getDest() && session->getDest()->getNumber() == aor)
+			if (session->getDest() && session->getDest()->getNumber() == aor)
 				fn(callID, *session, DialogRole::Callee);
 		}
 	}

--- a/src/SIP/RtpSender.cpp
+++ b/src/SIP/RtpSender.cpp
@@ -13,10 +13,10 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <chrono>
-#include <cstdlib>
 #include <iostream>
+#include <random>
 #else
-#include <cstdlib>   // std::rand on host (only for SSRC/seq seeding in stubbed start)
+#include <random>   // std::mt19937/random_device on host (SSRC/seq seeding in stubbed start)
 #endif
 
 namespace
@@ -29,16 +29,25 @@ namespace
 	// 2π as a double (M_PI is not guaranteed on MSVC without _USE_MATH_DEFINES).
 	constexpr double TWO_PI = 6.283185307179586476925286766559;
 
-	// Cross-platform 32-bit random (RTP SSRC / initial seq+timestamp). On ESP we use
-	// the hardware RNG; on host std::rand is fine (these are test-only there).
+	// Cross-platform 32-bit random (RTP SSRC / initial seq+timestamp). On ESP we
+	// use the hardware RNG. On host/Linux, RFC 3550 §3 wants the SSRC genuinely
+	// random (so colliding streams can be told apart) — std::rand() is a single
+	// process-wide stream shared and correlated across every caller, which is
+	// exactly the property SSRC randomness needs NOT to have. Each thread gets
+	// its own std::mt19937, seeded from std::random_device (Issue #108).
+#if !(defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO))
 	uint32_t rand32()
 	{
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-		return esp_random();
-#else
-		return (static_cast<uint32_t>(std::rand()) << 16) ^ static_cast<uint32_t>(std::rand());
-#endif
+		thread_local std::mt19937 gen{std::random_device{}()};
+		thread_local std::uniform_int_distribution<uint32_t> dist;
+		return dist(gen);
 	}
+#else
+	uint32_t rand32()
+	{
+		return esp_random();
+	}
+#endif
 }
 
 // ── ITU-T G.711 µ-law encode ────────────────────────────────────────────────
@@ -157,7 +166,16 @@ RtpSender::~RtpSender()
 		vTaskDelay(pdMS_TO_TICKS(5));
 	}
 #else
-	stop("");   // host stub: just clears the (no-task) active flag
+	// Issue #108: destroying a joinable std::thread calls std::terminate, so a
+	// stream must never be left running when this object goes away. stop("")
+	// (empty callID matches any active stream, per its own doc comment) covers
+	// both non-ESP shapes correctly: on Linux it sets _stopRequested and JOINS
+	// _senderThread synchronously (see that stop()'s own comment), so the
+	// thread is never outliving this object; on the plain host stub there is no
+	// real thread at all, so it just clears the (no-task) active flag. Either
+	// way this call is safe to make unconditionally, active stream or not
+	// (idempotent on an already-idle sender).
+	stop("");
 #endif
 }
 

--- a/src/SIP/SipStatus.cpp
+++ b/src/SIP/SipStatus.cpp
@@ -5,9 +5,17 @@
 namespace PocketDial {
 namespace {
 
+// cppcheck flags every scalar member below for having no constructor to
+// assign it (uninitMemberVarNoCtor). False positive: StatusEntry is a
+// deliberate plain aggregate -- the only instance is the constexpr
+// kStatusTable below, where every element is brace-initialised with all
+// three fields, so nothing is ever read uninitialised. A constructor would
+// defeat the point of a constexpr ROM table.
 struct StatusEntry {
+    // cppcheck-suppress uninitMemberVarNoCtor
     uint16_t         code;
     std::string_view reason;
+    // cppcheck-suppress uninitMemberVarNoCtor
     bool             softFail;
 };
 

--- a/tests/BlfSubscriptions_test.cpp
+++ b/tests/BlfSubscriptions_test.cpp
@@ -125,3 +125,57 @@ TEST(BlfSubscriptions, ConfirmedCallOnWatchedTargetNotifiesConfirmed)
 	EXPECT_NE(notify.find("<state>confirmed</state>"), std::string::npos) << notify;
 	EXPECT_NE(notify.find("direction=\"initiator\""), std::string::npos) << notify;
 }
+
+// Issue #106: forEachSessionInvolving used to be an if/else-if chain, so a
+// session whose src AND dest are the same watched extension (self-call) only
+// ever reported the Caller leg — the Callee leg was silently dropped. Both
+// checks must be independent so a self-call invokes the callback twice, once
+// per role.
+TEST(BlfSubscriptions, ForEachSessionInvolvingFiresBothRolesForSelfCall)
+{
+	FakePbxEnv env;
+	const sockaddr_in phoneAddr = FakePbxEnv::addr("192.168.1.50", 5060);
+
+	auto self = std::make_shared<SipClient>("101", phoneAddr);
+	auto session = std::make_shared<Session>("call-self", self);
+	session->setDest(self);
+	env.sessions.emplace("call-self", session);
+
+	std::vector<PbxEnv::DialogRole> rolesSeen;
+	env.forEachSessionInvolving("101",
+		[&](const std::string& callID, const Session&, PbxEnv::DialogRole role)
+	{
+		EXPECT_EQ(callID, "call-self");
+		rolesSeen.push_back(role);
+	});
+
+	ASSERT_EQ(rolesSeen.size(), 2u);
+	EXPECT_EQ(rolesSeen[0], PbxEnv::DialogRole::Caller);
+	EXPECT_EQ(rolesSeen[1], PbxEnv::DialogRole::Callee);
+}
+
+// End-to-end through the real BlfSubscriptions::computeDialogState: with the
+// bug, a ringing self-call only ever reported the Caller leg ("trying"/
+// initiator); with both roles firing, the higher-ranked Callee leg ("early"/
+// recipient) wins, since dest is visited after src.
+TEST(BlfSubscriptions, SelfCallRingingReportsCalleeLegNotJustCaller)
+{
+	FakePbxEnv env;
+	BlfSubscriptions blf(env);
+	const sockaddr_in watcherAddr = FakePbxEnv::addr("192.168.1.60", 5060);
+	const sockaddr_in phoneAddr   = FakePbxEnv::addr("192.168.1.50", 5060);
+
+	auto self = std::make_shared<SipClient>("101", phoneAddr);
+	auto session = std::make_shared<Session>("call-self", self);
+	session->setDest(self);
+	session->setState(Session::State::Invited);
+	env.sessions.emplace("call-self", session);
+
+	blf.onSubscribe(subscribe("200", "101", "watch-6@192.168.1.60", "Event: dialog", 3600,
+		watcherAddr));
+
+	ASSERT_EQ(env.sent.size(), 2u);
+	const std::string notify = env.sentRaw(1);
+	EXPECT_NE(notify.find("<state>early</state>"), std::string::npos) << notify;
+	EXPECT_NE(notify.find("direction=\"recipient\""), std::string::npos) << notify;
+}

--- a/tests/FakePbxEnv.hpp
+++ b/tests/FakePbxEnv.hpp
@@ -57,6 +57,10 @@ public:
 
 	// Set false to simulate a drained session pool (the 503 guard paths).
 	bool sessionPoolAvailable = true;
+	// Set false to simulate an exhausted message pool (Issue #101(A) territory):
+	// messageFromPool() returns nullptr, as the real pool does once it and its
+	// bounded heap fallback are both spent.
+	bool messagePoolAvailable = true;
 
 	static sockaddr_in addr(const char* ip, uint16_t port)
 	{
@@ -93,6 +97,7 @@ public:
 	}
 	std::shared_ptr<SipMessage> messageFromPool(std::string raw, sockaddr_in src) override
 	{
+		if (!messagePoolAvailable) return nullptr;
 		return std::make_shared<SipMessage>(raw, src);
 	}
 	void log(std::string msg, bool /*isError*/ = false) override

--- a/tests/FakePbxEnv.hpp
+++ b/tests/FakePbxEnv.hpp
@@ -156,7 +156,7 @@ public:
 			if (!session) continue;
 			if (session->getSrc() && session->getSrc()->getNumber() == aor)
 				fn(callID, *session, DialogRole::Caller);
-			else if (session->getDest() && session->getDest()->getNumber() == aor)
+			if (session->getDest() && session->getDest()->getNumber() == aor)
 				fn(callID, *session, DialogRole::Callee);
 		}
 	}

--- a/tests/RegisterBeeper_test.cpp
+++ b/tests/RegisterBeeper_test.cpp
@@ -123,6 +123,85 @@ TEST(RegisterBeeper, LateOkAfterSweepCancelStillGetsAckedAndByed)
 	EXPECT_EQ(env.byeCalls[0].callId, callId);
 }
 
+// Issue #104: buildCancel() draws a message from the pool, which can be spent
+// under the same flood conditions that make an operator watch this log
+// (Issue #101(A)). sweep() must not claim "cancelled" or advance to
+// AwaitingCancelDone when nothing was actually sent — that would abandon the
+// dialog in a half-cancelled limbo no later tick ever revisits. It must retry
+// on a later tick instead, succeeding once pool pressure eases.
+TEST(RegisterBeeper, SweepRetriesCancelWhenBuildCancelFailsUnderPoolPressure)
+{
+	FakePbxEnv env;
+	RegisterBeeper beeper(env);
+
+	const sockaddr_in phoneAddr = FakePbxEnv::addr("192.168.1.50", 5060);
+	const auto t0 = std::chrono::steady_clock::now();
+	beeper.sendBeep(std::make_shared<SipClient>("101", phoneAddr));
+	ASSERT_EQ(env.sent.size(), 1u);
+	const std::string callId = callIdOf(env.sentRaw(0));
+	ASSERT_FALSE(callId.empty());
+
+	// No answer within the beep deadline, but the message pool is exhausted:
+	// buildCancel() returns nullptr. No CANCEL goes out, no "cancelled" log,
+	// and the dialog must not move to AwaitingCancelDone (verified below: it is
+	// still recognized as an in-flight beep dialog on the next sweep, i.e. it
+	// was not silently freed either).
+	env.messagePoolAvailable = false;
+	beeper.sweep(t0 + std::chrono::seconds(6));
+	EXPECT_EQ(env.sent.size(), 1u) << "no CANCEL should have been sent";
+	ASSERT_FALSE(env.logs.empty());
+	EXPECT_EQ(env.logs.back().find("cancelled"), std::string::npos) << env.logs.back();
+	EXPECT_NE(env.logs.back().find("cancel build failed"), std::string::npos)
+		<< env.logs.back();
+
+	// Pool pressure eases; the next sweep tick must retry and succeed, proving
+	// the dialog was left retryable rather than stuck forever.
+	env.messagePoolAvailable = true;
+	beeper.sweep(t0 + std::chrono::seconds(7));
+	ASSERT_EQ(env.sent.size(), 2u);
+	EXPECT_EQ(env.sentRaw(1).rfind("CANCEL sip:", 0), 0u) << env.sentRaw(1);
+	EXPECT_NE(env.logs.back().find("cancelled"), std::string::npos) << env.logs.back();
+
+	// The dialog is still tracked (now AwaitingCancelDone): a raced 200 OK is
+	// still ACKed/BYEd, exactly like the non-pool-pressure path.
+	EXPECT_TRUE(beeper.handleOk(okFor(callId, phoneAddr)));
+	ASSERT_EQ(env.sent.size(), 4u);   // + ACK, + (BYE delegated to serverBye)
+}
+
+// Issue #104 follow-up: retrying forever is its own bug ("don't leave it stuck
+// forever either"). If the message pool never recovers, sweep() must eventually
+// give up and free the slot instead of retrying indefinitely.
+TEST(RegisterBeeper, SweepGivesUpAndFreesSlotAfterSustainedPoolPressure)
+{
+	FakePbxEnv env;
+	RegisterBeeper beeper(env);
+
+	const sockaddr_in phoneAddr = FakePbxEnv::addr("192.168.1.50", 5060);
+	const auto t0 = std::chrono::steady_clock::now();
+	beeper.sendBeep(std::make_shared<SipClient>("101", phoneAddr));
+	const std::string callId = callIdOf(env.sentRaw(0));
+	ASSERT_FALSE(callId.empty());
+
+	// Pool pressure never eases: every retry tick fails to build the CANCEL.
+	env.messagePoolAvailable = false;
+	auto t = t0 + std::chrono::seconds(6);
+	for (int i = 0; i < 10; ++i)
+	{
+		beeper.sweep(t);
+		t += std::chrono::seconds(1);
+	}
+
+	// No CANCEL was ever sent (pool never had a slot for it) ...
+	EXPECT_EQ(env.sent.size(), 1u) << "only the original INVITE, never a CANCEL";
+	// ... and sweep eventually gave up rather than retrying forever.
+	ASSERT_FALSE(env.logs.empty());
+	EXPECT_NE(env.logs.back().find("giving up"), std::string::npos) << env.logs.back();
+
+	// The slot is free again: this now-stale Call-ID is no longer recognized,
+	// exactly like the normal fallback-expiry path (SlotFreedByFallback...).
+	EXPECT_FALSE(beeper.handleOk(okFor(callId, phoneAddr)));
+}
+
 // If nothing further ever arrives after the CANCEL (the CANCEL landed cleanly,
 // or the response was simply lost), the slot must still be freed by the bounded
 // fallback rather than lingering forever.

--- a/tests/Rtp_test.cpp
+++ b/tests/Rtp_test.cpp
@@ -296,3 +296,21 @@ TEST(MediaAnswer, SingleStreamCap) {
     // Idempotent: stopping an idle sender is a no-op.
     EXPECT_FALSE(tx.stop("callA"));
 }
+
+// Issue #108: on the Linux media path, only stop() joined the sender thread —
+// no destructor was visible in that patch. std::thread's destructor calls
+// std::terminate on a still-joinable thread, so destroying an RtpSender while
+// a stream is active (process shutdown mid-diagnostic-call, or any future
+// owner with a shorter lifetime than RequestsHandler) would crash the process.
+// Reaching the end of this test at all — rather than the binary aborting — is
+// the assertion; ~RtpSender() must stop (and, on Linux, join) any live stream.
+TEST(MediaAnswer, DestructorStopsActiveStreamWithoutCrash) {
+    {
+        RtpSender tx;
+        EXPECT_TRUE(tx.start("192.168.4.22", 4004, "callD"));
+        EXPECT_TRUE(tx.isActive());
+        // No stop() call: ~RtpSender() runs here, at scope exit, on a live
+        // stream.
+    }
+    SUCCEED();
+}


### PR DESCRIPTION
Closes #106. Closes #104. Addresses #108 (SSRC/seq fixed; destructor confirmed already correct on `main`). Addresses #112 (partial — see below: all findings fixed/suppressed, but the `ci.yml` pin itself couldn't be pushed this session).

Four small, independently-filed correctness bugs plus one CI hygiene fix, bundled per the triage bucket.

## #106 — BLF `forEachSessionInvolving` drops the Callee leg on a self-call

Commit `f0446d9`'s refactor from independent `isSrc`/`isDest` flags to an `if/else if` chain meant a session whose src **and** dest are both the watched extension — an extension calling itself, or a hunt/ring group where the caller is also a member — only ever fired the Caller role. `BlfSubscriptions::computeDialogState` never saw the Callee leg, so the watcher's dialog-info XML reported the wrong role/state.

Restored to two independent `if`s, matching the pre-`f0446d9` visitor that received both flags at once. `tests/FakePbxEnv.hpp`'s test double carried the identical bug (it's written to mirror the production method) and is fixed identically — worth noting since `RequestsHandler::forEachSessionInvolving()` is a private `PbxEnv` override and isn't directly host-testable in isolation; the fake is what the new tests actually exercise, alongside the real `BlfSubscriptions.cpp` logic that consumes it.

Two new tests in `tests/BlfSubscriptions_test.cpp`: one asserts the callback fires twice (once per `DialogRole`) for a self-call session, the other drives the real `computeDialogState` end-to-end and confirms a ringing self-call reports the higher-ranked Callee leg (`early`/`recipient`) instead of getting stuck on `trying`/`initiator`.

## #104 — `RegisterBeeper::sweep` claims "cancelled" when the CANCEL was never built

Confirmed live via the issue's own real-hardware evidence (a LilyGO T-ETH-Elite S3 logging "cancelled" in the same breath as message-pool exhaustion). `sweep()`'s `AwaitingInviteOk` branch unconditionally logged "cancelled" and advanced to `AwaitingCancelDone` even when `buildCancel()` returned `nullptr` under pool pressure — `AwaitingCancelDone` means "a CANCEL is in flight, keep matching this Call-ID for a raced 200 OK," which is false here, and leaves the dialog in a half-cancelled limbo nothing revisits.

Fixed: on failure the dialog stays in `AwaitingInviteOk` with a short (1s) retry deadline and a distinct log message; the next `sweep()` tick retries, succeeding once pool pressure eases. Per the issue's own caution against getting stuck forever either, added a bounded retry count (`BeepDialog::cancelRetries`, capped at `kMaxCancelRetries = 5`) — past that, `sweep()` gives up and frees the slot rather than retrying indefinitely under sustained exhaustion.

Two new tests in `tests/RegisterBeeper_test.cpp`, using a new `FakePbxEnv::messagePoolAvailable` toggle (matching the existing `sessionPoolAvailable` pattern) to force `buildCancel()`'s pool draw to fail: one confirms the retry-then-succeed path, the other confirms the bounded give-up-and-free path.

## #108 — `RtpSender` Linux: destructor join + `std::rand()` seeding

Two items in the issue; one was a real fix, one turned out to already be correct:

1. **SSRC/sequence/timestamp seeded from `std::rand()`** — fixed. `rand32()` on host/Linux now uses a `thread_local std::mt19937` seeded from `std::random_device`, rather than a single process-wide `std::rand()` stream shared and correlated across every caller (the opposite of what RFC 3550 §3 wants SSRC randomness for). The ESP branch (`esp_random()`) was already correct.
2. **No destructor join** — investigated and found **already correct on `main`**. The issue's "no destructor is visible in the patch" refers to commit `af5fd24` (the Linux media path) not adding one, but `~RtpSender()` predates that commit (added with the original media feature, `119ca84`) and its non-ESP branch already calls `stop("")` unconditionally — which on Linux sets `_stopRequested` and **joins `_senderThread` synchronously** before returning. No joinable thread is ever left running at destruction. Only the destructor's comment was stale (still called it a "host stub" after `af5fd24` gave that path a real thread) — updated for accuracy, no behavior change.

New test in `tests/Rtp_test.cpp` starts a stream and lets the object destruct without calling `stop()` first. Verified this actually exercises the real join path (not the Windows host-stub no-op): built and ran the full suite under WSL/Linux, where `RtpSender.cpp` compiles its `__linux__` `std::thread` branch — 196/196 passing there.

## #112 — Pin cppcheck in CI (partial — see note below)

The issue documented **4** cppcheck findings that appear on 2.21.0 but not the currently-floating apt 2.13.0. Before pinning, that count was verified rather than trusted — both versions built from source and run against `main` with the workflow's exact invocation, first cross-compiled on Windows (surfaced a discrepancy), then on a real Linux build via WSL Debian (gcc 14, matching `ubuntu-latest`) to rule out a Windows-build artifact.

**On real Linux: 2.13.0 finds zero issues; 2.21.0 finds 13, across six categories, not four.** The other nine are the same false-positive shape as the issue's own `SipStatus.cpp` example — plain aggregates cppcheck now flags per-scalar-member (`uninitMemberVarNoCtor`) even though every construction site brace-initializes or immediately overwrites the field before any read — plus a third, previously-unreported `ESP_IDF_VERSION_VAL` `syntaxError` site, and one `performance` suggestion. All 13 are fixed/suppressed in this PR:

| Finding | Where | Resolution |
|---|---|---|
| `syntaxError` ×3 | `esp_main_eth.cpp:36`, `esp_main_eth_lan8720.cpp:43`, `RequestsHandler.cpp:3734` (new, found during verification) | Investigated for real per the issue's "dangerous one" flag — confirmed a cppcheck include-path gap (`esp_idf_version.h` isn't on `-I src/Helpers -I src/SIP -I main`), not a real defect; a genuine `idf.py` build resolves it fine. Inline `// cppcheck-suppress syntaxError` at each site — verified with a standalone repro that this scopes to just that line and doesn't blind cppcheck to the rest of the file, rather than the issue's suggested whole-file suppression, which on `RequestsHandler.cpp` (the codebase's largest, most-changed file) would hide any *future* real syntax error too |
| `uninitMemberVarNoCtor` ×9 | `SipStatus.cpp` (both fields, not just the one the issue named), `PcapCapture.hpp` ×6, `RequestsHandler.hpp` ×2 (all new, found during verification) | Inline suppressions with per-site false-positive rationale (checked each: always brace-initialized or assigned-immediately-after-default-construct, never read uninitialized) |
| `dangerousTypeCast` ×2 | `DnsServer.cpp:113,141` | Inline suppressions — standard BSD-sockets `(struct sockaddr *)&x` idiom |
| `performance: returnByReference` ×1 | `RequestsHandler.hpp:160`, `getAdminExt()` (new, found during verification) | **Declined**, not applied: `_adminExt` is mutated from call paths that don't share a lock with this getter (dashboard/HTTP reads happen off the SIP thread); returning a reference would let it dangle under a concurrent write, which is worse than the current by-value copy, not a free win. Suppressed with that rationale |

Verified clean (`EXIT=0`, zero findings) with the exact CI invocation, cppcheck 2.21.0 built on both a Windows cross-build and real WSL/Linux.

**Why this is only partial:** the `ci.yml` change that actually pins the analyzer to 2.21.0 and adds the `actions/cache`-backed build step could **not be pushed** — this session's `gh` token lacks the `workflow` OAuth scope GitHub requires for any push touching `.github/workflows/*` (`refusing to allow an OAuth App to create or update workflow ci.yml without workflow scope`). Every source-level suppression/fix above **is** in this PR and is a no-op under the currently-running apt 2.13.0 (which reports none of these findings), so nothing regresses by merging as-is. The finished, verified `ci.yml` diff sits on a local branch, `backup-with-ci-workflow-change`, based on this PR's branch — someone with `workflow` scope needs to push that branch (or cherry-pick its one commit) to actually land the pin. Recommend re-running `gh auth refresh -s workflow` (or using a PAT with that scope) and pushing it before closing #112 for real.

## Verification

- **WSL Debian, gcc 14.2.0** (matches the CI runner's OS/toolchain family): full host suite **196/196 passing**, including the `RtpSender` destructor test exercising the real `__linux__` thread-join path.
- **Windows, MSVC 19.44**: builds clean through every touched file; test *execution* is currently blocked on this sandbox by an unrelated Smart App Control policy (`CodeIntegrity` event log: "did not meet the Enterprise signing level requirements") that started blocking any freshly-linked, unsigned test binary partway through this session — confirmed unrelated to these changes (`SipServer.exe` runs fine; only the re-linked `sip_parser_tests.exe` is affected). For #106 and #104, the production fix was temporarily reverted with the new tests left in place and confirmed to fail (on Windows, before the block appeared), then restored and confirmed to pass.
- **cppcheck 2.21.0**, built from source on both a Windows cross-compile and a real WSL/Linux build: `EXIT=0`, zero findings, on both, against the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
