### PR TITLE
fix(sip): relay broadcast hold/resume 200 OK to the peer leg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,34 @@
   bytes on the wire — global header magic/linktype, and the first record's
   `incl_len`/`orig_len` agreement, frame-fits-in-body, and verbatim SIP payload.
 
+## Unreleased (issue-74-broadcast-hold) - 2026-08-28
+
+### Fixed — Hold/resume on broadcast (ring-group) calls silently discarded (#74)
+
+- `RequestsHandler::onOk`'s mid-dialog re-INVITE relay (the block that forwards
+  a hold/resume `200 OK` to the opposite leg once a session is `Connected` or
+  `Held`) explicitly excluded broadcast/ring-group sessions with
+  `!isBroadcast()`. Since the broadcast-specific block below it only runs the
+  first-answer connect path when `state == Invited`, a hold/resume `200 OK`
+  arriving in `Connected`/`Held` state matched neither branch and was silently
+  dropped — the offer reached the held leg fine (`onReinvite` never checked
+  `isBroadcast()`), but the answer never made it back, so the re-INVITE
+  transaction timed out client-side and the phone reported hold as failed.
+
+  Fixed by dropping the `!isBroadcast()` restriction: once a broadcast session
+  is `Connected`, `getSrc()`/`getDest()` name exactly the two live legs (the
+  original caller and the one target that answered) the same way a unicast
+  session's do, so the same source-address peer lookup now relays a
+  hold/resume `200 OK` for either. The `#69b` non-destructive guard
+  (`state == Invited` gating the connect/cancel path) is unaffected — it and
+  the relay block above it are disjoint on session state.
+
+  New coverage in `tests/BroadcastHoldResume_test.cpp` drives a full 999
+  broadcast call end-to-end through connect → hold → resume and asserts the
+  relay actually reaches the held leg's peer (not just that nothing crashes),
+  while also pinning `#69b`: exactly one `CANCEL` is ever sent to the losing
+  fork target across the whole hold/resume sequence.
+
 ## Unreleased (issue-106-104-108-112-misc-bugs) - 2026-08-19
 
 Four small, independently-filed correctness bugs plus one CI hygiene fix,

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,28 +6,6 @@ This document serves as the active issue tracker and architectural roadmap for *
 
 ## Active Issues & Backlog Roadmap
 
-### 🟡 Issue #74: Hold/resume on broadcast (ring-group) calls is not yet supported
-* **Status**: ⏳ Open / Planned
-* **Labels**: `bug`, `hold-resume`, `broadcast`
-* **Severity**: Medium
-
-#### Description
-When a phone in a ring-group (or 999 broadcast) call sends a re-INVITE to hold, the
-200 OK answer from the peer is silently discarded. The hold relay block in `onOk` is
-correctly guarded by `!isBroadcast()` to avoid looping, but there is no equivalent
-broadcast-aware relay path. As a result the phone's hold request is never forwarded, the
-re-INVITE transaction times out after 32 s (Timer D), and the phone treats hold as
-failed. Unicast hold/resume is unaffected.
-
-**Root cause (found by code review):** `onOk`'s broadcast first-answer block was guarded
-by `state != Connected`, which is also true for `Held` — so a re-INVITE 200 OK re-ran
-the connect path, overwrote the established dest, and sent CANCEL to already-gone targets.
-Fixed in this release: the guard now requires `state == Invited` so only a genuine first
-answer triggers the connect path. The 200 OK is now discarded (better than the previous
-destructive behaviour). A full relay path for broadcast hold/resume is tracked here.
-
----
-
 ### 🟡 Issue #44: End-to-end SIP call test needed on JC3248W535EN hardware
 * **Status**: ⏳ Open / Planned
 * **Labels**: `hardware-testing`, `verification`
