### PR TITLE
feat: bounded pattern -> action dial plan generalizing ring groups (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,64 @@
   while also pinning `#69b`: exactly one `CANCEL` is ever sent to the losing
   fork target across the whole hold/resume sequence.
 
+## Unreleased (issue-69-dial-plan) - 2026-08-28
+
+### Added — Dial-plan / hunt-group generalization (#69)
+
+- **`src/SIP/DialPlan.hpp`** (new, pure/header-only, same shape as `PbxConfig.hpp`):
+  a bounded, ordered `pattern → action` rule table. Each rule maps a dialed number
+  to one of the three actions already on `main` — ring/hunt **group**, **page**
+  zone (#66), or **park** orbit (#65). (#68's directed pickup is not merged and is
+  deliberately absent; adding it later is one enum value and one dispatch arm.)
+
+- **Pattern grammar** — deliberately tiny, no regex: literal characters, `X`/`x`
+  for exactly one digit, and a *trailing* `*` for a prefix match. A `*` in any
+  other position is a **literal** `*`, because star-codes (`*8`, `*4887`) are real
+  dialable strings here. Rules are evaluated **in table order, first match wins** —
+  order is the operator's, not a specificity heuristic — and editing an existing
+  pattern updates it in place rather than moving it to the end.
+
+- **No behavior change when nothing matches.** The plan is consulted *after* every
+  reserved virtual extension (`777`, `999`, `980`–`989`, `440`, `700`–`70N`) and
+  after the direct ring-group lookup, and *before* CFU/DND/extension lookup, so a
+  rule can only capture a number that would otherwise have reached the ordinary
+  extension lookup. Not even a catch-all `*` can shadow the echo test, a park
+  retrieval, or a configured group. An unmatched number routes exactly as before.
+
+- **Bounded**: `POCKETDIAL_MAX_DIAL_RULES` (default **16**, `src/SIP/PoolConfig.hpp`)
+  caps both the table's memory and the per-INVITE linear walk. Enforced inside
+  `DialPlan::upsert()` so the HTTP setter and the NVS replay both inherit it; a full
+  table stays editable, since an upsert on an existing pattern is not growth.
+
+- **Admin config surface**: `POST /api/dialplan` (`pattern` / `action` / `target`;
+  an empty `target` deletes) behind the same same-origin + `pd_session` gate as
+  `/api/group`, with the table echoed back in `GET /api/status` under `dialplan` in
+  evaluation order. NVS-persisted under key `dplan`, in table order. Documented in
+  `docs/API.md` (endpoint catalog, endpoint section, and status field schema).
+
+- **Refactor, no functional change**: `onInvite()`'s 98x page-zone and ring-group
+  bodies were lifted verbatim into `RequestsHandler::routePageZone()` /
+  `routeRingGroup()` so the built-in dial codes and the dial plan share one
+  implementation. `routeRingGroup()` takes the group extension *explicitly* rather
+  than reading it off the INVITE's To-number — under a dial rule those differ, and
+  `Session::setGroupExt()` feeds the hunt-exhausted CDR and the no-answer Contact.
+
+- **Hardening**: pattern and target are charset-validated (`[0-9A-Za-z#*]`) at
+  config time in both `setDialRule()` and the HTTP handler, because the persisted
+  record is tab/newline delimited and a smuggled separator would corrupt every rule
+  after it on reload. `777`/`999`/`440` are refused as literal patterns (they route
+  before the plan, so such a rule could never fire). A matched rule whose target no
+  longer resolves answers `404` rather than falling through — a stale rule must not
+  silently ring whichever real extension shares the dialed digits.
+
+- **Tests**: `tests/DialPlan_test.cpp` (32 new) — grammar; precedence from both
+  directions (exact-first wins, *and* wildcard-first shadows the exact rule below
+  it, the property a "sort most-specific-first" refactor would quietly delete); the
+  cap through both the pure class and `setDialRule`/`getDialRules`; fallthrough
+  driven through `handle()` against a *populated* table; dispatch into each of the
+  three actions; the stale-target `404`; and a real-socket round-trip of
+  `POST /api/dialplan` through `HttpServer`. Full host suite **233/233**.
+
 ## Unreleased (issue-106-104-108-112-misc-bugs) - 2026-08-19
 
 Four small, independently-filed correctness bugs plus one CI hygiene fix,

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -49,13 +49,6 @@ signaling and tracks state. See **Non-Goals** below for the hard scope boundary.
 * **Description**: Answer a ringing peer's call from your own phone via a pickup code (`*8` group pickup or `**<ext>` directed). Reuses the fork/`Session` machinery and the registrar's view of in-progress INVITEs; the call lands P2P on the picker — no server media.
 * **Acceptance**: while ext A rings, ext B dials the pickup code and connects to the caller with P2P SDP; only same-pickup-group calls eligible; race with A answering resolves cleanly (one wins, other `486`/cancel).
 
-### 🔵 Issue #69: [Feature] Dial-Plan / Hunt-Group Generalization
-* **Status**: ⏳ Open / Planned (Backlog)
-* **Labels**: `feature`, `sip`, `routing`
-* **Description**: Extend the existing `ringall`/`hunt` ring groups (`setRingGroup`/`getRingGroups`) into a small **pattern → action** dial plan for LAN routing (match an extension/prefix → group ring / hunt / page zone / park orbit / pickup). Table-driven, bounded, LAN-only.
-* **Acceptance**: a configurable rule table maps dialed patterns to existing actions, evaluated in order; bounded table size.
-* **Notes**: Promotes `FEATURE_ROADMAP.md` "Dial plan / hunt groups."
-
 ### ⚪ Non-Goals (hard scope boundary)
 pocket-dial's default call path stays **LAN-only, peer-to-peer media** — every feature above is
 signaling-only and needs none of the below. **Out of scope, intentionally not implemented here:**
@@ -150,6 +143,27 @@ the other is CANCELed), hold, then resume — and asserts the 200 OK for each ac
 reaches the held leg's peer, with the session state and `dest` tracked correctly
 throughout. It also pins `#69b`: exactly one `CANCEL` is ever sent to the losing fork
 target across the whole sequence, and the loser never receives any hold/resume traffic.
