### PR TITLE
feat(api): add GET /api/diagnostics/pcap for Wireshark analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased (issue-33-pcap-dump-endpoint) - 2026-08-28
+
+### Added — `GET /api/diagnostics/pcap` (#33)
+
+- Added `GET /api/diagnostics/pcap`, the path Issue #33's feature request
+  actually asked for. It's a second route to the exact same `sendApiPcap()`
+  handler `GET /api/pcap` already uses (shipped in `607bd91`, hardened for
+  wire-byte fidelity by #105) — same bounded `PcapCapture` ring, same session
+  gate, same `application/vnd.tcpdump.pcap` response with a
+  `Content-Disposition: attachment` header — so no second capture mechanism
+  and no new allocation path were introduced. A real 24-byte libpcap global
+  header (magic `0xa1b2c3d4`, `LINKTYPE_ETHERNET`) followed by one 16-byte
+  record header + synthesized Ethernet/IPv4/UDP frame per captured packet, so
+  `curl -o dump.pcap http://<device>/api/diagnostics/pcap` opens directly in
+  Wireshark without following a redirect.
+- `docs/API.md`'s endpoint catalog and `/api/pcap` section now note the alias.
+- New test in `tests/PcapCapture_test.cpp`,
+  `ApiDiagnosticsPcapServesValidGlobalHeaderAndOneRecordOverRealSocket`: drives
+  a real `HttpServer` + `RequestsHandler` pair over an actual TCP socket,
+  captures a REGISTER, then fetches the new endpoint and checks the actual
+  bytes on the wire — global header magic/linktype, and the first record's
+  `incl_len`/`orig_len` agreement, frame-fits-in-body, and verbatim SIP payload.
+
 ## Unreleased (issue-106-104-108-112-misc-bugs) - 2026-08-19
 
 Four small, independently-filed correctness bugs plus one CI hygiene fix,

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -38,16 +38,6 @@ Since physical target hardware (smart display JC3248W535EN, POE boards, etc.) is
 
 ---
 
-### 🔵 Issue #33: [Feature Request] PCAP Dump Endpoint for Wireshark analysis
-* **Status**: ⏳ Open / Planned (Backlog)
-* **Labels**: `feature-request`, `diagnostics`
-* **Severity**: Low
-
-#### Description
-Expose an HTTP endpoint `/api/diagnostics/pcap` to dump a live ring-buffer of SIP packets in PCAP format for quick network troubleshooting.
-
----
-
 ## Feature-Parity Backlog (LAN PBX)
 
 Generic desk-PBX features to bring pocket-dial to parity with full-size PBXes. **All of these are
@@ -134,6 +124,20 @@ until a fork (or a future pass here) adds the routing policy.
 ---
 
 ## Resolved Issues
+
+### 🟢 Issue #33: [Feature Request] PCAP Dump Endpoint for Wireshark analysis
+* **Status**: ✅ Resolved 2026-08-28
+* **Labels**: `feature-request`, `diagnostics`
+* **Severity**: Low
+
+#### Resolution
+The underlying ask — a live ring-buffer of SIP packets downloadable in real libpcap format for Wireshark — was already fully built out by `607bd91` (`GET /api/pcap`) and hardened by Issue #105 (exact wire bytes, not a re-serialization): `PcapCapture::toPcapFile()` already emits a standard 24-byte global header (magic `0xa1b2c3d4`, `LINKTYPE_ETHERNET`) followed by one 16-byte per-packet record header + a synthesized Ethernet+IPv4+UDP frame per captured entry, straight off the same bounded ring `/api/trace`'s JSON view reads. What this issue's own text asked for was specifically the path `/api/diagnostics/pcap`, which didn't exist — the tracker had drifted out of sync with what actually shipped under `/api/pcap`.
+
+Closed by adding `GET /api/diagnostics/pcap` in `HttpServer.cpp` as a second route to the exact same `sendApiPcap()` handler `/api/pcap` already uses — same `PcapCapture` ring, same session gate, same `application/vnd.tcpdump.pcap` response — rather than an HTTP redirect, so a plain `curl -o dump.pcap http://<device>/api/diagnostics/pcap` works without `-L` and opens directly in Wireshark. No second capture mechanism and no new allocation path: both routes read the one ring `RequestsHandler` already maintains. `docs/API.md`'s endpoint catalog and the `/api/pcap` section now note the alias.
+
+Covered by a new test in `tests/PcapCapture_test.cpp`, `ApiDiagnosticsPcapServesValidGlobalHeaderAndOneRecordOverRealSocket`: drives a real `HttpServer`+`RequestsHandler` pair over an actual TCP socket (mirroring `HttpTraceCommand_test.cpp`'s pattern), sends a REGISTER through the handler, then fetches `GET /api/diagnostics/pcap` and asserts on the wire bytes — the global header's magic number and `LINKTYPE_ETHERNET`, and the first record header's `incl_len`/`orig_len` agreement and that its declared frame length actually fits the response body and contains the captured SIP text verbatim. Full host suite passing. Full detail: https://github.com/GlomarGadaffi/pocket-dial/issues/33
+
+---
 
 ### 🟢 Issue #35 / #113: Zero-Touch Phone Auto-Provisioning (HTTP) — scope clarified to onboarding/admin-window reachability
 * **Status**: ✅ Resolved 2026-08-28 (documentation clarification; no code change — the behavior was already correct)

--- a/docs/API.md
+++ b/docs/API.md
@@ -110,6 +110,7 @@ When booting into onboarding mode, the device intercepts client browser check do
 | [`/api/kill`](#post-apikill) | `POST` | High | Same-Origin (+session once provisioned) | Forcefully disconnects and de-registers an active SIP extension. |
 | [`/api/cdr`](#get-apicdr) | `GET` | Low | None | Returns the in-memory Call Detail Record ring (most recent calls, newest first). |
 | [`/api/pcap`](#get-apipcap) | `GET` | Medium | Session once provisioned | Downloads the last `POCKETDIAL_PCAP_RING_SIZE` SIP signaling packets as a `.pcap` (Wireshark-readable). |
+| [`/api/diagnostics/pcap`](#get-apipcap) | `GET` | Medium | Session once provisioned | Alias for `/api/pcap` (Issue #33's originally-requested path) — identical response, same ring, same gate. |
 | [`/api/trace`](#get-apitrace) | `GET` | Medium | Session once provisioned | The same capture ring as JSON, for the dashboard's polling live SIP tracer. |
 | [`/config/<mac>.cfg`](#get-configmaccfg) | `GET` | Low | None (MAC is the bearer token) | Yealink auto-provisioning config for an already-adopted device. |
 | [`/api/dnd`](#post-apidnd) | `POST` | High | Same-Origin (+session once provisioned) | Sets or clears Do-Not-Disturb on an extension. |
@@ -376,6 +377,8 @@ Only packets that pass structural validation and the per-source-IP rate limiter 
 * **Response Status Codes**:
   * `200 OK`: Always — an empty/never-populated ring still returns a valid (headers-only) `.pcap`.
   * `401 Unauthorized`: Device is provisioned and the request carries no valid session.
+
+`GET /api/diagnostics/pcap` is a second route to this exact same handler — the path Issue #33's original feature request asked for — kept as a route rather than a redirect so `curl -o dump.pcap http://<device>/api/diagnostics/pcap` works without `-L`. Identical response, ring, and gate; use whichever path you like.
 
 ---
 

--- a/src/Helpers/HttpServer.cpp
+++ b/src/Helpers/HttpServer.cpp
@@ -495,6 +495,24 @@ void HttpServer::handleClient(int clientSock)
 			sendApiTrace(clientSock);
 		}
 	}
+	else if (req.method == "GET" && req.path == "/api/diagnostics/pcap")
+	{
+		// Issue #33: the path the original feature request actually asked for.
+		// Deliberately a second route to the SAME handler as /api/pcap rather
+		// than an HTTP redirect — a plain `curl -o dump.pcap .../pcap` should
+		// work without `-L`, and there is no second capture mechanism here:
+		// sendApiPcap() reads the same PcapCapture ring either way. Same
+		// sensitivity/gate as /api/pcap for the same reason.
+		if (AdminAuth::isProvisioned() && !isAuthed(req))
+		{
+			sendResponse(clientSock, 401, "Unauthorized", "application/json",
+			             "{\"error\":\"authentication required\"}");
+		}
+		else
+		{
+			sendApiPcap(clientSock);
+		}
+	}
 	else if (req.method == "POST" && req.path == "/api/dnd")
 	{
 		// Mutating: same gate as /api/kill (same-origin + auth once provisioned).

--- a/tests/PcapCapture_test.cpp
+++ b/tests/PcapCapture_test.cpp
@@ -7,6 +7,7 @@
 #include "PcapCapture.hpp"
 #include "RequestsHandler.hpp"
 #include "HttpServer.hpp"
+#include "AdminAuth.hpp"
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <WinSock2.h>
@@ -18,6 +19,9 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #endif
+
+#include <chrono>
+#include <thread>
 
 namespace
 {
@@ -38,6 +42,28 @@ namespace
 		       (static_cast<uint32_t>(static_cast<unsigned char>(buf[off + 1])) << 8) |
 		       (static_cast<uint32_t>(static_cast<unsigned char>(buf[off + 2])) << 16) |
 		       (static_cast<uint32_t>(static_cast<unsigned char>(buf[off + 3])) << 24);
+	}
+
+	bool canConnect(int port)
+	{
+#if defined(_WIN32) || defined(_WIN64)
+		SOCKET s = socket(AF_INET, SOCK_STREAM, 0);
+		if (s == INVALID_SOCKET) return false;
+#else
+		int s = socket(AF_INET, SOCK_STREAM, 0);
+		if (s < 0) return false;
+#endif
+		sockaddr_in a{};
+		a.sin_family = AF_INET;
+		a.sin_port = htons(static_cast<uint16_t>(port));
+		inet_pton(AF_INET, "127.0.0.1", &a.sin_addr);
+		int rc = connect(s, reinterpret_cast<sockaddr*>(&a), sizeof(a));
+#if defined(_WIN32) || defined(_WIN64)
+		closesocket(s);
+#else
+		close(s);
+#endif
+		return rc == 0;
 	}
 
 	// Minimal blocking HTTP GET over a raw socket — mirrors the pattern
@@ -494,4 +520,81 @@ TEST(PcapCapture, ApiTraceEscapesRawControlBytesFromWireCapture)
 		<< "raw control byte must not appear unescaped in the JSON body: " << body;
 	EXPECT_NE(body.find("\\u0001"), std::string::npos)
 		<< "control byte must be escaped as \\u0001: " << body;
+}
+
+// ── GET /api/diagnostics/pcap (Issue #33) ───────────────────────────────────
+//
+// The canonical path the original feature request asked for. It routes to the
+// exact same sendApiPcap() handler as /api/pcap (see HttpServer.cpp) — no
+// second capture mechanism, no second allocation path — so this test drives it
+// over a real socket the way a `curl -o dump.pcap` client would, and checks
+// the actual bytes on the wire: the 24-byte global header's magic number, and
+// one full 16-byte record header + synthesized frame for a captured packet.
+TEST(PcapCapture, ApiDiagnosticsPcapServesValidGlobalHeaderAndOneRecordOverRealSocket)
+{
+	// Ungated path: no PIN provisioned, so /api/diagnostics/pcap serves without
+	// a session (same setup as HttpTraceCommand_test.cpp's equivalent test) —
+	// keeps this test's outcome independent of whatever AdminAuth state an
+	// earlier test in the same binary left behind.
+	AdminAuth::clearCredential();
+
+	RequestsHandler handler("192.168.4.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	HttpServer server("127.0.0.1", 18096, nullptr);
+	server.attachHandler(&handler);
+	server.start();
+
+	for (int i = 0; i < 50 && !canConnect(18096); ++i)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+	ASSERT_TRUE(canConnect(18096));
+
+	const sockaddr_in src = addr("192.168.4.80", 5060);
+	const std::string raw =
+		"REGISTER sip:server SIP/2.0\r\n"
+		"Via: SIP/2.0/UDP 192.168.4.80:5060;branch=z9hG4bKdiag\r\n"
+		"From: <sip:108@server>;tag=rt108\r\n"
+		"To: <sip:108@server>\r\n"
+		"Call-ID: diagnostics-pcap-test\r\n"
+		"CSeq: 1 REGISTER\r\n"
+		"Contact: <sip:108@192.168.4.80:5060>;expires=3600\r\n"
+		"Content-Length: 0\r\n\r\n";
+	handler.handle(RequestsHandler::getMessageFromPool(raw, src));
+
+	const std::string resp = httpGetRaw(18096, "/api/diagnostics/pcap");
+	ASSERT_NE(resp.find("200"), std::string::npos) << resp;
+	ASSERT_NE(resp.find("application/vnd.tcpdump.pcap"), std::string::npos) << resp;
+	ASSERT_NE(resp.find("Content-Disposition: attachment"), std::string::npos) << resp;
+
+	const size_t bodyStart = resp.find("\r\n\r\n");
+	ASSERT_NE(bodyStart, std::string::npos);
+	const std::string body = resp.substr(bodyStart + 4);
+
+	// Global header: at least the 24 bytes must be present, magic number
+	// 0xa1b2c3d4 written little-endian, LINKTYPE_ETHERNET = 1.
+	ASSERT_GE(body.size(), 24u + 16u) << "expected a global header plus at least one record";
+	EXPECT_EQ(static_cast<unsigned char>(body[0]), 0xd4);
+	EXPECT_EQ(static_cast<unsigned char>(body[1]), 0xc3);
+	EXPECT_EQ(static_cast<unsigned char>(body[2]), 0xb2);
+	EXPECT_EQ(static_cast<unsigned char>(body[3]), 0xa1);
+	EXPECT_EQ(leU32At(body, 20), 1u) << "LINKTYPE_ETHERNET";
+
+	// First per-packet record header (16 bytes right after the global header):
+	// ts_sec, ts_usec, incl_len, orig_len. incl_len must equal orig_len (this
+	// capture never truncates), and the frame it describes — Ethernet(14) +
+	// IPv4(20) + UDP(8) + payload — must actually fit in what follows, and
+	// must contain the captured REGISTER's raw bytes verbatim.
+	const uint32_t inclLen = leU32At(body, 24 + 8);
+	const uint32_t origLen = leU32At(body, 24 + 12);
+	EXPECT_EQ(inclLen, origLen);
+	EXPECT_GE(inclLen, 14u + 20u + 8u) << "frame must be at least Eth+IPv4+UDP headers";
+	// A REGISTER always draws some response (200/401/403/etc, captured
+	// outbound too), so at least a second record follows this one — assert
+	// the first record's declared length actually fits inside the body rather
+	// than assuming exactly one record.
+	ASSERT_GE(body.size(), 24u + 16u + inclLen)
+		<< "first record's frame must fit within the response body";
+	EXPECT_NE(body.find("REGISTER sip:server"), std::string::npos)
+		<< "captured SIP bytes must appear verbatim in the record's frame";
 }


### PR DESCRIPTION
## Summary
- Adds `GET /api/diagnostics/pcap`, the path Issue #33's original feature request asked for.
- It's a second route to the exact same `sendApiPcap()` handler that `GET /api/pcap` already uses (shipped in `607bd91`, hardened for wire-byte fidelity by #105) — same bounded `PcapCapture` ring, same session gate, same `application/vnd.tcpdump.pcap` response with a real 24-byte libpcap global header + one 16-byte record header per captured packet. No second capture mechanism and no new allocation path were introduced.
- Deliberately a route rather than a redirect, so `curl -o dump.pcap http://<device>/api/diagnostics/pcap` works without `-L` and the result opens directly in Wireshark.
- `docs/API.md` and `ISSUES.md` updated; `CHANGELOG.md` entry added.

Closes #33.

## Test plan
- [x] `cmake --build build --config Release` — clean MSVC build
- [x] `ctest --test-dir build/tests -C Release` — 1/1 suite passing
- [x] New test `PcapCapture.ApiDiagnosticsPcapServesValidGlobalHeaderAndOneRecordOverRealSocket` drives a real `HttpServer` + `RequestsHandler` over an actual TCP socket, captures a REGISTER, fetches `GET /api/diagnostics/pcap`, and validates the pcap global header magic number/linktype plus the first record header's `incl_len`/`orig_len` and verbatim SIP payload.
- [x] Existing `PcapCapture_test.cpp` / `HttpTraceCommand_test.cpp` suites still pass unmodified (16/16 in `PcapCapture.*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3ufrZzhv4XLWC6DHQ243