@@ -136,6 +114,42 @@ The underlying ask — a live ring-buffer of SIP packets downloadable in real li
 Closed by adding `GET /api/diagnostics/pcap` in `HttpServer.cpp` as a second route to the exact same `sendApiPcap()` handler `/api/pcap` already uses — same `PcapCapture` ring, same session gate, same `application/vnd.tcpdump.pcap` response — rather than an HTTP redirect, so a plain `curl -o dump.pcap http://<device>/api/diagnostics/pcap` works without `-L` and opens directly in Wireshark. No second capture mechanism and no new allocation path: both routes read the one ring `RequestsHandler` already maintains. `docs/API.md`'s endpoint catalog and the `/api/pcap` section now note the alias.
 
 Covered by a new test in `tests/PcapCapture_test.cpp`, `ApiDiagnosticsPcapServesValidGlobalHeaderAndOneRecordOverRealSocket`: drives a real `HttpServer`+`RequestsHandler` pair over an actual TCP socket (mirroring `HttpTraceCommand_test.cpp`'s pattern), sends a REGISTER through the handler, then fetches `GET /api/diagnostics/pcap` and asserts on the wire bytes — the global header's magic number and `LINKTYPE_ETHERNET`, and the first record header's `incl_len`/`orig_len` agreement and that its declared frame length actually fits the response body and contains the captured SIP text verbatim. Full host suite passing. Full detail: https://github.com/GlomarGadaffi/pocket-dial/issues/33
+
+---
+
+### 🟢 Issue #74: Hold/resume on broadcast (ring-group) calls is not yet supported
+* **Status**: ✅ Resolved 2026-08-28
+* **Labels**: `bug`, `hold-resume`, `broadcast`
+
+#### Resolution
+When a phone in a ring-group (or 999 broadcast) call sent a re-INVITE to hold, the
+200 OK answer from the peer was silently discarded. `onOk`'s mid-dialog re-INVITE relay
+block (the one that forwards a hold/resume `200 OK` to the opposite leg once a session is
+`Connected` or `Held`) explicitly excluded broadcast sessions with `!isBroadcast()`, and
+the broadcast-specific block below it only runs the first-answer connect path when
+`state == Invited` — so a Held/Connected 200 OK matched neither branch and fell through
+to nothing. The offer itself was never the problem: `onReinvite()` relays a broadcast
+session's re-INVITE fine, since it identifies the peer leg by source address off
+`getSrc()`/`getDest()` with no `isBroadcast()` check at all. Only the answer's return trip
+was blocked, so the re-INVITE transaction timed out client-side (Timer D, ~32s) and the
+phone reported hold as failed even though the hold had actually taken effect on the wire.
+
+Fixed by dropping the `!isBroadcast()` restriction from the relay block. Once a broadcast
+session reaches `Connected` (the first-answer connect path has already run and set
+`dest` to the one target that answered, cancelling the rest), `getSrc()`/`getDest()` name
+exactly the two live legs the same way a unicast session's do — so the identical
+source-address peer lookup that already relays unicast hold/resume now relays broadcast
+hold/resume too, with no new helper or broadcast-specific logic needed. The two blocks are
+disjoint on session state (`Connected`/`Held` relay above; `Invited`-only connect below),
+so the earlier `#69b` fix (the connect/cancel path must never re-fire once a call is up)
+is untouched.
+
+New coverage in `tests/BroadcastHoldResume_test.cpp` drives a full 999 broadcast call
+through `handle()` end-to-end — register three extensions, connect (one target answers,
+the other is CANCELed), hold, then resume — and asserts the 200 OK for each actually
+reaches the held leg's peer, with the session state and `dest` tracked correctly
+throughout. It also pins `#69b`: exactly one `CANCEL` is ever sent to the losing fork
+target across the whole sequence, and the loser never receives any hold/resume traffic.
 
 ---
 

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1510,10 +1510,14 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 		{
 			// Re-INVITE answer (hold/resume): relay 200 OK to the opposite leg and
 			// preserve the session state set by onReinvite() — do NOT re-run connect.
+			// Applies equally to a broadcast/ring-group session once it is
+			// Connected or Held (#74): after the first-answer connect path runs,
+			// getSrc()/getDest() name exactly the two live legs (original caller,
+			// answering client) the same way a unicast session's do, so the same
+			// source-address peer lookup relays a hold/resume 200 OK for either.
 			{
 				const auto st = session.value()->getState();
-				if ((st == Session::State::Connected || st == Session::State::Held) &&
-					!session.value()->isBroadcast())
+				if (st == Session::State::Connected || st == Session::State::Held)
 				{
 					auto legSrc  = session.value()->getSrc();
 					auto legDest = session.value()->getDest();
@@ -1542,11 +1546,10 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 			if (session.value()->isBroadcast())
 			{
 				// Only the first answer from a pending fork (Invited state) should run
-				// the connect path. A re-INVITE 200 OK from an already-connected or held
-				// broadcast call (Held / Connected state) falls through to a silent drop
-				// below — the peer relay above was already skipped by !isBroadcast(), so
-				// the hold/resume path for broadcast calls is currently unsupported and
-				// the 200 OK is discarded (the hold stays in place). (#69)
+				// the connect path below. A hold/resume re-INVITE's 200 OK arrives while
+				// the session is Connected or Held, which the block above already relays
+				// and returns from (#74) — so only a genuine new answer from a pending
+				// fork ever reaches this point (#69b).
 				if (session.value()->getState() == Session::State::Invited)
 				{
 					auto clientOpt = findClientByAddress(data->getSource());

--- a/tests/BroadcastHoldResume_test.cpp
+++ b/tests/BroadcastHoldResume_test.cpp
@@ -1,0 +1,343 @@
+// BroadcastHoldResume_test.cpp — Issue #74 regression coverage.
+//
+// A phone in a broadcast/ring-group (999-style) call that sends a re-INVITE to
+// hold gets its offer relayed fine (onReinvite() never checked isBroadcast()),
+// but the peer's 200 OK answering that re-INVITE used to be silently dropped:
+// onOk()'s generic Connected/Held relay block explicitly excluded broadcast
+// sessions (`!isBroadcast()`), and the broadcast-specific block below it only
+// handles a first answer (state == Invited) — so a Held/Connected 200 OK fell
+// through to nothing. The re-INVITE transaction then timed out client-side and
+// the phone reported hold as failed even though the offer got through.
+//
+// This drives a real RequestsHandler through handle() end-to-end (mirroring
+// Invite777SessionPool_test.cpp's pattern): register three extensions, place a
+// 999 broadcast call, let one target answer (the other gets CANCELed — the
+// ordinary, correct broadcast-connect behavior), then hold and resume the
+// established call and assert the 200 OK for each actually reaches the FAR
+// leg (not just that the offer/relay of the re-INVITE itself works, and not
+// just that nothing crashes). It also pins the #69b fix: the connect/cancel
+// path must never re-fire once the call is up, so exactly one CANCEL is ever
+// sent across the whole hold/resume sequence.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "PoolConfig.hpp"
+#include "RequestsHandler.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <WinSock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	sockaddr_in addrFor(const std::string& ip, uint16_t port = 5060)
+	{
+		sockaddr_in a{};
+		a.sin_family = AF_INET;
+		a.sin_addr.s_addr = inet_addr(ip.c_str());
+		a.sin_port = htons(port);
+		return a;
+	}
+
+	std::shared_ptr<SipMessage> makeRegister(const std::string& ext, const std::string& ip,
+	                                          const std::string& callId)
+	{
+		std::string raw =
+			"REGISTER sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + ip + ":5060;branch=z9hG4bKr" + callId + "\r\n"
+			"From: <sip:" + ext + "@server>;tag=rt" + callId + "\r\n"
+			"To: <sip:" + ext + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 REGISTER\r\n"
+			"Contact: <sip:" + ext + "@" + ip + ":5060>;expires=3600\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, addrFor(ip));
+	}
+
+	std::string sdpBody(const char* direction)
+	{
+		std::string body =
+			"v=0\r\n"
+			"o=- 0 0 IN IP4 10.0.0.1\r\n"
+			"s=-\r\n"
+			"c=IN IP4 10.0.0.1\r\n"
+			"t=0 0\r\n"
+			"m=audio 10000 RTP/AVP 0\r\n"
+			"a=rtpmap:0 PCMU/8000\r\n";
+		if (direction && *direction)
+		{
+			body += std::string("a=") + direction + "\r\n";
+		}
+		return body;
+	}
+
+	std::shared_ptr<SipMessage> makeBroadcastInvite(const std::string& fromExt, const std::string& ip,
+	                                                 const std::string& callId)
+	{
+		std::string body = sdpBody("sendrecv");
+		std::string raw =
+			"INVITE sip:999@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + ip + ":5060;branch=z9hG4bKi" + callId + "\r\n"
+			"From: <sip:" + fromExt + "@server>;tag=ft" + callId + "\r\n"
+			"To: <sip:999@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Contact: <sip:" + fromExt + "@" + ip + ":5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		return RequestsHandler::getMessageFromPool(raw, addrFor(ip));
+	}
+
+	// Finds the most recent message this test recorded whose destination address
+	// matches `addr` and whose serialized text contains `needle` (a request line
+	// or status line fragment). Returns an empty string if none matches.
+	std::string findSentTo(const std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                       const sockaddr_in& addr, const std::string& needle)
+	{
+		for (auto it = sent.rbegin(); it != sent.rend(); ++it)
+		{
+			if (it->first.sin_addr.s_addr != addr.sin_addr.s_addr) continue;
+			if (it->first.sin_port != addr.sin_port) continue;
+			if (!it->second) continue;
+			std::string raw = it->second->toString();
+			if (raw.find(needle) != std::string::npos) return raw;
+		}
+		return {};
+	}
+
+	size_t countContaining(const std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                       const std::string& needle)
+	{
+		size_t n = 0;
+		for (const auto& [addr, msg] : sent)
+		{
+			if (!msg) continue;
+			if (msg->toString().find(needle) != std::string::npos) ++n;
+		}
+		return n;
+	}
+
+	// Extracts a single header's full raw line (e.g. "To: <sip:999@server>;tag=x")
+	// out of a serialized SIP message, so a hand-built follow-on request can reuse
+	// dialog-identifying headers verbatim, the way a real UA would.
+	std::string extractHeaderLine(const std::string& raw, const std::string& name)
+	{
+		size_t pos = 0;
+		while (pos < raw.size())
+		{
+			size_t eol = raw.find("\r\n", pos);
+			if (eol == std::string::npos) eol = raw.size();
+			std::string line = raw.substr(pos, eol - pos);
+			if (line.size() > name.size() &&
+				line.compare(0, name.size(), name) == 0)
+			{
+				return line;
+			}
+			pos = eol + 2;
+		}
+		return {};
+	}
+}
+
+TEST(BroadcastHoldResume, HoldThenResumeRelaysTheAnsweringPartysOkToTheHeldLeg)
+{
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+	RequestsHandler handler("192.168.20.1", 5060,
+		[&sent](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			sent.emplace_back(addr, std::move(msg));
+		});
+
+	const sockaddr_in callerAddr = addrFor("192.168.20.10");
+	const sockaddr_in answererAddr = addrFor("192.168.20.20");
+	const sockaddr_in losingAddr = addrFor("192.168.20.30");
+
+	handler.handle(makeRegister("100", "192.168.20.10", "reg-100"));
+	handler.handle(makeRegister("106", "192.168.20.20", "reg-106"));
+	handler.handle(makeRegister("107", "192.168.20.30", "reg-107"));
+
+	// ── Place the 999 broadcast call: forks to both 106 and 107 ────────────────
+	const std::string callId = "bcast-74";
+	handler.handle(makeBroadcastInvite("100", "192.168.20.10", callId));
+
+	std::string forkTo106 = findSentTo(sent, answererAddr, "INVITE sip:106@");
+	ASSERT_FALSE(forkTo106.empty()) << "999 broadcast must fork an INVITE to 106";
+	std::string forkTo107 = findSentTo(sent, losingAddr, "INVITE sip:107@");
+	ASSERT_FALSE(forkTo107.empty()) << "999 broadcast must fork an INVITE to 107";
+
+	// ── 106 answers first: this is the ONLY leg allowed to run the connect path
+	// (state == Invited). 107 must be CANCELed exactly once as a side effect. ──
+	{
+		std::string fromLine = extractHeaderLine(forkTo106, "From:");
+		std::string via106   = extractHeaderLine(forkTo106, "Via:");
+		ASSERT_FALSE(fromLine.empty());
+		std::string body = sdpBody("sendrecv");
+		std::string raw =
+			"SIP/2.0 200 OK\r\n" +
+			via106 + "\r\n" +
+			fromLine + "\r\n"
+			"To: <sip:106@server>;tag=ans106\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Contact: <sip:106@192.168.20.20:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, answererAddr));
+	}
+
+	ASSERT_EQ(countContaining(sent, "CANCEL sip:107@"), 1u)
+		<< "the losing fork target (107) must be CANCELed exactly once on connect";
+	ASSERT_EQ(countContaining(sent, "CANCEL sip:106@"), 0u)
+		<< "the answering target must never be CANCELed";
+
+	auto sessionOpt = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(sessionOpt.has_value());
+	ASSERT_EQ(sessionOpt.value()->getState(), Session::State::Connected);
+	ASSERT_TRUE(sessionOpt.value()->getDest());
+	EXPECT_EQ(sessionOpt.value()->getDest()->getNumber(), "106");
+
+	// Capture the 200 OK the CALLER received for the 999 INVITE — its To header
+	// (original-To + the answerer's tag) is exactly what a real phone echoes
+	// back, with the tag, on every subsequent re-INVITE in this dialog.
+	std::string callerOk = findSentTo(sent, callerAddr, "SIP/2.0 200 OK");
+	ASSERT_FALSE(callerOk.empty()) << "the caller must receive the 999 call's 200 OK";
+	std::string dialogTo = extractHeaderLine(callerOk, "To:");
+	ASSERT_NE(dialogTo.find("tag="), std::string::npos)
+		<< "the caller's dialog To-header must carry the answerer's tag";
+
+	// ── Caller places the established call on HOLD (re-INVITE, a=sendonly) ────
+	{
+		std::string body = sdpBody("sendonly");
+		std::string raw =
+			"INVITE sip:999@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.20.10:5060;branch=z9hG4bKhold1\r\n"
+			"From: <sip:100@server>;tag=ft" + callId + "\r\n" +
+			dialogTo + "\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 2 INVITE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Contact: <sip:100@192.168.20.10:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, callerAddr));
+	}
+
+	std::string holdOfferAt106 = findSentTo(sent, answererAddr, "a=sendonly");
+	ASSERT_FALSE(holdOfferAt106.empty())
+		<< "the hold offer must be relayed untouched to the held leg (106)";
+
+	sessionOpt = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(sessionOpt.has_value());
+	EXPECT_EQ(sessionOpt.value()->getState(), Session::State::Held);
+	ASSERT_TRUE(sessionOpt.value()->getDest());
+	EXPECT_EQ(sessionOpt.value()->getDest()->getNumber(), "106")
+		<< "hold must not re-run the broadcast connect path and reassign dest (#69b)";
+
+	// ── 106 answers the hold re-INVITE with its own 200 OK ─────────────────────
+	// THE REGRESSION: before the fix, onOk's Connected/Held relay explicitly
+	// excluded broadcast sessions, and the broadcast-specific block only handles
+	// state == Invited, so this 200 OK was silently dropped -- the caller's phone
+	// never saw it and Timer D fired 32s later, reporting hold as failed.
+	{
+		std::string body = sdpBody("sendonly");
+		std::string raw =
+			"SIP/2.0 200 OK\r\n"
+			"Via: SIP/2.0/UDP 192.168.20.10:5060;branch=z9hG4bKhold1\r\n"
+			"From: <sip:100@server>;tag=ft" + callId + "\r\n" +
+			dialogTo + "\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 2 INVITE\r\n"
+			"Contact: <sip:106@192.168.20.20:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, answererAddr));
+	}
+
+	// Keyed on "CSeq: 2 INVITE", not the generic "SIP/2.0 200 OK" text: the
+	// connect-time answer earlier in this same run also said 200 OK to the
+	// caller, so a needle that could match it would pass even with the bug
+	// (nothing sent for CSeq 2 ever reaches the caller without the fix).
+	std::string holdOkAtCaller = findSentTo(sent, callerAddr, "CSeq: 2 INVITE");
+	ASSERT_FALSE(holdOkAtCaller.empty())
+		<< "#74: the hold re-INVITE's 200 OK must actually reach the caller, not be dropped";
+	EXPECT_NE(holdOkAtCaller.find("SIP/2.0 200 OK"), std::string::npos)
+		<< "the relayed message must be the hold transaction's 200 OK";
+
+	// Still exactly one CANCEL in the whole run: the hold OK must not re-trigger
+	// the broadcast connect/cancel path against the (already long gone) loser.
+	EXPECT_EQ(countContaining(sent, "CANCEL sip:107@"), 1u)
+		<< "the hold OK must not re-run the connect path and re-CANCEL 107 (#69b)";
+
+	sessionOpt = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(sessionOpt.has_value());
+	EXPECT_EQ(sessionOpt.value()->getState(), Session::State::Held)
+		<< "relaying the hold OK must not itself change hold state";
+
+	// ── Caller RESUMES the call (re-INVITE, a=sendrecv) ────────────────────────
+	{
+		std::string body = sdpBody("sendrecv");
+		std::string raw =
+			"INVITE sip:999@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.20.10:5060;branch=z9hG4bKresume1\r\n"
+			"From: <sip:100@server>;tag=ft" + callId + "\r\n" +
+			dialogTo + "\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 3 INVITE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Contact: <sip:100@192.168.20.10:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, callerAddr));
+	}
+
+	std::string resumeOfferAt106 = findSentTo(sent, answererAddr, "CSeq: 3 INVITE");
+	ASSERT_FALSE(resumeOfferAt106.empty())
+		<< "the resume offer must be relayed to the held leg (106)";
+	EXPECT_NE(resumeOfferAt106.find("a=sendrecv"), std::string::npos);
+
+	sessionOpt = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(sessionOpt.has_value());
+	EXPECT_EQ(sessionOpt.value()->getState(), Session::State::Connected);
+
+	// ── 106 answers the resume re-INVITE: the resume OK must also be relayed ──
+	{
+		std::string body = sdpBody("sendrecv");
+		std::string raw =
+			"SIP/2.0 200 OK\r\n"
+			"Via: SIP/2.0/UDP 192.168.20.10:5060;branch=z9hG4bKresume1\r\n"
+			"From: <sip:100@server>;tag=ft" + callId + "\r\n" +
+			dialogTo + "\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 3 INVITE\r\n"
+			"Contact: <sip:106@192.168.20.20:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, answererAddr));
+	}
+
+	std::string resumeOkAtCaller = findSentTo(sent, callerAddr, "CSeq: 3 INVITE");
+	ASSERT_FALSE(resumeOkAtCaller.empty())
+		<< "the resume re-INVITE's 200 OK must reach the caller too";
+	EXPECT_NE(resumeOkAtCaller.find("SIP/2.0 200 OK"), std::string::npos);
+
+	sessionOpt = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(sessionOpt.has_value());
+	EXPECT_EQ(sessionOpt.value()->getState(), Session::State::Connected)
+		<< "resume must restore the Connected state";
+	ASSERT_TRUE(sessionOpt.value()->getDest());
+	EXPECT_EQ(sessionOpt.value()->getDest()->getNumber(), "106")
+		<< "dest must remain the originally-answering leg throughout hold/resume";
+
+	// Across the entire hold->resume sequence: never more than the one CANCEL
+	// issued at connect time, and nothing sent to the long-gone loser (107).
+	EXPECT_EQ(countContaining(sent, "CANCEL sip:107@"), 1u);
+	EXPECT_TRUE(findSentTo(sent, losingAddr, "CSeq: 2 INVITE").empty())
+		<< "the loser (107) must never receive any hold traffic";
+	EXPECT_TRUE(findSentTo(sent, losingAddr, "CSeq: 3 INVITE").empty())
+		<< "the loser (107) must never receive any resume traffic";
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,11 @@ add_executable(sip_parser_tests
     ArpLookup_test.cpp
     Pbx_test.cpp
     PageZone_test.cpp
+    # Issue #74: broadcast/ring-group hold-resume relay. onOk()'s Connected/Held
+    # relay used to explicitly exclude broadcast sessions, so a hold re-INVITE's
+    # 200 OK was silently dropped instead of reaching the held leg. Drives a full
+    # 999 broadcast call through connect -> hold -> resume via handle().
+    BroadcastHoldResume_test.cpp
     Rtp_test.cpp
     RtpReceiver_test.cpp
     PlayoutBuffer_test.cpp


### PR DESCRIPTION
## Summary
- `onOk`'s Connected/Held re-INVITE relay explicitly excluded broadcast/ring-group sessions (`!isBroadcast()`), so a hold/resume `200 OK` on a 999 or ring-group call was silently discarded instead of reaching the held leg -- `onReinvite()` already relayed the hold *offer* fine (no `isBroadcast()` check there), only the answer's return trip was blocked.
- Fixed by dropping the `!isBroadcast()` restriction. Once a broadcast session reaches `Connected` (the first-answer connect path has run and pinned `dest` to the one target that answered), `getSrc()`/`getDest()` name exactly the two live legs the same way a unicast session's do -- so the identical source-address peer lookup that already relays unicast hold/resume now covers broadcast too, with no new broadcast-specific logic or helper needed.
- The `#69b` fix (connect/cancel path must only fire on `state == Invited`, not `Held`) is untouched: the Connected/Held relay block and the Invited-only connect block are disjoint on session state, so removing the exclusion can't reawaken that regression.
- Added `tests/BroadcastHoldResume_test.cpp`: drives a full 999 broadcast call through `handle()` end-to-end (register 3 extensions -> connect, with one target answered and the other CANCELed -> hold -> resume) and asserts the `200 OK` for both hold and resume actually reaches the held leg's peer address (not just that nothing crashes). It also pins `#69b`: exactly one `CANCEL` is ever sent to the losing fork target across the whole hold/resume sequence, and that target never receives any hold/resume traffic.
- ISSUES.md: moved #74 from Active to Resolved with a resolution writeup; CHANGELOG.md: added an entry.

Resolves ISSUES.md tracker issue #74 ("Hold/resume on broadcast (ring-group) calls"). Note: GitHub issue #74 on this repo is an unrelated, already-closed item ("ESP-IDF firmware bootloops in FreeRTOS scheduler before app_main") -- the ISSUES.md tracker and the GitHub issue numbering diverged some time ago, so the GitHub `Closes` keyword is deliberately not used here to avoid cross-linking/re-closing that unrelated issue.

## Test plan
- [x] `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release` (host build, `IDF_PATH` unset)
- [x] `cmake --build build --config Release`
- [x] `ctest --test-dir build/tests -C Release --output-on-failure` -> 202/202 host tests passing, including the new `BroadcastHoldResume` test
- [x] Verified the new test discriminates the bug by analysis: the assertions are keyed to messages carrying `CSeq: 2 INVITE` / `CSeq: 3 INVITE` at the caller's address, which cannot exist without the relay fix (a direct revert-and-rerun was attempted to confirm empirically, but Windows Smart App Control blocked the reverted rebuilt binary from executing at all -- a known environment limitation, not a test issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3ufrZzhv4XLWC6DHQ243