+
+---
+
+### 🟢 Issue #69: [Feature] Dial-Plan / Hunt-Group Generalization
+* **Status**: ✅ Shipped 2026-08-28 (`src/SIP/DialPlan.hpp` + `setDialRule`/`getDialRules`, `POST /api/dialplan`, cap `POCKETDIAL_MAX_DIAL_RULES` = 16)
+* **Labels**: `feature`, `sip`, `routing`
+
+#### Resolution
+The ring-group mechanism is now the special case of a general, bounded `pattern → action` rule table. `src/SIP/DialPlan.hpp` is a new pure, header-only module in the same shape as `PbxConfig.hpp` — an action enum, a `DialRule` record, a pure matcher, and an ordered `DialPlan` container — so the grammar, the precedence rule and the size cap are all unit-testable without linking the registrar.
+
+The pattern grammar is deliberately tiny (no regex, no backtracking, O(pattern length) per rule): literal characters, `X`/`x` for exactly one digit, and a **trailing** `*` for a prefix match. A `*` in any other position is a literal `*` — star-codes (`*8`, `*4887`) are real dialable strings on this box, so treating a leading star as a wildcard would have made a rule like `*8*` ambiguous with the codes it was meant to sit beside. Rules are walked in table order and the first match wins; order is the operator's and not a specificity heuristic, so a catch-all listed first really does shadow the exact rule below it (pinned by tests from both directions, because that is exactly the property a well-meaning "sort most-specific-first" refactor would quietly delete). Editing an existing pattern updates it in place rather than re-appending, since moving a rule changes which numbers it captures.
+
+Each rule selects one of the three actions already shipped on `main` — ring/hunt group (Class A sweep), paging zone (#66), park orbit (#65). #68's directed pickup is deliberately absent because it is not merged; adding it later is one enum value, one name string and one dispatch arm. To reach those actions without duplicating them, the 98x page-zone and ring-group bodies were lifted out of `onInvite()` verbatim into `routePageZone()` / `routeRingGroup()` and are now called from both the built-in dial codes and the dial plan. `routeRingGroup()` takes the group extension **explicitly** rather than reading it back off the INVITE's To-number: under a dial rule the dialed number and the group extension are no longer the same string, and `Session::setGroupExt()` feeds the hunt-exhausted CDR and the no-answer Contact, both of which want the group's identity, not the alias.
+
+Placement in `onInvite()` is what makes this additive rather than a behavior change. The plan is consulted **after** every reserved virtual extension (`777`, `999`, the `980`–`989` zones, `440`, the `700`–`70N` orbits) and after the direct ring-group lookup, but **before** CFU/DND/extension lookup. A rule can therefore only ever intercept a dialed number that would otherwise have reached the ordinary extension lookup (and, for an unknown number, `404`) — so no rule, not even a catch-all `*`, can shadow the echo test, a park retrieval, or a configured group. A dialed number matching no rule falls straight through with the pre-#69 routing untouched, asserted end-to-end against a *populated* table so the test proves "no rule matched" rather than "the feature is switched off". `777`, `999` and `440` are also refused as literal patterns at config time, so an operator writing a rule that could never fire gets a `400` instead of a dead entry.
+
+The table is hard-capped at **`POCKETDIAL_MAX_DIAL_RULES` = 16** (`src/SIP/PoolConfig.hpp`, documented there with its reasoning: the cap bounds both the table's memory and the per-INVITE linear walk on the SIP packet path). The ceiling is enforced inside `DialPlan::upsert()` itself so every entry point inherits it — the HTTP setter, and the NVS replay, which means a blob written by a build with a larger cap simply stops being applied at this build's ceiling instead of overflowing it. A full table stays *editable*: an upsert on an existing pattern is not a growth operation, so the operator can always fix the rule that filled the table.
+
+Two details worth naming. Pattern and target are charset-validated (`[0-9A-Za-z#*]`) at config time in both `setDialRule()` and the HTTP handler — the persisted record is tab/newline delimited, and a smuggled separator would have corrupted every rule after it on the next boot. And a rule whose target no longer resolves (a group or zone deleted after the rule was written) is answered `404` at dial time rather than falling through: falling through would silently ring whichever real extension happens to share the dialed digits, i.e. connect the caller to the wrong person, whereas a stale rule failing loudly is diagnosable from a single response.
+
+Exposed through the existing admin config surface exactly as ring groups are: `POST /api/dialplan` (`pattern`/`action`/`target`, empty target deletes) behind the same same-origin + `pd_session` gate as `/api/group`, with the table echoed back in `/api/status` under `dialplan` in evaluation order. NVS-persisted under key `dplan` in table order, since order is the semantics. Host-tested in `tests/DialPlan_test.cpp` (32 tests): grammar, precedence in both directions, the cap through both the pure class and `setDialRule`/`getDialRules`, fallthrough, dispatch into each of the three actions, the stale-target `404`, and a real-socket round-trip of `POST /api/dialplan` through `HttpServer`. Full suite 233/233. Docs: `docs/API.md` endpoint catalog + status schema.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,7 +38,7 @@ this document is unreachable. An **unprovisioned** device listens unconditionall
 | `/api/admin/keepalive` | `POST` | Session | Extends the HTTP-open window by 3600 s. |
 
 Once provisioned, all state-mutating endpoints (`/api/kill`, `/api/dnd`,
-`/api/forward`, `/api/group`, `/api/wifi/*`, `/api/factory-reset`, OTA upload)
+`/api/forward`, `/api/group`, `/api/dialplan`, `/api/wifi/*`, `/api/factory-reset`, OTA upload)
 additionally require the `pd_session` cookie.
 
 ---
@@ -116,6 +116,7 @@ When booting into onboarding mode, the device intercepts client browser check do
 | [`/api/dnd`](#post-apidnd) | `POST` | High | Same-Origin (+session once provisioned) | Sets or clears Do-Not-Disturb on an extension. |
 | [`/api/forward`](#post-apiforward) | `POST` | High | Same-Origin (+session once provisioned) | Configures call forwarding (`always`/`busy`/`noanswer`) for an extension. |
 | [`/api/group`](#post-apigroup) | `POST` | High | Same-Origin (+session once provisioned) | Creates, updates, or deletes a ring/hunt group. |
+| [`/api/dialplan`](#post-apidialplan) | `POST` | High | Same-Origin (+session once provisioned) | Creates, updates, or deletes one dial-plan rule (pattern → action). |
 | [`/api/wifi/scan`](#get-apiwifiscan) | `GET` | Low | None | Triggers a scan of nearby Wi-Fi APs and returns their SSIDs and signal strengths. |
 | [`/api/wifi/connect`](#post-apiwificonnect) | `POST` | High | Same-Origin (+session once provisioned) | Saves Wi-Fi credentials to NVS and schedules an ESP32 system reboot into Station Mode. |
 | [`/api/wifi/mode_ap`](#post-apiwifimode_ap) | `POST` | High | Same-Origin (+session once provisioned) | Sets the device to Standalone Access Point Mode and schedules a system reboot. |
@@ -192,6 +193,10 @@ Returns a detailed JSON object representing the active state of the SIP registra
 | `sessions[].callee` | String | Target extension receiving the call. |
 | `sessions[].state` | String | Active session state: `Invited`, `Connected`, `Busy`, `Unavailable`, `Cancel`, `Bye`. |
 | `sessions[].duration` | String | Active call length formatted as `MM:SS` or `HH:MM:SS`. |
+| `dialplan` | Array | The dial-plan rule table (Issue #69), **in evaluation order** — first match wins, so this array's order is load-bearing. |
+| `dialplan[].pattern` | String | The dialed-number pattern (see [`POST /api/dialplan`](#post-apidialplan) for the grammar). |
+| `dialplan[].action` | String | `group`, `page`, or `park`. |
+| `dialplan[].target` | String | The group / paging-zone / park-orbit extension the rule routes to. |
 
 ---
 
@@ -535,6 +540,80 @@ Creates, updates, or deletes a ring/hunt group.
   "extension": "700",
   "mode": "ringall",
   "members": "1001,1002,1003"
+}
+```
+
+---
+
+### `POST /api/dialplan`
+Creates, updates, or deletes one rule in the dial plan (Issue #69) — the bounded,
+ordered `pattern → action` table that generalizes ring groups into LAN routing.
+
+Rules are evaluated **in table order, first match wins**. A pattern already in the
+table is edited **in place**, keeping its evaluation position; a new pattern is
+appended to the end. To reorder, delete a rule and re-add it. The table is hard-capped
+at `POCKETDIAL_MAX_DIAL_RULES` (**16** by default, see `src/SIP/PoolConfig.hpp`);
+once it is full a *new* pattern is rejected server-side (logged, still `200`), while
+existing rules stay editable.
+
+The plan is consulted **after** every reserved virtual extension (`777`, `999`,
+`440`, the `980`–`989` paging zones, the `700`–`70N` park orbits) and after a direct
+ring-group extension lookup, and **before** call-forwarding / DND / ordinary
+extension lookup. So a rule can only capture a number that would otherwise have
+reached the ordinary extension lookup — no rule, not even a catch-all `*`, can
+shadow the echo test, a park retrieval, or a configured group extension. **A dialed
+number that matches no rule routes exactly as it did before the dial plan existed.**
+
+**Pattern grammar** (deliberately tiny — no regex):
+
+| Token | Meaning |
+| :--- | :--- |
+| digits / letters / `#` / `*` | Match themselves, literally. |
+| `X` or `x` | Match exactly one digit (`0`–`9`). |
+| a **trailing** `*` | Match the rest of the dialed number, including nothing at all (prefix match). |
+
+A `*` anywhere but the last character is a **literal** `*`, because star-codes
+(`*8`, `*4887`) are real dialable strings on this device. Examples: `601` (exact),
+`6XX` (any three-digit number starting with 6), `6*` (any number starting with 6),
+`*` (catch-all), `*8` (the literal star-code).
+
+* **Requires Same-Origin Check**: Yes
+* **Requires `pd_session` cookie**: Once the device is provisioned (see §0)
+* **Request Content-Type**: `application/x-www-form-urlencoded`
+* **Request Parameters**:
+  * `pattern` (Required): The rule's dialed-number pattern, and its key in the table. May contain only letters, digits, `#` and `*`. Must not be `777`, `999` or `440` — those are routed before the dial plan, so such a rule could never fire.
+  * `action` (Optional, default `group`): `group` (ring/hunt group), `page` (paging zone), or `park` (park orbit).
+  * `target` (Optional): The extension the action routes to — a ring-group extension for `group`, a `980`–`989` zone for `page`, a `700`–`70N` orbit for `park`. **An empty `target` deletes the rule with that pattern.**
+* **Response Content-Type**: `application/json`
+* **Response Status Codes**:
+  * `200 OK`
+  * `400 Bad Request`: `pattern` missing, `pattern`/`target` contains a character outside `[0-9A-Za-z#*]`, `pattern` is a reserved extension, `action` is not `group`/`page`/`park`, or the `target` is the wrong shape for the action.
+  * `401 Unauthorized` / `403 Forbidden`: as above.
+
+> [!NOTE]
+> A rule whose target no longer resolves — a group or zone deleted after the rule
+> was written — is answered `404 Not Found` at dial time rather than falling
+> through, so a stale rule fails visibly instead of silently ringing whichever real
+> extension happens to share the dialed digits.
+
+#### Request Example (Form URL-Encoded)
+```http
+POST /api/dialplan HTTP/1.1
+Host: 192.168.4.1
+Origin: http://192.168.4.1
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 36
+
+pattern=2XX&action=group&target=610
+```
+
+#### Response Example (200 OK)
+```json
+{
+  "status": "ok",
+  "pattern": "2XX",
+  "action": "group",
+  "target": "610"
 }
 ```
 

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -168,7 +168,8 @@ Iteration D  ── Observability & ops
 
 Iteration E+ ── Bigger bets
   ✓   Call parking · BLF/presence · paging zones ........... shipped (ISSUES.md #65-67)
-  P1  Dial plan / hunt-group generalization (reuse 999 forking) · directed pickup .. ISSUES.md #68/#69
+  ✓   Dial plan / hunt-group generalization (pattern -> action table) ... shipped (ISSUES.md #69)
+  P1  Directed call pickup (pickup groups) ................................ ISSUES.md #68
   P2  DHCP Opt-66 · multi-vendor provisioning
   P2  Secure Boot v2 + flash encryption + signed OTA  (durable physical/supply-chain fix)
   P2  Multi-AP/mesh · optional HTTPS · SRTP

--- a/src/Helpers/HttpServer.cpp
+++ b/src/Helpers/HttpServer.cpp
@@ -1,6 +1,7 @@
 // HttpServer.cpp: Issues #23 and #28 resolved.
 #include "HttpServer.hpp"
 #include "RequestsHandler.hpp"
+#include "DialPlan.hpp"          // Issue #69: dial-rule validation shared with setDialRule
 #include "CallDetailRecord.hpp"
 #include "AdminAuth.hpp"
 #include "OtaUpdater.hpp"
@@ -567,6 +568,24 @@ void HttpServer::handleClient(int clientSock)
 			sendApiGroup(clientSock, req.body);
 		}
 	}
+	else if (req.method == "POST" && req.path == "/api/dialplan")
+	{
+		// Mutating: same gate as /api/group (same-origin + auth once provisioned).
+		if (!isSameOrigin(req))
+		{
+			sendResponse(clientSock, 403, "Forbidden", "application/json",
+			             "{\"error\":\"cross-origin request rejected\"}");
+		}
+		else if (AdminAuth::isProvisioned() && !isAuthed(req))
+		{
+			sendResponse(clientSock, 401, "Unauthorized", "application/json",
+			             "{\"error\":\"authentication required\"}");
+		}
+		else
+		{
+			sendApiDialPlan(clientSock, req.body);
+		}
+	}
 	else if (req.method == "GET" && req.path == "/api/wifi/scan")
 	{
 		sendApiWifiScan(clientSock);
@@ -872,6 +891,7 @@ void HttpServer::sendApiStatus(int sock)
 	std::vector<std::string> dndExtensions;
 	std::vector<std::tuple<std::string, std::string, std::string, std::string>> forwards;
 	std::vector<std::tuple<std::string, std::string, std::string>> ringGroups;
+	std::vector<std::tuple<std::string, std::string, std::string>> dialRules;
 	uint64_t packets = 0;
 	uint64_t dropped = 0;
 
@@ -883,6 +903,7 @@ void HttpServer::sendApiStatus(int sock)
 		dndExtensions = handler->getDndExtensions();
 		forwards = handler->getForwards();
 		ringGroups = handler->getRingGroups();
+		dialRules = handler->getDialRules();
 		packets = handler->getPacketsProcessed();
 		dropped = handler->getPacketsDropped();   // Issue #38
 	}
@@ -967,6 +988,18 @@ void HttpServer::sendApiStatus(int sock)
 		json << "{\"extension\":\"" << jsonEscape(std::get<0>(ringGroups[i]))
 		     << "\",\"mode\":\""     << jsonEscape(std::get<1>(ringGroups[i]))
 		     << "\",\"members\":\""  << jsonEscape(std::get<2>(ringGroups[i])) << "\"}";
+	}
+	json << "],";
+
+	// Dial-plan rules (Issue #69). Emitted in TABLE ORDER — this array's order is
+	// load-bearing (first match wins), unlike the sets above.
+	json << "\"dialplan\":[";
+	for (size_t i = 0; i < dialRules.size(); i++)
+	{
+		if (i > 0) json << ",";
+		json << "{\"pattern\":\"" << jsonEscape(std::get<0>(dialRules[i]))
+		     << "\",\"action\":\"" << jsonEscape(std::get<1>(dialRules[i]))
+		     << "\",\"target\":\"" << jsonEscape(std::get<2>(dialRules[i])) << "\"}";
 	}
 	json << "]";
 
@@ -1233,6 +1266,79 @@ void HttpServer::sendApiGroup(int sock, const std::string& body)
 	             "{\"status\":\"ok\",\"extension\":\"" + jsonEscape(ext) +
 	             "\",\"mode\":\"" + jsonEscape(mode) +
 	             "\",\"members\":\"" + jsonEscape(members) + "\"}");
+}
+
+void HttpServer::sendApiDialPlan(int sock, const std::string& body)
+{
+	// Issue #69. Params: pattern (the rule's key), action ("group"|"page"|"park"),
+	// target (the group/zone/orbit extension). An empty target deletes the rule.
+	// The dial plan is ORDERED and first-match-wins, so an existing pattern is
+	// edited in place (keeping its position) and a new one is appended — see
+	// RequestsHandler::setDialRule, which owns the full validation and the
+	// POCKETDIAL_MAX_DIAL_RULES cap.
+	std::string pattern = getFormParam(body, "pattern");
+	std::string action  = getFormParam(body, "action");
+	std::string target  = getFormParam(body, "target");
+
+	if (pattern.empty())
+	{
+		sendResponse(sock, 400, "Bad Request", "application/json",
+		             "{\"error\":\"missing pattern parameter\"}");
+		return;
+	}
+	if (!pbx::isDialTokenSafe(pattern))
+	{
+		sendResponse(sock, 400, "Bad Request", "application/json",
+		             "{\"error\":\"pattern may contain only letters, digits, '#' and '*'\"}");
+		return;
+	}
+	if (pattern == "777" || pattern == "999" || pattern == "440")
+	{
+		sendResponse(sock, 400, "Bad Request", "application/json",
+		             "{\"error\":\"cannot use a reserved extension as a dial-plan pattern\"}");
+		return;
+	}
+
+	// A delete only needs the pattern; everything else is validated for an upsert.
+	if (!target.empty())
+	{
+		if (action.empty()) action = "group";
+		pbx::DialActionType parsed;
+		if (!pbx::parseDialAction(action, parsed))
+		{
+			sendResponse(sock, 400, "Bad Request", "application/json",
+			             "{\"error\":\"action must be group|page|park\"}");
+			return;
+		}
+		if (!pbx::isDialTokenSafe(target))
+		{
+			sendResponse(sock, 400, "Bad Request", "application/json",
+			             "{\"error\":\"target may contain only letters, digits, '#' and '*'\"}");
+			return;
+		}
+		if (parsed == pbx::DialActionType::PageZone && !pbx::isPageZoneExt(target))
+		{
+			sendResponse(sock, 400, "Bad Request", "application/json",
+			             "{\"error\":\"page target must be a paging zone (980-989)\"}");
+			return;
+		}
+		if (parsed == pbx::DialActionType::ParkOrbit && !pbx::isParkOrbitExt(target))
+		{
+			sendResponse(sock, 400, "Bad Request", "application/json",
+			             "{\"error\":\"park target must be a park orbit\"}");
+			return;
+		}
+	}
+
+	if (RequestsHandler* handler = _handler.load(std::memory_order_acquire))
+	{
+		handler->setDialRule(pattern, action, target);
+	}
+
+	sendResponse(sock, 200, "OK", "application/json",
+	             "{\"status\":\"ok\",\"pattern\":\"" + jsonEscape(pattern) +
+	             "\",\"action\":\"" + jsonEscape(action) +
+	             "\",\"target\":\"" + jsonEscape(target) + "\"}");
 }
 
 bool HttpServer::isSameOrigin(const HttpRequest& req) const

--- a/src/Helpers/HttpServer.hpp
+++ b/src/Helpers/HttpServer.hpp
@@ -114,6 +114,11 @@ private:
 	// configure ring/hunt groups. Mutating (same-origin + auth gated), mirroring DND.
 	void sendApiForward(int sock, const std::string& body);
 	void sendApiGroup(int sock, const std::string& body);
+	// Issue #69: upsert/delete one dial-plan rule. Same gate and same shape as
+	// sendApiGroup — validation lives in RequestsHandler::setDialRule; this only
+	// rejects the parameter-level mistakes it can name precisely (missing pattern,
+	// bad action) so the operator gets a 400 instead of a silent server-side drop.
+	void sendApiDialPlan(int sock, const std::string& body);
 	void sendApiWifiScan(int sock);
 	void sendApiWifiConnect(int sock, const std::string& body);
 	void sendApiWifiModeAp(int sock);

--- a/src/SIP/DialPlan.hpp
+++ b/src/SIP/DialPlan.hpp
@@ -1,0 +1,231 @@
+#ifndef DIAL_PLAN_HPP
+#define DIAL_PLAN_HPP
+
+// DialPlan.hpp — Issue #69: a small, bounded, table-driven pattern → action dial
+// plan for LAN routing.
+//
+// This is the generalization of the ring-group mechanism (setRingGroup /
+// getRingGroups): instead of "a dialed number IS a group extension", a dial rule
+// says "a dialed number that LOOKS LIKE this pattern is routed to that action".
+// The actions are the ones pocket-dial already ships — nothing here invents new
+// call handling:
+//
+//   group  → the ring/hunt group named by the rule's target (RequestsHandler's
+//            findRingGroup + the ring-all fork / sequential hunt, Class A sweep)
+//   page   → the paging zone named by the rule's target (Issue #66, 980–989)
+//   park   → the park orbit named by the rule's target (Issue #65, 700–70N);
+//            dialing a rule with this action is exactly dialing the orbit, i.e.
+//            park into a free slot / retrieve from an occupied one
+//
+// (Issue #68's directed pickup is deliberately absent: it is not on main. Adding
+// it later is one enum value, one parse/name string, and one dispatch arm.)
+//
+// Design mirrors PbxConfig.hpp: everything here is pure and header-only so the
+// host tests can exercise pattern precedence and the size cap without linking
+// the registrar. The table lives in RequestsHandler behind _mutex, is capped at
+// POCKETDIAL_MAX_DIAL_RULES, and is NVS-persisted alongside the ring groups and
+// paging zones.
+//
+// ── Pattern grammar ──────────────────────────────────────────────────────────
+// Deliberately tiny — this is a LAN desk PBX, not a carrier dial plan. There is
+// no regex engine, no backtracking, and matching is O(pattern length).
+//
+//   digits / letters / '#' / '*'   match themselves, literally
+//   'X' or 'x'                     match exactly one digit (0–9)
+//   a trailing '*'                 matches the rest of the dialed number,
+//                                  including nothing at all (prefix match)
+//
+// A '*' anywhere but the last character is a LITERAL '*', because star-codes
+// (`*8`, `*4887`) are real dialable strings on this box — treating a leading '*'
+// as a wildcard would make `*8*` ambiguous with the pickup-style codes. Only the
+// final character is special.
+//
+//   "601"    exact match: only 601
+//   "6XX"    601, 655, 699 … (three digits, first is 6)
+//   "6*"     6, 60, 601, 6123 … (anything starting with 6)
+//   "*"      catch-all (a single trailing star with an empty literal prefix)
+//   "*8"     the literal star-code *8 — NOT a wildcard
+//
+// ── Evaluation ───────────────────────────────────────────────────────────────
+// Rules are evaluated in TABLE ORDER and the FIRST match wins. Order is the
+// operator's, not a specificity heuristic: if a catch-all is listed first it
+// shadows everything after it, exactly as written. Rules are appended in the
+// order they are configured, and editing an existing pattern keeps its position.
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+#include "PoolConfig.hpp"
+
+namespace pbx
+{
+	// The already-shipped call-handling actions a dial rule can select.
+	enum class DialActionType
+	{
+		RingGroup,   // route to the ring/hunt group named by `target`
+		PageZone,    // route to the paging zone named by `target`
+		ParkOrbit    // route to the park orbit named by `target` (park/retrieve)
+	};
+
+	// One rule: a pattern, the action it selects, and the action's target
+	// (a group extension, a zone extension, or an orbit extension).
+	struct DialRule
+	{
+		std::string pattern;
+		DialActionType action = DialActionType::RingGroup;
+		std::string target;
+	};
+
+	// ── Pure helpers (unit-tested directly) ───────────────────────────────────
+
+	// Wire/NVS/JSON name for an action, and the inverse. Unknown names parse to
+	// false so a corrupted NVS record or a bad API parameter is rejected rather
+	// than silently defaulting to some action the operator never asked for.
+	inline const char* dialActionName(DialActionType a)
+	{
+		switch (a)
+		{
+		case DialActionType::PageZone:  return "page";
+		case DialActionType::ParkOrbit: return "park";
+		case DialActionType::RingGroup:
+		default:                        return "group";
+		}
+	}
+
+	inline bool parseDialAction(const std::string& name, DialActionType& out)
+	{
+		if (name == "group") { out = DialActionType::RingGroup; return true; }
+		if (name == "page")  { out = DialActionType::PageZone;  return true; }
+		if (name == "park")  { out = DialActionType::ParkOrbit; return true; }
+		return false;
+	}
+
+	// Match `dialed` against `pattern` under the grammar documented at the top of
+	// this file. Pure, allocation-free, and O(pattern.size()).
+	inline bool dialPatternMatches(const std::string& pattern, const std::string& dialed)
+	{
+		if (pattern.empty())
+		{
+			return false;   // an empty pattern never matches (also rejected at config time)
+		}
+
+		// A trailing '*' is the only wildcard that consumes more than one char:
+		// everything before it must match position-for-position, and whatever is
+		// left of `dialed` (possibly nothing) is absorbed.
+		const bool prefixMode = (pattern.back() == '*');
+		const size_t litLen = prefixMode ? pattern.size() - 1 : pattern.size();
+
+		if (!prefixMode && dialed.size() != litLen) return false;
+		if (dialed.size() < litLen) return false;
+
+		for (size_t i = 0; i < litLen; ++i)
+		{
+			const char p = pattern[i];
+			const char d = dialed[i];
+			if (p == 'X' || p == 'x')
+			{
+				if (!std::isdigit(static_cast<unsigned char>(d))) return false;
+			}
+			else if (p != d)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// True iff every character of `s` is safe to round-trip through the tab/newline
+	// delimited NVS blob and the dashboard JSON: digits, ASCII letters, '#', '*'.
+	// Rejecting at config time (rather than escaping) keeps the persisted record
+	// format unambiguous — a tab or newline smuggled into a pattern would otherwise
+	// corrupt every rule after it on the next boot.
+	inline bool isDialTokenSafe(const std::string& s)
+	{
+		if (s.empty()) return false;
+		for (char c : s)
+		{
+			const unsigned char u = static_cast<unsigned char>(c);
+			if (std::isalnum(u) || c == '#' || c == '*') continue;
+			return false;
+		}
+		return true;
+	}
+
+	// True iff `ext` is a valid park-orbit extension for this build ("700" ..
+	// "70(POCKETDIAL_PARK_SLOTS-1)"). Mirrors ParkOrbit::orbitIndex()'s range test
+	// as a pure predicate so a dial rule's target can be validated at CONFIG time,
+	// off the SIP thread and without a ParkOrbit instance.
+	inline bool isParkOrbitExt(const std::string& ext)
+	{
+		if (ext.size() != 3 || ext[0] != '7' || ext[1] != '0') return false;
+		if (!std::isdigit(static_cast<unsigned char>(ext[2]))) return false;
+		return (ext[2] - '0') < POCKETDIAL_PARK_SLOTS;
+	}
+
+	// ── The bounded rule table ────────────────────────────────────────────────
+	//
+	// An ordered vector — order IS the semantics, so this is deliberately not a
+	// map. Capacity is hard-capped at POCKETDIAL_MAX_DIAL_RULES (see PoolConfig.hpp
+	// for the rationale); upsert() refuses to grow past it but still edits rules
+	// that are already in the table, so a full table is never un-editable.
+	class DialPlan
+	{
+	public:
+		// Insert `rule` at the end, or replace the existing rule with the same
+		// pattern IN PLACE (keeping its evaluation position — editing a rule's
+		// action or target must never silently re-order the plan). Returns false
+		// only when the rule is new and the table is already full.
+		bool upsert(const DialRule& rule)
+		{
+			for (auto& existing : _rules)
+			{
+				if (existing.pattern == rule.pattern)
+				{
+					existing.action = rule.action;
+					existing.target = rule.target;
+					return true;
+				}
+			}
+			if (_rules.size() >= static_cast<size_t>(POCKETDIAL_MAX_DIAL_RULES))
+			{
+				return false;
+			}
+			_rules.push_back(rule);
+			return true;
+		}
+
+		// Remove the rule with this pattern. Returns true if one was removed.
+		bool erase(const std::string& pattern)
+		{
+			auto it = std::find_if(_rules.begin(), _rules.end(),
+				[&](const DialRule& r) { return r.pattern == pattern; });
+			if (it == _rules.end()) return false;
+			_rules.erase(it);
+			return true;
+		}
+
+		// First rule whose pattern matches `dialed`, or nullptr when nothing does
+		// (the fallthrough case: the caller must then route exactly as it did
+		// before the dial plan existed).
+		const DialRule* match(const std::string& dialed) const
+		{
+			for (const auto& r : _rules)
+			{
+				if (dialPatternMatches(r.pattern, dialed)) return &r;
+			}
+			return nullptr;
+		}
+
+		const std::vector<DialRule>& rules() const { return _rules; }
+		size_t size() const { return _rules.size(); }
+		bool empty() const { return _rules.empty(); }
+		void clear() { _rules.clear(); }
+
+	private:
+		std::vector<DialRule> _rules;
+	};
+}
+
+#endif

--- a/src/SIP/PoolConfig.hpp
+++ b/src/SIP/PoolConfig.hpp
@@ -151,6 +151,19 @@
 #define POCKETDIAL_ZONE_MEMBER_CAP 8
 #endif
 
+// Maximum number of dial-plan rules (Issue #69). The rule table is walked
+// linearly, in table order, on every INVITE that reaches the dial plan — so this
+// cap bounds BOTH the memory the table can occupy and the per-INVITE matching
+// work in the SIP packet path. Sixteen rules is comfortably more than a desk PBX
+// needs (the whole dial space here is three-digit LAN extensions) while keeping
+// the worst-case walk a handful of short string compares. setDialRule() refuses
+// a new rule once the table is full (existing rules can still be edited in
+// place), and loadPbxConfig() applies the same ceiling when replaying NVS, so a
+// blob written by a build with a larger cap can never overflow a smaller one.
+#ifndef POCKETDIAL_MAX_DIAL_RULES
+#define POCKETDIAL_MAX_DIAL_RULES 16
+#endif
+
 // Maximum concurrent RFC 3261 §17 transaction records tracked for retransmit
 // timers.  Each InviteClient slot tracks one outgoing INVITE fork (Timer A/B):
 // retransmit interval doubles from T1 until a provisional stops it, or Timer B

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -865,27 +865,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	{
 		if (const pbx::PageZone* zone = findPageZone(destNumber))
 		{
-			std::vector<std::shared_ptr<SipClient>> targets;
-			for (const auto& m : zone->members)
-			{
-				if (m == caller.value()->getNumber()) continue;
-				auto mc = findClient(m);
-				if (mc.has_value())
-					targets.push_back(mc.value());
-			}
-
-			if (targets.empty())
-			{
-				std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
-				if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
-				responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
-				responseObj->clearBody();
-				responseObj->setContact(buildContact(caller.value()->getNumber()));
-				_outbox.emplace_back(data->getSource(), std::move(responseObj));
-				return;
-			}
-
-			startBroadcastFork(data, caller.value(), std::move(targets), /*intercom=*/true);
+			routePageZone(data, caller.value(), *zone);
 			return;
 		}
 	}
@@ -915,69 +895,22 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// real endpoint and so never carries its own DND/forward config.
 	if (const pbx::RingGroup* group = findRingGroup(destNumber))
 	{
-		// Collect the registered members (skip the caller and any offline member).
-		std::vector<std::shared_ptr<SipClient>> members;
-		std::vector<std::string> huntOrder;
-		for (const auto& m : group->members)
-		{
-			if (m == caller.value()->getNumber()) continue;
-			auto mc = findClient(m);
-			if (mc.has_value())
-			{
-				members.push_back(mc.value());
-				huntOrder.push_back(m);
-			}
-		}
+		routeRingGroup(data, caller.value(), destNumber, *group);
+		return;
+	}
 
-		if (members.empty())
-		{
-			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
-			if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
-			responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
-			responseObj->clearBody();
-			responseObj->setContact(buildContact(caller.value()->getNumber()));
-			endHandle(data->getFromNumber(), responseObj);
-			return;
-		}
-
-		if (group->mode == pbx::GroupMode::RingAll)
-		{
-			startBroadcastFork(data, caller.value(), std::move(members), /*intercom=*/false);
-			return;
-		}
-
-		// Hunt (sequential): build a broadcast-style session but ring one at a time.
-		auto newSession = allocateSession(std::string(data->getCallID()), caller.value());
-		if (!newSession)
-		{
-			std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
-			if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
-			responseObj->setHeader("SIP/2.0 503 Service Unavailable");
-			responseObj->clearBody();
-			responseObj->setContact(buildContact(caller.value()->getNumber()));
-			_outbox.emplace_back(data->getSource(), std::move(responseObj));
-			return;
-		}
-		newSession->setBroadcast(true);
-		newSession->setHunt(true);
-		newSession->setGroupExt(destNumber);
-		newSession->setInviteMessage(data);
-		newSession->setHuntMembers(std::move(huntOrder));
-		newSession->setHuntIndex(0);
-		_sessions.emplace(data->getCallID(), newSession);
-
-		// 180 Ringing back to the caller while we walk the list.
-		auto ringing = getMessageFromPool(*data);
-		if (!ringing) return;   // pool exhausted: drop, peer retransmits (#101A)
-		ringing->setHeader("SIP/2.0 180 Ringing");
-		ringing->clearBody();
-		std::string activeIp = _localIp;
-		ringing->setVia(std::string(data->getVia()) + ";received=" + activeIp);
-		ringing->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
-		ringing->setContact(buildContact(destNumber));
-		_outbox.emplace_back(data->getSource(), std::move(ringing));
-
-		huntRingNext(newSession);   // ring the first member, arm its timeout
+	// Dial plan (Issue #69): the bounded, ordered pattern → action rule table.
+	// Deliberately evaluated HERE — after every reserved virtual extension (777,
+	// 999, 98x zones, 440, 70x orbits) and after the direct ring-group lookup, but
+	// before CFU/DND/extension lookup. That ordering is what makes the feature
+	// additive rather than a behavior change: a rule can only ever intercept a
+	// dialed number that would otherwise have reached the ordinary extension
+	// lookup (and, for an unknown number, 404). No rule can shadow the echo test,
+	// a park retrieval or a configured group extension — so even a catch-all "*"
+	// pattern leaves the built-ins working. Nothing matched ⇒ routeDialPlan()
+	// returns false and everything below runs exactly as it did before #69.
+	if (routeDialPlan(data, caller.value(), destNumber))
+	{
 		return;
 	}
 
@@ -2791,6 +2724,289 @@ std::vector<std::tuple<std::string, std::string, std::string>> RequestsHandler::
 	return _snapshot.ringGroups;
 }
 
+// ── Action dispatch shared by the built-in codes and the dial plan (#69) ─────
+
+void RequestsHandler::routePageZone(const std::shared_ptr<SipMessage>& data,
+	const std::shared_ptr<SipClient>& caller,
+	const pbx::PageZone& zone)
+{
+	// A zone page is a scoped 999: fork an intercom (auto-answer) INVITE to every
+	// registered member of the zone. Lifted verbatim out of onInvite()'s 98x
+	// branch so the dial plan reaches the same code. Unlike routeRingGroup this
+	// needs no zone-extension parameter: startBroadcastFork stamps the intercom
+	// Contact as 999 for every page, built-in or dial-rule-aliased alike, so the
+	// zone's own extension never appears on the wire.
+	std::vector<std::shared_ptr<SipClient>> targets;
+	for (const auto& m : zone.members)
+	{
+		if (m == caller->getNumber()) continue;
+		auto mc = findClient(m);
+		if (mc.has_value())
+			targets.push_back(mc.value());
+	}
+
+	if (targets.empty())
+	{
+		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+		if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
+		responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
+		responseObj->clearBody();
+		responseObj->setContact(buildContact(caller->getNumber()));
+		_outbox.emplace_back(data->getSource(), std::move(responseObj));
+		return;
+	}
+
+	startBroadcastFork(data, caller, std::move(targets), /*intercom=*/true);
+}
+
+void RequestsHandler::routeRingGroup(const std::shared_ptr<SipMessage>& data,
+	const std::shared_ptr<SipClient>& caller,
+	const std::string& groupExt, const pbx::RingGroup& group)
+{
+	// Ring-all reuses the broadcast fork (without the intercom auto-answer headers,
+	// so members ring normally); hunt rings members one at a time, driven from
+	// tick(). Lifted verbatim out of onInvite()'s ring-group branch. `groupExt` is
+	// the REAL group extension — under a dial rule it differs from the dialed
+	// number, and Session::setGroupExt feeds the hunt-exhausted CDR and the
+	// no-answer Contact, both of which want the group's identity, not the alias.
+
+	// Collect the registered members (skip the caller and any offline member).
+	std::vector<std::shared_ptr<SipClient>> members;
+	std::vector<std::string> huntOrder;
+	for (const auto& m : group.members)
+	{
+		if (m == caller->getNumber()) continue;
+		auto mc = findClient(m);
+		if (mc.has_value())
+		{
+			members.push_back(mc.value());
+			huntOrder.push_back(m);
+		}
+	}
+
+	if (members.empty())
+	{
+		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+		if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
+		responseObj->setHeader(SipMessageTypes::UNAVAILABLE);
+		responseObj->clearBody();
+		responseObj->setContact(buildContact(caller->getNumber()));
+		endHandle(data->getFromNumber(), responseObj);
+		return;
+	}
+
+	if (group.mode == pbx::GroupMode::RingAll)
+	{
+		startBroadcastFork(data, caller, std::move(members), /*intercom=*/false);
+		return;
+	}
+
+	// Hunt (sequential): build a broadcast-style session but ring one at a time.
+	auto newSession = allocateSession(std::string(data->getCallID()), caller);
+	if (!newSession)
+	{
+		std::shared_ptr<SipMessage> responseObj = getMessageFromPool(*data);
+		if (!responseObj) return;   // pool exhausted: drop, peer retransmits (#101A)
+		responseObj->setHeader("SIP/2.0 503 Service Unavailable");
+		responseObj->clearBody();
+		responseObj->setContact(buildContact(caller->getNumber()));
+		_outbox.emplace_back(data->getSource(), std::move(responseObj));
+		return;
+	}
+	newSession->setBroadcast(true);
+	newSession->setHunt(true);
+	newSession->setGroupExt(groupExt);
+	newSession->setInviteMessage(data);
+	newSession->setHuntMembers(std::move(huntOrder));
+	newSession->setHuntIndex(0);
+	_sessions.emplace(data->getCallID(), newSession);
+
+	// 180 Ringing back to the caller while we walk the list.
+	auto ringing = getMessageFromPool(*data);
+	if (!ringing) return;   // pool exhausted: drop, peer retransmits (#101A)
+	ringing->setHeader("SIP/2.0 180 Ringing");
+	ringing->clearBody();
+	std::string activeIp = _localIp;
+	ringing->setVia(std::string(data->getVia()) + ";received=" + activeIp);
+	ringing->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
+	ringing->setContact(buildContact(groupExt));
+	_outbox.emplace_back(data->getSource(), std::move(ringing));
+
+	huntRingNext(newSession);   // ring the first member, arm its timeout
+}
+
+// ── Dial plan (Issue #69) ────────────────────────────────────────────────────
+
+bool RequestsHandler::routeDialPlan(const std::shared_ptr<SipMessage>& data,
+	const std::shared_ptr<SipClient>& caller,
+	const std::string& destNumber)
+{
+	// Fast path: the table is empty on a default install, so the overwhelmingly
+	// common case costs one size check and nothing else.
+	if (_dialPlan.empty())
+	{
+		return false;
+	}
+
+	const pbx::DialRule* rule = _dialPlan.match(destNumber);
+	if (!rule)
+	{
+		return false;   // fallthrough — routing continues exactly as it did pre-#69
+	}
+
+	queueLog("Dial plan: " + destNumber + " matched \"" + rule->pattern + "\" -> " +
+		pbx::dialActionName(rule->action) + " " + rule->target);
+
+	switch (rule->action)
+	{
+	case pbx::DialActionType::RingGroup:
+		if (const pbx::RingGroup* group = findRingGroup(rule->target))
+		{
+			routeRingGroup(data, caller, rule->target, *group);
+			return true;
+		}
+		break;
+
+	case pbx::DialActionType::PageZone:
+		if (const pbx::PageZone* zone = findPageZone(rule->target))
+		{
+			routePageZone(data, caller, *zone);
+			return true;
+		}
+		break;
+
+	case pbx::DialActionType::ParkOrbit:
+	{
+		// Park/retrieve is stateless config-wise — the orbit always exists, so the
+		// only way this fails is a target outside this build's orbit range, which
+		// setDialRule() already refuses. Re-checked here anyway: POCKETDIAL_PARK_SLOTS
+		// can shrink under a rebuilt firmware that reloads an older NVS blob.
+		const int orbitIdx = _park.orbitIndex(rule->target);
+		if (orbitIdx >= 0)
+		{
+			_park.onInvite(data, caller, orbitIdx);
+			return true;
+		}
+		break;
+	}
+	}
+
+	// The rule matched but its target no longer resolves — a group or zone deleted
+	// after the rule was written, or an orbit outside this build's range. Answer
+	// 404 rather than falling through: falling through would silently ring a real
+	// extension that happens to share the dialed digits, which is a mis-routed
+	// call, whereas a stale rule failing loudly is diagnosable from one 404.
+	queueLog("Dial plan: rule \"" + rule->pattern + "\" -> " +
+		pbx::dialActionName(rule->action) + " " + rule->target +
+		" has no such target; answering 404", true);
+	auto responseObj = getMessageFromPool(*data);
+	if (!responseObj) return true;   // pool exhausted: drop, peer retransmits (#101A)
+	responseObj->setHeader(SipMessageTypes::NOT_FOUND);
+	responseObj->clearBody();
+	responseObj->setContact(buildContact(caller->getNumber()));
+	_outbox.emplace_back(data->getSource(), std::move(responseObj));
+	return true;
+}
+
+void RequestsHandler::setDialRule(const std::string& pattern, const std::string& action,
+	const std::string& target)
+{
+	std::vector<std::pair<bool, std::string>> localLogs;
+	{
+		std::lock_guard<std::mutex> lock(_mutex);
+
+		// Validate once, here, so a bad rule can never reach the SIP thread — and
+		// so the NVS blob (tab/newline delimited) can never be corrupted by a
+		// smuggled separator. Same "log and drop" contract as setRingGroup.
+		if (!pbx::isDialTokenSafe(pattern))
+		{
+			queueLog("Dial rule ignored: invalid pattern \"" + pattern + "\"", true);
+		}
+		else if (pattern == "777" || pattern == "999" || pattern == "440")
+		{
+			// These are handled above the dial plan in onInvite(), so a rule here
+			// would never fire. Refuse it instead of accepting a dead rule.
+			queueLog("Dial rule ignored: " + pattern +
+				" is a reserved extension and is routed before the dial plan", true);
+		}
+		else if (target.empty())
+		{
+			// Empty target deletes the rule (mirrors setRingGroup's empty member list).
+			if (_dialPlan.erase(pattern))
+			{
+				queueLog("Dial rule " + pattern + " deleted");
+				persistDialPlan();
+			}
+		}
+		else if (!pbx::isDialTokenSafe(target))
+		{
+			queueLog("Dial rule ignored: invalid target \"" + target + "\"", true);
+		}
+		else
+		{
+			pbx::DialActionType parsed;
+			if (!pbx::parseDialAction(action, parsed))
+			{
+				queueLog("Dial rule ignored: unknown action \"" + action +
+					"\" (want group|page|park)", true);
+			}
+			else if (parsed == pbx::DialActionType::PageZone && !pbx::isPageZoneExt(target))
+			{
+				queueLog("Dial rule ignored: page target " + target +
+					" is not a paging zone (zones are 980-989)", true);
+			}
+			else if (parsed == pbx::DialActionType::ParkOrbit && !pbx::isParkOrbitExt(target))
+			{
+				queueLog("Dial rule ignored: park target " + target +
+					" is not a park orbit for this build", true);
+			}
+			else
+			{
+				pbx::DialRule rule;
+				rule.pattern = pattern;
+				rule.action = parsed;
+				rule.target = target;
+				if (!_dialPlan.upsert(rule))
+				{
+					queueLog("Dial rule ignored (table full) for " + pattern, true);
+				}
+				else
+				{
+					queueLog("Dial rule " + pattern + " -> " +
+						pbx::dialActionName(parsed) + " " + target);
+					persistDialPlan();
+				}
+			}
+		}
+
+		// Refresh dashboard snapshot immediately (mirrors setRingGroup).
+		{
+			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+			_snapshot.dialRules.clear();
+			_snapshot.dialRules.reserve(_dialPlan.size());
+			for (const auto& r : _dialPlan.rules())
+			{
+				_snapshot.dialRules.emplace_back(r.pattern, pbx::dialActionName(r.action), r.target);
+			}
+		}
+
+		localLogs = std::move(_logQueue);
+		_logQueue.clear();
+	}
+
+	for (const auto& log : localLogs)
+	{
+		if (log.first) std::cerr << log.second << std::endl;
+		else std::cout << log.second << std::endl;
+	}
+}
+
+std::vector<std::tuple<std::string, std::string, std::string>> RequestsHandler::getDialRules()
+{
+	std::lock_guard<std::mutex> lock(_snapshotMutex);
+	return _snapshot.dialRules;
+}
+
 // ── Registrar mode (STAGE 2) ──────────────────────────────────────────────────
 
 void RequestsHandler::setRegistrarMode(RegistrarMode mode)
@@ -3171,6 +3387,15 @@ void RequestsHandler::tick()
 				pbx::joinMembers(g.members));
 		}
 
+		// Dial-plan rules (Issue #69), in table order. Rebuilt from _dialPlan here
+		// alongside ringGroups rather than mirrored out of band like pageZones, so
+		// the snapshot swap below can never blank or re-order them.
+		nextSnapshot.dialRules.reserve(_dialPlan.size());
+		for (const auto& r : _dialPlan.rules())
+		{
+			nextSnapshot.dialRules.emplace_back(r.pattern, pbx::dialActionName(r.action), r.target);
+		}
+
 		// Parked calls view: {orbit, parkedExt, parker, secondsParked}. This full
 		// rebuild already reflects anything _park.sweep() just did above, so clear
 		// the dirty flag here rather than leaving it to trigger a redundant mirror
@@ -3444,6 +3669,25 @@ void RequestsHandler::loadPbxConfig()
 		if (!z.members.empty()) _pageZones[rec[0]] = std::move(z);
 	}
 
+	// Dial plan (Issue #69): pattern \t action \t target, one record per rule, in
+	// evaluation order. DialPlan::upsert() enforces POCKETDIAL_MAX_DIAL_RULES on
+	// its own, so a blob written by a build with a larger cap simply stops being
+	// applied at this build's ceiling instead of overflowing it. Records that no
+	// longer validate (an unknown action, or a park target outside a shrunken
+	// POCKETDIAL_PARK_SLOTS) are dropped rather than loaded.
+	for (const auto& rec : deserializeBlob(readBlob("dplan")))
+	{
+		if (rec.size() < 3 || rec[0].empty() || rec[2].empty()) continue;
+		pbx::DialRule rule;
+		if (!pbx::parseDialAction(rec[1], rule.action)) continue;
+		if (!pbx::isDialTokenSafe(rec[0]) || !pbx::isDialTokenSafe(rec[2])) continue;
+		if (rule.action == pbx::DialActionType::PageZone && !pbx::isPageZoneExt(rec[2])) continue;
+		if (rule.action == pbx::DialActionType::ParkOrbit && !pbx::isParkOrbitExt(rec[2])) continue;
+		rule.pattern = rec[0];
+		rule.target = rec[2];
+		if (!_dialPlan.upsert(rule)) break;   // table full at this build's cap
+	}
+
 	nvs_close(h);
 #endif
 }
@@ -3502,6 +3746,28 @@ void RequestsHandler::persistPageZones()
 	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
 	{
 		nvs_set_str(h, "pzones", blob.c_str());
+		nvs_commit(h);
+		nvs_close(h);
+	}
+#endif
+}
+
+void RequestsHandler::persistDialPlan()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	// Order matters here in a way it does not for the maps above: the blob is
+	// written (and replayed) in table order, because that IS the evaluation order.
+	std::string blob;
+	for (const auto& r : _dialPlan.rules())
+	{
+		blob += r.pattern; blob += '\t';
+		blob += pbx::dialActionName(r.action); blob += '\t';
+		blob += r.target; blob += '\n';
+	}
+	nvs_handle_t h;
+	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
+	{
+		nvs_set_str(h, "dplan", blob.c_str());
 		nvs_commit(h);
 		nvs_close(h);
 	}

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -32,6 +32,7 @@
 #include "CallDetailRecord.hpp"
 #include "PcapCapture.hpp"
 #include "PbxConfig.hpp"
+#include "DialPlan.hpp"
 #include "RtpSender.hpp"
 #include "PbxEnv.hpp"
 #include "TransactionLayer.hpp"
@@ -170,6 +171,26 @@ public:
 	// returns {zoneExt, "m1,m2,..."} pairs for the dashboard.
 	void setPageZone(const std::string& zoneExt, const std::string& members);
 	std::vector<std::pair<std::string, std::string>> getPageZones();
+
+	// ── Dial plan (Issue #69) ─────────────────────────────────────────────────
+	// A bounded, ordered pattern → action rule table (see DialPlan.hpp for the
+	// pattern grammar and POCKETDIAL_MAX_DIAL_RULES for the cap). setDialRule
+	// upserts one rule: a rule whose pattern is already in the table is edited IN
+	// PLACE, keeping its evaluation position; a new pattern is appended, and is
+	// refused (logged, not applied) once the table is full. An empty `target`
+	// deletes the rule with that pattern. `action` is "group" | "page" | "park".
+	//
+	// The rule is validated here, not at dial time: the pattern and target must be
+	// NVS/JSON-safe tokens (DialPlan.hpp's isDialTokenSafe), the target must have
+	// the right shape for the action (980–989 for "page", a real orbit for
+	// "park"), and reserved virtual extensions are refused as patterns. Invalid
+	// input is logged and dropped — same contract as setRingGroup/setPageZone.
+	//
+	// Thread-safe (takes _mutex / _snapshotMutex) and NVS-persisted, exactly like
+	// setRingGroup. The getter returns {pattern, action, target} triples in TABLE
+	// ORDER — the order rules are evaluated in — for the dashboard and the API.
+	void setDialRule(const std::string& pattern, const std::string& action, const std::string& target);
+	std::vector<std::tuple<std::string, std::string, std::string>> getDialRules();
 
 	// ── Admin extension (Task 2B) ─────────────────────────────────────────────────
 	// NVS-persisted extension identity for the administrative endpoint.
@@ -435,6 +456,29 @@ private:
 	const pbx::PageZone* findPageZone(const std::string& extension) const;
 	bool isPageZoneDialog(const std::string& extension) const;
 
+	// ── Dial-plan dispatch (Issue #69) ────────────────────────────────────────
+	// The two "route this INVITE to an already-shipped action" bodies, lifted
+	// verbatim out of onInvite()'s built-in 98x / ring-group branches so the dial
+	// plan can reach the same code instead of duplicating it. Both take the action
+	// target EXPLICITLY rather than reading it back off the INVITE's To-number,
+	// because under a dial rule the dialed number and the group/zone extension are
+	// no longer the same string. Both always answer the caller (fork, 480, or
+	// 503) and so are terminal for the INVITE. Caller holds _mutex.
+	void routePageZone(const std::shared_ptr<SipMessage>& data,
+		const std::shared_ptr<SipClient>& caller,
+		const pbx::PageZone& zone);
+	void routeRingGroup(const std::shared_ptr<SipMessage>& data,
+		const std::shared_ptr<SipClient>& caller,
+		const std::string& groupExt, const pbx::RingGroup& group);
+
+	// Evaluate the dial plan against the dialed number. Returns true if a rule
+	// matched and the INVITE was fully handled (onInvite must return); false means
+	// no rule matched and routing falls through to the unchanged extension-lookup
+	// path. Caller holds _mutex.
+	bool routeDialPlan(const std::shared_ptr<SipMessage>& data,
+		const std::shared_ptr<SipClient>& caller,
+		const std::string& destNumber);
+
 	// Fan an INVITE out to a set of targets (the reusable core extracted from the
 	// 999 all-page path). `targets` are pre-selected registered clients; `intercom`
 	// adds the 999 auto-answer headers (true for 999, false for a ring group so it
@@ -577,6 +621,11 @@ private:
 		std::vector<std::tuple<std::string, std::string, std::string, int>> parkedCalls;
 		// Paging zones: {zoneExt, "m1,m2,..."}.
 		std::vector<std::pair<std::string, std::string>> pageZones;
+		// Dial-plan rules (Issue #69): {pattern, "group"|"page"|"park", target},
+		// in table order — the order they are evaluated in. Unlike pageZones this
+		// is rebuilt from _dialPlan every tick() alongside ringGroups, so it needs
+		// no out-of-band carry-over across the snapshot swap.
+		std::vector<std::tuple<std::string, std::string, std::string>> dialRules;
 		// Adopted devices (STAGE 2): {mac, ext, state, online}. Mirrored from the
 		// Registrar's registry under _mutex; copied out under _snapshotMutex.
 		std::vector<AdoptedDevice> devices;
@@ -620,6 +669,14 @@ private:
 	// Guarded by _mutex; mirrored into the snapshot and persisted to NVS.
 	std::unordered_map<std::string, pbx::PageZone> _pageZones;
 
+	// Dial-plan rule table (Issue #69). An ORDERED vector, not a map: first match
+	// wins, so evaluation order is the semantics. Hard-capped at
+	// POCKETDIAL_MAX_DIAL_RULES by DialPlan::upsert(). Guarded by _mutex; mirrored
+	// into the snapshot and persisted to NVS. Empty by default, and an empty table
+	// is a no-op on routing — every dialed number falls straight through to the
+	// pre-#69 extension-lookup path.
+	pbx::DialPlan _dialPlan;
+
 	// How long to wait between OPTIONS keepalive cycles, in minutes. Atomic so the
 	// TUI can read without taking _mutex. Persisted to NVS ("pbxcfg"/"rewarm_min").
 	std::atomic<uint16_t> _rewarmMinutes{60};
@@ -648,6 +705,7 @@ private:
 	void persistForwards();               // write-through after a setForward mutation
 	void persistRingGroups();             // write-through after a setRingGroup mutation
 	void persistPageZones();              // write-through after a setPageZone mutation
+	void persistDialPlan();               // write-through after a setDialRule mutation
 	bool _pbxConfigLoaded = false;
 
 	// Persistent CDR (Class A sweep). The CDR ring is flushed to the "cdrlog" NVS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,12 @@ add_executable(sip_parser_tests
     # 200 OK was silently dropped instead of reaching the held leg. Drives a full
     # 999 broadcast call through connect -> hold -> resume via handle().
     BroadcastHoldResume_test.cpp
+    # Issue #69: the bounded pattern -> action dial plan that generalizes the
+    # ring-group mechanism. Pure grammar/precedence/cap coverage against
+    # DialPlan.hpp, end-to-end routing (dispatch + fallthrough) driven through
+    # RequestsHandler::handle(), and a real-socket round-trip of the
+    # POST /api/dialplan admin surface through HttpServer.
+    DialPlan_test.cpp
     Rtp_test.cpp
     RtpReceiver_test.cpp
     PlayoutBuffer_test.cpp

--- a/tests/DialPlan_test.cpp
+++ b/tests/DialPlan_test.cpp
@@ -835,13 +835,25 @@ TEST(DialPlanHttp, PostApiDialPlanUpsertsAndDeletesThroughTheAdminSurface)
 	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan",
 		"pattern=3XX&action=page&target=981")), 200);
 
+	// '*' and '#' are the grammar's own characters AND form-encoding metacharacters,
+	// so a rule that uses them has to survive getFormParam's url-decoding intact —
+	// a plan whose wildcard cannot be configured over the API is no plan at all.
+	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan",
+		"pattern=6*&action=group&target=610")), 200);
+	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan",
+		"pattern=%239&action=park&target=701")), 200);
+
 	auto rules = handler.getDialRules();
-	ASSERT_EQ(rules.size(), 2u);
+	ASSERT_EQ(rules.size(), 4u);
 	EXPECT_EQ(std::get<0>(rules[0]), "2XX");
 	EXPECT_EQ(std::get<1>(rules[0]), "group");
 	EXPECT_EQ(std::get<2>(rules[0]), "610");
 	EXPECT_EQ(std::get<0>(rules[1]), "3XX");
 	EXPECT_EQ(std::get<1>(rules[1]), "page");
+	EXPECT_EQ(std::get<0>(rules[2]), "6*")
+		<< "a trailing-star prefix rule must round-trip the form body verbatim";
+	EXPECT_EQ(std::get<0>(rules[3]), "#9")
+		<< "a '#' pattern must survive url-decoding as the literal character";
 
 	// The rule table is readable back out of /api/status, in table order.
 	std::string status = httpGetRaw(18090, "/api/status");
@@ -852,11 +864,13 @@ TEST(DialPlanHttp, PostApiDialPlanUpsertsAndDeletesThroughTheAdminSurface)
 	EXPECT_NE(second, std::string::npos);
 	EXPECT_LT(first, second) << "/api/status must emit the plan in evaluation order";
 
-	// An empty target deletes.
+	// An empty target deletes — including a pattern carrying a wildcard.
 	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan", "pattern=2XX&target=")), 200);
+	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan", "pattern=6*&target=")), 200);
 	rules = handler.getDialRules();
-	ASSERT_EQ(rules.size(), 1u);
+	ASSERT_EQ(rules.size(), 2u);
 	EXPECT_EQ(std::get<0>(rules[0]), "3XX");
+	EXPECT_EQ(std::get<0>(rules[1]), "#9");
 }
 
 TEST(DialPlanHttp, PostApiDialPlanRejectsBadParametersWith400)

--- a/tests/DialPlan_test.cpp
+++ b/tests/DialPlan_test.cpp
@@ -1,0 +1,888 @@
+// DialPlan_test.cpp — Issue #69: the bounded, table-driven pattern → action dial
+// plan that generalizes the ring-group mechanism.
+//
+// Three properties the feature lives or dies by, and one refactor guard:
+//
+//   1. PATTERN PRECEDENCE — rules are evaluated in TABLE ORDER and the first
+//      match wins. Order is the operator's, not a specificity heuristic: a
+//      catch-all listed first really does shadow the exact rule below it. That
+//      is easy to "helpfully" break later by sorting most-specific-first, so it
+//      is pinned here from both directions.
+//   2. THE BOUNDED-SIZE CAP — POCKETDIAL_MAX_DIAL_RULES is a hard ceiling on the
+//      table, enforced in DialPlan::upsert() itself (so every entry point
+//      inherits it), asserted here through the pure class AND through
+//      RequestsHandler::setDialRule/getDialRules.
+//   3. FALLTHROUGH — a dialed number no rule matches must route EXACTLY as it did
+//      before #69 existed. Asserted end-to-end through handle(), against a
+//      populated rule table, by observing the wire messages the handler emits.
+//
+// Plus dispatch coverage for each of the three already-shipped actions the plan
+// can select (ring group / hunt, page zone, park orbit), the stale-target 404,
+// and a real-socket round-trip of POST /api/dialplan through HttpServer — the
+// admin config surface, driven the same way AdminHttpGate_test.cpp drives it.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "AdminAuth.hpp"
+#include "DialPlan.hpp"
+#include "HttpServer.hpp"
+#include "PbxConfig.hpp"
+#include "PoolConfig.hpp"
+#include "RequestsHandler.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <WinSock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#endif
+
+#include <chrono>
+#include <thread>
+
+namespace
+{
+	sockaddr_in addrFor(const std::string& ip)
+	{
+		sockaddr_in s{};
+		s.sin_family = AF_INET;
+		s.sin_addr.s_addr = inet_addr(ip.c_str());
+		s.sin_port = htons(5060);
+		return s;
+	}
+
+	std::shared_ptr<SipMessage> makeRegister(const std::string& ext, const std::string& srcIp,
+	                                         const std::string& callId)
+	{
+		std::string raw =
+			"REGISTER sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + srcIp + ":5060;branch=z9hG4bKr" + callId + "\r\n"
+			"From: <sip:" + ext + "@server>;tag=rt" + callId + "\r\n"
+			"To: <sip:" + ext + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 REGISTER\r\n"
+			"Contact: <sip:" + ext + "@" + srcIp + ":5060>;expires=3600\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, addrFor(srcIp));
+	}
+
+	// A minimally-valid INVITE carrying an SDP offer — onInvite()'s ordinary path
+	// requires hasSdp() before it will allocate a session, and the park action
+	// needs a real offer to hold. Same shape as Invite777SessionPool_test.cpp's.
+	std::shared_ptr<SipMessage> makeInvite(const std::string& fromExt, const std::string& toExt,
+	                                       const std::string& srcIp, const std::string& callId)
+	{
+		std::string body =
+			"v=0\r\n"
+			"o=- 0 0 IN IP4 " + srcIp + "\r\n"
+			"s=-\r\n"
+			"c=IN IP4 " + srcIp + "\r\n"
+			"t=0 0\r\n"
+			"m=audio 10000 RTP/AVP 0\r\n"
+			"a=rtpmap:0 PCMU/8000\r\n";
+		std::string raw =
+			"INVITE sip:" + toExt + "@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + srcIp + ":5060;branch=z9hG4bKi" + callId + "\r\n"
+			"From: <sip:" + fromExt + "@server>;tag=ft" + callId + "\r\n"
+			"To: <sip:" + toExt + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Contact: <sip:" + fromExt + "@" + srcIp + ":5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		return RequestsHandler::getMessageFromPool(raw, addrFor(srcIp));
+	}
+
+	// Records every message the handler puts on the wire, so a test can assert on
+	// what a dialed number actually produced rather than on internal state.
+	struct WireLog
+	{
+		std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+
+		std::vector<std::string> raws() const
+		{
+			std::vector<std::string> out;
+			out.reserve(sent.size());
+			for (const auto& [addr, msg] : sent)
+			{
+				(void)addr;
+				out.push_back(msg ? msg->toString() : std::string{});
+			}
+			return out;
+		}
+
+		// True if some emitted message is an INVITE fork aimed at `ext`.
+		bool sawInviteTo(const std::string& ext) const
+		{
+			for (const auto& raw : raws())
+			{
+				if (raw.rfind("INVITE sip:" + ext + "@", 0) == 0) return true;
+			}
+			return false;
+		}
+
+		bool sawContaining(const std::string& needle) const
+		{
+			for (const auto& raw : raws())
+			{
+				if (raw.find(needle) != std::string::npos) return true;
+			}
+			return false;
+		}
+
+		size_t inviteCount() const
+		{
+			size_t n = 0;
+			for (const auto& raw : raws())
+			{
+				if (raw.rfind("INVITE ", 0) == 0) ++n;
+			}
+			return n;
+		}
+
+		void clear() { sent.clear(); }
+	};
+
+	// A handler with 500 (the caller) and 600/601 (two callees) registered.
+	// 500 -> 192.168.9.50, 600 -> 192.168.9.60, 601 -> 192.168.9.61.
+	void registerThreePhones(RequestsHandler& handler)
+	{
+		handler.handle(makeRegister("500", "192.168.9.50", "reg-500"));
+		handler.handle(makeRegister("600", "192.168.9.60", "reg-600"));
+		handler.handle(makeRegister("601", "192.168.9.61", "reg-601"));
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Pattern grammar (pure — DialPlan.hpp only, no registrar linkage needed)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DialPlanPattern, ExactMatchIsExact)
+{
+	EXPECT_TRUE(pbx::dialPatternMatches("601", "601"));
+	EXPECT_FALSE(pbx::dialPatternMatches("601", "602"));
+	EXPECT_FALSE(pbx::dialPatternMatches("601", "6010"));   // longer
+	EXPECT_FALSE(pbx::dialPatternMatches("601", "60"));     // shorter
+	EXPECT_FALSE(pbx::dialPatternMatches("601", ""));
+}
+
+TEST(DialPlanPattern, XMatchesExactlyOneDigit)
+{
+	EXPECT_TRUE(pbx::dialPatternMatches("6XX", "600"));
+	EXPECT_TRUE(pbx::dialPatternMatches("6XX", "699"));
+	EXPECT_TRUE(pbx::dialPatternMatches("6xx", "642"));     // lowercase accepted too
+	EXPECT_FALSE(pbx::dialPatternMatches("6XX", "6001"));   // X is one char, not many
+	EXPECT_FALSE(pbx::dialPatternMatches("6XX", "60"));
+	EXPECT_FALSE(pbx::dialPatternMatches("6XX", "700"));
+	EXPECT_FALSE(pbx::dialPatternMatches("XXX", "6A0"))
+		<< "X means DIGIT, not any character";
+}
+
+TEST(DialPlanPattern, TrailingStarIsAPrefixMatch)
+{
+	EXPECT_TRUE(pbx::dialPatternMatches("6*", "6"));        // zero remaining chars
+	EXPECT_TRUE(pbx::dialPatternMatches("6*", "60"));
+	EXPECT_TRUE(pbx::dialPatternMatches("6*", "601"));
+	EXPECT_TRUE(pbx::dialPatternMatches("6*", "6123456"));
+	EXPECT_FALSE(pbx::dialPatternMatches("6*", "7"));
+	EXPECT_FALSE(pbx::dialPatternMatches("6*", ""));
+}
+
+TEST(DialPlanPattern, LoneStarIsACatchAll)
+{
+	EXPECT_TRUE(pbx::dialPatternMatches("*", "601"));
+	EXPECT_TRUE(pbx::dialPatternMatches("*", "anything"));
+	EXPECT_TRUE(pbx::dialPatternMatches("*", ""));
+}
+
+TEST(DialPlanPattern, NonTrailingStarIsLiteral)
+{
+	// Star-codes (*8, *4887) are real dialable strings on this box, so only a
+	// FINAL '*' is a wildcard — otherwise "*8" could never mean the literal *8.
+	EXPECT_TRUE(pbx::dialPatternMatches("*8", "*8"));
+	EXPECT_FALSE(pbx::dialPatternMatches("*8", "8"));
+	EXPECT_FALSE(pbx::dialPatternMatches("*8", "998"));
+	EXPECT_TRUE(pbx::dialPatternMatches("*8*", "*8"))
+		<< "leading '*' literal, trailing '*' wildcard";
+	EXPECT_TRUE(pbx::dialPatternMatches("*8*", "*812"));
+	EXPECT_FALSE(pbx::dialPatternMatches("*8*", "812"));
+}
+
+TEST(DialPlanPattern, MixedWildcards)
+{
+	EXPECT_TRUE(pbx::dialPatternMatches("2X*", "210"));
+	EXPECT_TRUE(pbx::dialPatternMatches("2X*", "29"));
+	EXPECT_FALSE(pbx::dialPatternMatches("2X*", "2"))
+		<< "the X still needs its one digit before the star absorbs the rest";
+	EXPECT_FALSE(pbx::dialPatternMatches("2X*", "2A1"));
+}
+
+TEST(DialPlanPattern, EmptyPatternNeverMatches)
+{
+	EXPECT_FALSE(pbx::dialPatternMatches("", "601"));
+	EXPECT_FALSE(pbx::dialPatternMatches("", ""));
+}
+
+TEST(DialPlanPattern, ActionNamesRoundTrip)
+{
+	pbx::DialActionType a;
+	ASSERT_TRUE(pbx::parseDialAction("group", a));
+	EXPECT_EQ(a, pbx::DialActionType::RingGroup);
+	EXPECT_STREQ(pbx::dialActionName(a), "group");
+
+	ASSERT_TRUE(pbx::parseDialAction("page", a));
+	EXPECT_EQ(a, pbx::DialActionType::PageZone);
+	EXPECT_STREQ(pbx::dialActionName(a), "page");
+
+	ASSERT_TRUE(pbx::parseDialAction("park", a));
+	EXPECT_EQ(a, pbx::DialActionType::ParkOrbit);
+	EXPECT_STREQ(pbx::dialActionName(a), "park");
+
+	// Unknown names must be REJECTED, not silently defaulted — a corrupt NVS
+	// record must never turn into some action the operator never configured.
+	EXPECT_FALSE(pbx::parseDialAction("pickup", a));
+	EXPECT_FALSE(pbx::parseDialAction("", a));
+	EXPECT_FALSE(pbx::parseDialAction("GROUP", a));
+}
+
+TEST(DialPlanPattern, TokenSafetyRejectsBlobSeparators)
+{
+	// The NVS record is tab/newline delimited; a smuggled separator would corrupt
+	// every rule after it on the next boot, so both fields are charset-checked.
+	EXPECT_TRUE(pbx::isDialTokenSafe("6XX"));
+	EXPECT_TRUE(pbx::isDialTokenSafe("*8#"));
+	EXPECT_FALSE(pbx::isDialTokenSafe("6\tXX"));
+	EXPECT_FALSE(pbx::isDialTokenSafe("6\nXX"));
+	EXPECT_FALSE(pbx::isDialTokenSafe("6 XX"));
+	EXPECT_FALSE(pbx::isDialTokenSafe("6@XX"));
+	EXPECT_FALSE(pbx::isDialTokenSafe(""));
+}
+
+TEST(DialPlanPattern, ParkOrbitExtMatchesThisBuildsSlotCount)
+{
+	EXPECT_TRUE(pbx::isParkOrbitExt("700"));
+	EXPECT_TRUE(pbx::isParkOrbitExt("70" + std::to_string(POCKETDIAL_PARK_SLOTS - 1)));
+	EXPECT_FALSE(pbx::isParkOrbitExt("710"));
+	EXPECT_FALSE(pbx::isParkOrbitExt("70"));
+	EXPECT_FALSE(pbx::isParkOrbitExt("7000"));
+	if (POCKETDIAL_PARK_SLOTS < 10)
+	{
+		EXPECT_FALSE(pbx::isParkOrbitExt("70" + std::to_string(POCKETDIAL_PARK_SLOTS)))
+			<< "an orbit past this build's slot count is not a valid park target";
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Precedence: table order, first match wins
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DialPlanPrecedence, FirstMatchWinsInTableOrder)
+{
+	pbx::DialPlan plan;
+	ASSERT_TRUE(plan.upsert({"601", pbx::DialActionType::RingGroup, "610"}));
+	ASSERT_TRUE(plan.upsert({"6XX", pbx::DialActionType::RingGroup, "620"}));
+
+	const pbx::DialRule* hit = plan.match("601");
+	ASSERT_NE(hit, nullptr);
+	EXPECT_EQ(hit->target, "610") << "the exact rule was listed first, so it wins";
+
+	hit = plan.match("602");
+	ASSERT_NE(hit, nullptr);
+	EXPECT_EQ(hit->target, "620") << "602 only matches the wildcard rule";
+}
+
+TEST(DialPlanPrecedence, OrderNotSpecificityDecides)
+{
+	// The mirror image of the test above: with the WILDCARD listed first, it
+	// shadows the exact rule below it. This is the property that breaks the
+	// moment someone "improves" match() by sorting most-specific-first.
+	pbx::DialPlan plan;
+	ASSERT_TRUE(plan.upsert({"6XX", pbx::DialActionType::RingGroup, "620"}));
+	ASSERT_TRUE(plan.upsert({"601", pbx::DialActionType::RingGroup, "610"}));
+
+	const pbx::DialRule* hit = plan.match("601");
+	ASSERT_NE(hit, nullptr);
+	EXPECT_EQ(hit->target, "620")
+		<< "table order is the semantics: a wildcard placed first shadows the "
+		   "exact rule below it, even though the exact rule is 'more specific'";
+}
+
+TEST(DialPlanPrecedence, CatchAllFirstShadowsEverythingAfterIt)
+{
+	pbx::DialPlan plan;
+	ASSERT_TRUE(plan.upsert({"*", pbx::DialActionType::PageZone, "980"}));
+	ASSERT_TRUE(plan.upsert({"601", pbx::DialActionType::RingGroup, "610"}));
+
+	for (const char* dialed : {"601", "602", "700", "abc"})
+	{
+		const pbx::DialRule* hit = plan.match(dialed);
+		ASSERT_NE(hit, nullptr) << dialed;
+		EXPECT_EQ(hit->target, "980") << dialed;
+	}
+}
+
+TEST(DialPlanPrecedence, EditingARuleKeepsItsPosition)
+{
+	// Changing a rule's action/target must not silently re-order the plan —
+	// re-appending an edited rule would change which numbers it captures.
+	pbx::DialPlan plan;
+	ASSERT_TRUE(plan.upsert({"6XX", pbx::DialActionType::RingGroup, "620"}));
+	ASSERT_TRUE(plan.upsert({"7XX", pbx::DialActionType::RingGroup, "720"}));
+	ASSERT_TRUE(plan.upsert({"6XX", pbx::DialActionType::PageZone, "981"}));
+
+	ASSERT_EQ(plan.size(), 2u) << "an upsert on an existing pattern must not add a row";
+	EXPECT_EQ(plan.rules()[0].pattern, "6XX");
+	EXPECT_EQ(plan.rules()[0].action, pbx::DialActionType::PageZone);
+	EXPECT_EQ(plan.rules()[0].target, "981");
+	EXPECT_EQ(plan.rules()[1].pattern, "7XX");
+}
+
+TEST(DialPlanPrecedence, EraseRemovesOnlyThatRuleAndKeepsOrder)
+{
+	pbx::DialPlan plan;
+	ASSERT_TRUE(plan.upsert({"1XX", pbx::DialActionType::RingGroup, "610"}));
+	ASSERT_TRUE(plan.upsert({"2XX", pbx::DialActionType::RingGroup, "620"}));
+	ASSERT_TRUE(plan.upsert({"3XX", pbx::DialActionType::RingGroup, "630"}));
+
+	EXPECT_TRUE(plan.erase("2XX"));
+	EXPECT_FALSE(plan.erase("2XX")) << "erasing a pattern that is gone reports false";
+	ASSERT_EQ(plan.size(), 2u);
+	EXPECT_EQ(plan.rules()[0].pattern, "1XX");
+	EXPECT_EQ(plan.rules()[1].pattern, "3XX");
+}
+
+TEST(DialPlanPrecedence, NoRuleMatchesReturnsNull)
+{
+	pbx::DialPlan plan;
+	ASSERT_TRUE(plan.upsert({"6XX", pbx::DialActionType::RingGroup, "620"}));
+	EXPECT_EQ(plan.match("500"), nullptr);
+	EXPECT_EQ(plan.match(""), nullptr);
+
+	pbx::DialPlan emptyPlan;
+	EXPECT_EQ(emptyPlan.match("601"), nullptr);
+	EXPECT_TRUE(emptyPlan.empty());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. The bounded-size cap (POCKETDIAL_MAX_DIAL_RULES)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DialPlanCap, UpsertRefusesNewRulesOnceFull)
+{
+	pbx::DialPlan plan;
+	for (int i = 0; i < POCKETDIAL_MAX_DIAL_RULES; ++i)
+	{
+		SCOPED_TRACE(i);
+		ASSERT_TRUE(plan.upsert({"r" + std::to_string(i), pbx::DialActionType::RingGroup, "610"}));
+	}
+	ASSERT_EQ(static_cast<int>(plan.size()), POCKETDIAL_MAX_DIAL_RULES);
+
+	EXPECT_FALSE(plan.upsert({"overflow", pbx::DialActionType::RingGroup, "610"}));
+	EXPECT_EQ(static_cast<int>(plan.size()), POCKETDIAL_MAX_DIAL_RULES)
+		<< "a refused rule must not grow the table";
+	EXPECT_EQ(plan.match("overflow"), nullptr)
+		<< "a refused rule must not be routable either";
+}
+
+TEST(DialPlanCap, FullTableIsStillEditableAndFreeableInPlace)
+{
+	// A hard cap that also made the table read-only would be a trap: the operator
+	// could no longer fix the very rule that filled it.
+	pbx::DialPlan plan;
+	for (int i = 0; i < POCKETDIAL_MAX_DIAL_RULES; ++i)
+	{
+		ASSERT_TRUE(plan.upsert({"r" + std::to_string(i), pbx::DialActionType::RingGroup, "610"}));
+	}
+
+	EXPECT_TRUE(plan.upsert({"r0", pbx::DialActionType::PageZone, "982"}))
+		<< "editing an EXISTING rule is not a growth operation and must succeed at cap";
+	EXPECT_EQ(static_cast<int>(plan.size()), POCKETDIAL_MAX_DIAL_RULES);
+	EXPECT_EQ(plan.rules()[0].target, "982");
+
+	// Freeing one slot lets exactly one new rule in again.
+	ASSERT_TRUE(plan.erase("r0"));
+	EXPECT_TRUE(plan.upsert({"fresh", pbx::DialActionType::RingGroup, "610"}));
+	EXPECT_FALSE(plan.upsert({"fresh2", pbx::DialActionType::RingGroup, "610"}));
+}
+
+TEST(DialPlanCap, SetDialRuleEnforcesTheCapThroughTheHandler)
+{
+	// The same ceiling, observed through the public config API + dashboard getter
+	// the HTTP admin surface uses — not just the pure class.
+	RequestsHandler handler("192.168.9.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+
+	for (int i = 0; i < POCKETDIAL_MAX_DIAL_RULES; ++i)
+	{
+		handler.setDialRule("9" + std::to_string(100 + i), "group", "610");
+	}
+	ASSERT_EQ(static_cast<int>(handler.getDialRules().size()), POCKETDIAL_MAX_DIAL_RULES);
+
+	handler.setDialRule("overflow1", "group", "610");
+	handler.setDialRule("overflow2", "page", "980");
+	EXPECT_EQ(static_cast<int>(handler.getDialRules().size()), POCKETDIAL_MAX_DIAL_RULES)
+		<< "setDialRule must drop rules past POCKETDIAL_MAX_DIAL_RULES";
+
+	// Deleting one frees exactly one slot.
+	handler.setDialRule("9100", "", "");
+	ASSERT_EQ(static_cast<int>(handler.getDialRules().size()), POCKETDIAL_MAX_DIAL_RULES - 1);
+	handler.setDialRule("overflow3", "group", "610");
+	EXPECT_EQ(static_cast<int>(handler.getDialRules().size()), POCKETDIAL_MAX_DIAL_RULES);
+}
+
+TEST(DialPlanCap, HandlerGetterReportsRulesInTableOrder)
+{
+	RequestsHandler handler("192.168.9.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+
+	handler.setDialRule("1XX", "group", "610");
+	handler.setDialRule("2XX", "page", "981");
+	handler.setDialRule("3XX", "park", "701");
+
+	auto rules = handler.getDialRules();
+	ASSERT_EQ(rules.size(), 3u);
+	EXPECT_EQ(std::get<0>(rules[0]), "1XX");
+	EXPECT_EQ(std::get<1>(rules[0]), "group");
+	EXPECT_EQ(std::get<2>(rules[0]), "610");
+	EXPECT_EQ(std::get<0>(rules[1]), "2XX");
+	EXPECT_EQ(std::get<1>(rules[1]), "page");
+	EXPECT_EQ(std::get<0>(rules[2]), "3XX");
+	EXPECT_EQ(std::get<1>(rules[2]), "park");
+	EXPECT_EQ(std::get<2>(rules[2]), "701");
+
+	// tick() rebuilds the snapshot wholesale; the order must survive that swap.
+	handler.tick();
+	auto afterTick = handler.getDialRules();
+	ASSERT_EQ(afterTick.size(), 3u);
+	EXPECT_EQ(std::get<0>(afterTick[0]), "1XX");
+	EXPECT_EQ(std::get<0>(afterTick[1]), "2XX");
+	EXPECT_EQ(std::get<0>(afterTick[2]), "3XX");
+}
+
+TEST(DialPlanCap, SetDialRuleRejectsMalformedRules)
+{
+	RequestsHandler handler("192.168.9.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+
+	handler.setDialRule("6\tXX", "group", "610");        // tab would corrupt the NVS blob
+	handler.setDialRule("6XX", "group", "61\n0");        // …and so would a newline
+	handler.setDialRule("6XX", "pickup", "610");         // unknown action (#68 is not on main)
+	handler.setDialRule("6XX", "page", "601");           // page target is not a 98x zone
+	handler.setDialRule("6XX", "park", "799");           // park target is not an orbit
+	handler.setDialRule("777", "group", "610");          // reserved: routed before the plan
+	handler.setDialRule("999", "group", "610");
+	handler.setDialRule("440", "group", "610");
+
+	EXPECT_TRUE(handler.getDialRules().empty())
+		<< "every malformed rule above must be dropped, not stored";
+
+	// …and the valid shapes of each still land.
+	handler.setDialRule("6XX", "page", "981");
+	handler.setDialRule("7XX", "park", "701");
+	EXPECT_EQ(handler.getDialRules().size(), 2u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Fallthrough: an unmatched number routes exactly as it did before #69
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DialPlanRouting, UnmatchedNumberFallsThroughToNormalExtensionRouting)
+{
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+
+	// A populated, non-empty table — so this is really testing "no rule matched",
+	// not "the dial plan is switched off".
+	handler.setRingGroup("610", "600,601", "ringall");
+	handler.setDialRule("2XX", "group", "610");
+	handler.setDialRule("3*", "page", "980");
+	ASSERT_EQ(handler.getDialRules().size(), 2u);
+
+	wire.clear();
+	handler.handle(makeInvite("500", "600", "192.168.9.50", "fallthrough-1"));
+
+	EXPECT_TRUE(wire.sawInviteTo("600"))
+		<< "600 matches no rule, so it must ring the ordinary way";
+	EXPECT_FALSE(wire.sawInviteTo("601"))
+		<< "it must NOT have been fanned out as if it were the 610 group";
+	EXPECT_EQ(wire.inviteCount(), 1u) << "exactly one leg, as before #69";
+	EXPECT_FALSE(wire.sawContaining("404 Not Found"));
+	EXPECT_FALSE(wire.sawContaining("480 Temporarily Unavailable"));
+}
+
+TEST(DialPlanRouting, UnmatchedUnknownNumberStill404s)
+{
+	// The other half of "no behavior change": an unmatched number that is not a
+	// real extension must still get the pre-#69 answer, not a dial-plan error.
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+	handler.setRingGroup("610", "600,601", "ringall");
+	handler.setDialRule("2XX", "group", "610");
+
+	wire.clear();
+	handler.handle(makeInvite("500", "888", "192.168.9.50", "fallthrough-2"));
+
+	EXPECT_TRUE(wire.sawContaining("404 Not Found"));
+	EXPECT_EQ(wire.inviteCount(), 0u);
+}
+
+TEST(DialPlanRouting, ReservedCodesAreRoutedBeforeThePlanCanSeeThem)
+{
+	// A catch-all rule must not be able to swallow the built-in virtual
+	// extensions — that is what makes the plan safe to add to a live box.
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+	handler.setPageZone("980", "600");
+	handler.setDialRule("*", "page", "980");
+	ASSERT_EQ(handler.getDialRules().size(), 1u);
+
+	wire.clear();
+	handler.handle(makeInvite("500", "777", "192.168.9.50", "reserved-777"));
+	EXPECT_TRUE(wire.sawContaining("SIP/2.0 200 OK"))
+		<< "777 must still be the SDP echo test, not a page";
+	EXPECT_FALSE(wire.sawInviteTo("600"));
+
+	// …and a configured ring-group extension likewise resolves as itself.
+	handler.setRingGroup("610", "600,601", "ringall");
+	wire.clear();
+	handler.handle(makeInvite("500", "610", "192.168.9.50", "reserved-610"));
+	EXPECT_TRUE(wire.sawInviteTo("600"));
+	EXPECT_TRUE(wire.sawInviteTo("601"))
+		<< "610 is a real group, so it fans out as a group — the catch-all page "
+		   "rule must not have intercepted it";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. Dispatch into each already-shipped action
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DialPlanRouting, GroupActionFansOutTheRingGroup)
+{
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+	handler.setRingGroup("610", "600,601", "ringall");
+	handler.setDialRule("2XX", "group", "610");
+
+	wire.clear();
+	handler.handle(makeInvite("500", "250", "192.168.9.50", "plan-group"));
+
+	EXPECT_TRUE(wire.sawInviteTo("600"));
+	EXPECT_TRUE(wire.sawInviteTo("601"));
+	EXPECT_TRUE(wire.sawContaining("180 Ringing"));
+	EXPECT_FALSE(wire.sawContaining("P-Auto-Answer"))
+		<< "a ring group rings normally — the intercom headers are the 999/page path";
+}
+
+TEST(DialPlanRouting, GroupActionInHuntModeRingsOneMemberAtATime)
+{
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+	handler.setRingGroup("620", "600,601", "hunt");
+	handler.setDialRule("2XX", "group", "620");
+
+	wire.clear();
+	handler.handle(makeInvite("500", "222", "192.168.9.50", "plan-hunt"));
+
+	EXPECT_EQ(wire.inviteCount(), 1u) << "hunt rings members sequentially, one at a time";
+	EXPECT_TRUE(wire.sawInviteTo("600"));
+	EXPECT_FALSE(wire.sawInviteTo("601"));
+	EXPECT_TRUE(wire.sawContaining("180 Ringing"));
+
+	// The session must carry the REAL group extension, not the dialed alias —
+	// getGroupExt() feeds the hunt-exhausted CDR and the no-answer Contact.
+	auto session = handler.getSession("Call-ID: plan-hunt");
+	ASSERT_TRUE(session.has_value());
+	EXPECT_EQ(session.value()->getGroupExt(), "620")
+		<< "a dial-rule alias must not leak into the session's group identity";
+}
+
+TEST(DialPlanRouting, PageActionForksTheZoneWithIntercomHeaders)
+{
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+	handler.setPageZone("981", "600,601");
+	handler.setDialRule("55", "page", "981");
+
+	wire.clear();
+	handler.handle(makeInvite("500", "55", "192.168.9.50", "plan-page"));
+
+	EXPECT_TRUE(wire.sawInviteTo("600"));
+	EXPECT_TRUE(wire.sawInviteTo("601"));
+	EXPECT_TRUE(wire.sawContaining("P-Auto-Answer"))
+		<< "a zone page is an intercom fork — auto-answer headers must be present";
+}
+
+TEST(DialPlanRouting, ParkActionParksTheCallerOnTheOrbit)
+{
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+	handler.setDialRule("8XX", "park", "701");
+
+	wire.clear();
+	handler.handle(makeInvite("500", "800", "192.168.9.50", "plan-park"));
+
+	EXPECT_TRUE(wire.sawContaining("SIP/2.0 200 OK"));
+	EXPECT_TRUE(wire.sawContaining("a=inactive"))
+		<< "parking answers with the hold SDP, exactly as dialing 701 directly does";
+	EXPECT_TRUE(wire.sawContaining("sip:701@"))
+		<< "the answer's Contact must name the orbit the rule targeted";
+}
+
+TEST(DialPlanRouting, MatchedRuleWithAStaleTargetAnswers404NotAMisroutedCall)
+{
+	// The rule matched, so the plan owns the call — but its group was deleted
+	// after the rule was written. Falling through here would ring whichever real
+	// extension happens to share the dialed digits, i.e. connect the caller to
+	// the wrong person. A 404 is the diagnosable answer.
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	registerThreePhones(handler);
+	handler.setRingGroup("610", "600,601", "ringall");
+	handler.setDialRule("6XX", "group", "610");
+
+	handler.setRingGroup("610", "", "ringall");        // group deleted, rule left behind
+	ASSERT_TRUE(handler.getRingGroups().empty());
+	ASSERT_EQ(handler.getDialRules().size(), 1u);
+
+	wire.clear();
+	handler.handle(makeInvite("500", "600", "192.168.9.50", "plan-stale"));
+
+	EXPECT_TRUE(wire.sawContaining("404 Not Found"));
+	EXPECT_FALSE(wire.sawInviteTo("600"))
+		<< "a stale rule must not silently fall through and ring extension 600";
+}
+
+TEST(DialPlanRouting, GroupActionAnswers480WhenNoMemberIsRegistered)
+{
+	// The rule and its group are both fine; the members just aren't online. This
+	// is the group path's own pre-existing answer, reached through the dial plan.
+	WireLog wire;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&wire](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			wire.sent.emplace_back(addr, std::move(msg));
+		});
+	handler.handle(makeRegister("500", "192.168.9.50", "reg-500"));
+	handler.setRingGroup("610", "700,701", "ringall");   // never-registered members
+	handler.setDialRule("2XX", "group", "610");
+
+	wire.clear();
+	handler.handle(makeInvite("500", "250", "192.168.9.50", "plan-offline"));
+
+	EXPECT_TRUE(wire.sawContaining("480 Temporarily Unavailable"));
+	EXPECT_EQ(wire.inviteCount(), 0u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. The HTTP admin config surface (real socket round-trip through HttpServer)
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace
+{
+	// Minimal blocking HTTP POST over a raw socket, mirroring
+	// AdminHttpGate_test.cpp's helper. No Origin header → treated as a direct
+	// request by isSameOrigin(), which is what curl/the dashboard's own fetch do.
+	std::string httpPostRaw(int port, const std::string& path, const std::string& body)
+	{
+#if defined(_WIN32) || defined(_WIN64)
+		SOCKET s = socket(AF_INET, SOCK_STREAM, 0);
+		if (s == INVALID_SOCKET) return "";
+#else
+		int s = socket(AF_INET, SOCK_STREAM, 0);
+		if (s < 0) return "";
+#endif
+		sockaddr_in addr{};
+		addr.sin_family = AF_INET;
+		addr.sin_port = htons(static_cast<uint16_t>(port));
+		inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+		if (connect(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+		{
+#if defined(_WIN32) || defined(_WIN64)
+			closesocket(s);
+#else
+			close(s);
+#endif
+			return "";
+		}
+		std::string req = "POST " + path + " HTTP/1.1\r\n"
+			"Host: 127.0.0.1\r\n"
+			"Content-Type: application/x-www-form-urlencoded\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n"
+			"Connection: close\r\n\r\n" + body;
+		send(s, req.c_str(), static_cast<int>(req.size()), 0);
+
+		std::string resp;
+		char buf[2048];
+		for (;;)
+		{
+			int n = recv(s, buf, sizeof(buf), 0);
+			if (n <= 0) break;
+			resp.append(buf, static_cast<size_t>(n));
+		}
+#if defined(_WIN32) || defined(_WIN64)
+		closesocket(s);
+#else
+		close(s);
+#endif
+		return resp;
+	}
+
+	int statusOf(const std::string& resp)
+	{
+		size_t sp1 = resp.find(' ');
+		if (sp1 == std::string::npos) return -1;
+		size_t sp2 = resp.find(' ', sp1 + 1);
+		if (sp2 == std::string::npos) return -1;
+		return std::atoi(resp.substr(sp1 + 1, sp2 - sp1 - 1).c_str());
+	}
+
+	std::string httpGetRaw(int port, const std::string& path)
+	{
+#if defined(_WIN32) || defined(_WIN64)
+		SOCKET s = socket(AF_INET, SOCK_STREAM, 0);
+		if (s == INVALID_SOCKET) return "";
+#else
+		int s = socket(AF_INET, SOCK_STREAM, 0);
+		if (s < 0) return "";
+#endif
+		sockaddr_in addr{};
+		addr.sin_family = AF_INET;
+		addr.sin_port = htons(static_cast<uint16_t>(port));
+		inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+		if (connect(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+		{
+#if defined(_WIN32) || defined(_WIN64)
+			closesocket(s);
+#else
+			close(s);
+#endif
+			return "";
+		}
+		std::string req = "GET " + path + " HTTP/1.1\r\n"
+			"Host: 127.0.0.1\r\n"
+			"Connection: close\r\n\r\n";
+		send(s, req.c_str(), static_cast<int>(req.size()), 0);
+
+		std::string resp;
+		char buf[4096];
+		for (;;)
+		{
+			int n = recv(s, buf, sizeof(buf), 0);
+			if (n <= 0) break;
+			resp.append(buf, static_cast<size_t>(n));
+		}
+#if defined(_WIN32) || defined(_WIN64)
+		closesocket(s);
+#else
+		close(s);
+#endif
+		return resp;
+	}
+}
+
+TEST(DialPlanHttp, PostApiDialPlanUpsertsAndDeletesThroughTheAdminSurface)
+{
+	AdminAuth::clearCredential();   // unprovisioned → same-origin gate only
+
+	RequestsHandler handler("192.168.9.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	HttpServer server("127.0.0.1", 18090, nullptr);
+	server.attachHandler(&handler);
+	server.start();
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan",
+		"pattern=2XX&action=group&target=610")), 200);
+	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan",
+		"pattern=3XX&action=page&target=981")), 200);
+
+	auto rules = handler.getDialRules();
+	ASSERT_EQ(rules.size(), 2u);
+	EXPECT_EQ(std::get<0>(rules[0]), "2XX");
+	EXPECT_EQ(std::get<1>(rules[0]), "group");
+	EXPECT_EQ(std::get<2>(rules[0]), "610");
+	EXPECT_EQ(std::get<0>(rules[1]), "3XX");
+	EXPECT_EQ(std::get<1>(rules[1]), "page");
+
+	// The rule table is readable back out of /api/status, in table order.
+	std::string status = httpGetRaw(18090, "/api/status");
+	EXPECT_NE(status.find("\"dialplan\":["), std::string::npos);
+	size_t first = status.find("\"pattern\":\"2XX\"");
+	size_t second = status.find("\"pattern\":\"3XX\"");
+	EXPECT_NE(first, std::string::npos);
+	EXPECT_NE(second, std::string::npos);
+	EXPECT_LT(first, second) << "/api/status must emit the plan in evaluation order";
+
+	// An empty target deletes.
+	EXPECT_EQ(statusOf(httpPostRaw(18090, "/api/dialplan", "pattern=2XX&target=")), 200);
+	rules = handler.getDialRules();
+	ASSERT_EQ(rules.size(), 1u);
+	EXPECT_EQ(std::get<0>(rules[0]), "3XX");
+}
+
+TEST(DialPlanHttp, PostApiDialPlanRejectsBadParametersWith400)
+{
+	AdminAuth::clearCredential();
+
+	RequestsHandler handler("192.168.9.1", 5060,
+		[](const sockaddr_in&, std::shared_ptr<SipMessage>) {});
+	HttpServer server("127.0.0.1", 18091, nullptr);
+	server.attachHandler(&handler);
+	server.start();
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	EXPECT_EQ(statusOf(httpPostRaw(18091, "/api/dialplan", "action=group&target=610")), 400)
+		<< "missing pattern";
+	EXPECT_EQ(statusOf(httpPostRaw(18091, "/api/dialplan",
+		"pattern=2XX&action=pickup&target=610")), 400) << "unknown action";
+	EXPECT_EQ(statusOf(httpPostRaw(18091, "/api/dialplan",
+		"pattern=2XX&action=page&target=601")), 400) << "page target is not a 98x zone";
+	EXPECT_EQ(statusOf(httpPostRaw(18091, "/api/dialplan",
+		"pattern=2XX&action=park&target=799")), 400) << "park target is not an orbit";
+	EXPECT_EQ(statusOf(httpPostRaw(18091, "/api/dialplan",
+		"pattern=777&action=group&target=610")), 400) << "reserved extension as a pattern";
+	EXPECT_EQ(statusOf(httpPostRaw(18091, "/api/dialplan",
+		"pattern=2%20XX&action=group&target=610")), 400) << "unsafe character in pattern";
+
+	EXPECT_TRUE(handler.getDialRules().empty())
+		<< "no rejected request may have reached the rule table";
+}


### PR DESCRIPTION
Resolves ISSUES.md tracker issue #69 (see the numbering note below) -- the GitHub `Closes` keyword is deliberately not used since GitHub issue #69 is an unrelated, already-closed item.

Extends the existing ring-group mechanism (`setRingGroup`/`getRingGroups`) into a small, bounded, table-driven **pattern → action** dial plan for LAN routing.

> **Note on issue numbering:** this is **ISSUES.md #69** ("[Feature] Dial-Plan / Hunt-Group Generalization", Feature-Parity Backlog), not GitHub issue 69 (a closed CodeQL autofix suggestion).

## What's here

**`src/SIP/DialPlan.hpp`** (new, pure/header-only, shaped like `PbxConfig.hpp`) — an action enum, a `DialRule` record, a pure matcher, and an ordered `DialPlan` container. Being pure means the grammar, the precedence rule and the size cap are unit-testable without linking the registrar.

**Pattern grammar** — deliberately tiny, no regex, O(pattern length):

| Token | Meaning |
| :--- | :--- |
| digits / letters / `#` / `*` | literal |
| `X` or `x` | exactly one digit |
| a **trailing** `*` | the rest of the number, including nothing (prefix match) |

A `*` in any other position is a **literal** `*` — star-codes (`*8`, `*4887`) are real dialable strings on this box, so treating a leading star as a wildcard would have made `*8*` ambiguous with the codes it sits beside.

**Evaluation** is in table order, first match wins. Order is the operator's, not a specificity heuristic: a catch-all listed first really does shadow the exact rule below it. Editing an existing pattern updates it **in place** rather than re-appending, since moving a rule changes which numbers it captures.

**Actions** are the three already on `main`: ring/hunt **group**, **page** zone (#66), **park** orbit (#65). #68's directed pickup is not merged and is deliberately absent — adding it later is one enum value, one name string and one dispatch arm.

## Why it's additive, not a behavior change

The plan is consulted **after** every reserved virtual extension (`777`, `999`, the `980`–`989` zones, `440`, the `700`–`70N` orbits) and after the direct ring-group lookup, and **before** CFU/DND/extension lookup. So a rule can only ever intercept a number that would otherwise have reached the ordinary extension lookup — no rule, not even a catch-all `*`, can shadow the echo test, a park retrieval, or a configured group. An unmatched number routes exactly as before; this is asserted end-to-end against a *populated* table, so the test proves "no rule matched" rather than "the feature is off".

## Bounded

`POCKETDIAL_MAX_DIAL_RULES` = **16** (`src/SIP/PoolConfig.hpp`, documented there: the cap bounds both the table's memory and the per-INVITE linear walk on the SIP packet path). Enforced inside `DialPlan::upsert()` so every entry point inherits it — the HTTP setter and the NVS replay, which means a blob written by a build with a larger cap stops being applied at this build's ceiling instead of overflowing it. A full table stays **editable**: an upsert on an existing pattern is not a growth operation, so the operator can always fix the rule that filled it.

## Refactor (no functional change)

`onInvite()`'s 98x page-zone and ring-group bodies were lifted verbatim into `routePageZone()` / `routeRingGroup()`, now called from both the built-in dial codes and the dial plan. `routeRingGroup()` takes the group extension **explicitly** rather than reading it off the INVITE's To-number: under a dial rule those differ, and `Session::setGroupExt()` feeds the hunt-exhausted CDR and the no-answer Contact, both of which want the group's identity, not the alias.

## Hardening

- Pattern and target are charset-validated (`[0-9A-Za-z#*]`) at config time in **both** `setDialRule()` and the HTTP handler — the persisted record is tab/newline delimited, and a smuggled separator would corrupt every rule after it on the next boot.
- `777`/`999`/`440` are refused as literal patterns (they route before the plan, so such a rule could never fire) — a `400`, not a silently dead entry.
- A matched rule whose target no longer resolves (group/zone deleted after the rule was written) answers **`404`** rather than falling through. Falling through would silently ring whichever real extension happens to share the dialed digits — a mis-routed call — whereas a stale rule failing loudly is diagnosable from one response.

## Admin surface

`POST /api/dialplan` (`pattern` / `action` / `target`; empty `target` deletes) behind the same same-origin + `pd_session` gate as `/api/group`, with the table echoed back in `GET /api/status` under `dialplan` in evaluation order. NVS-persisted under key `dplan`, in table order (order is the semantics).

## Verification

- MSVC Release host build clean; **233/233** host tests (32 new), via the exe directly **and** `ctest --test-dir build/tests -C Release`.
- CI's exact pinned **cppcheck 2.21.0** invocation over `src/ main/`: clean, `EXIT=0`.
- GCC `-std=c++17 -Wall -Wextra -fsyntax-only` clean on every changed TU (Linux/WSL), and `DialPlan.hpp` compiles + runs standalone.

`tests/DialPlan_test.cpp` covers: grammar; precedence from **both** directions (exact-first wins, *and* wildcard-first shadows the exact rule below it — the property a well-meaning "sort most-specific-first" refactor would quietly delete); the cap through the pure class *and* through `setDialRule`/`getDialRules`; fallthrough driven through `handle()`; dispatch into each of the three actions; the stale-target `404`; and a real-socket round-trip of `POST /api/dialplan` through `HttpServer`, including `*`/`#` patterns surviving the form body.

## For the reviewer

- **`persistDialPlan()` and the `dplan` replay in `loadPbxConfig()` are `ESP_PLATFORM`-gated**, so the host suite never compiles them. They mirror the `pzones` idioms line-for-line and cppcheck parsed them, but their first real compile is the post-merge glolab CI verification workflow.
- **A matched rule intercepts before CFU/DND.** A rule covering a real extension's number therefore bypasses that extension's DND/forward config. That is intended — it is the feature — but it is the one behavior that could be mistaken for a bug.
- **Ring-all via an alias** stamps the *dialed alias* (not the group ext) in the 180's `Contact`, because `startBroadcastFork` uses the INVITE's To-number. Harmless — only a 2xx refreshes a dialog target — but worth a look if you disagree.
- Unrelated observation: `AdminHttpGate.Trigger_ExpiresAfterTtl_ClosesAutomatically` flaked once for me under heavy concurrent load. It leaves ~50 ms of margin against the accept loop's 250 ms poll cadence. Pre-existing and untouched here (9 clean full-suite runs on this branch; 6 clean with all `DialPlan*` tests excluded), but it may be worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3ufrZzhv4XLWC6DHQ243

