### PR TITLE
Implement directed and group call pickup (Issue #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,47 @@ firmware build clean.
   `POCKETDIAL_CONF_LEGS` added to `PoolConfig.hpp`. The PIE vector path
   (`POCKETDIAL_MIXBUS_PIE`, `src/SIP/pie/`) is untouched and still opt-in.
 
+## Unreleased (issue-68-call-pickup) - 2026-08-28
+
+### Added — Directed (`**<ext>`) and group (`*8`) call pickup (#68)
+
+- New virtual dial codes, intercepted in `onInvite` alongside the existing
+  700-709 park orbits and 980-989 page zones: `*8` answers the **oldest**
+  ringing call among the picker's ring-group co-members; `**<ext>` answers a
+  **named** extension's ringing call. Both are restricted to the picker's own
+  pickup group — pickup groups are **reused ring-group membership**
+  (`setRingGroup`/`getRingGroups`), not a new config table: two extensions are
+  pickup-eligible for each other iff they're both members of the same ring
+  group (see `PbxConfig.hpp`'s `isGroupPickupCode`/`directedPickupTarget` doc
+  comment for the rationale).
+- Picking up a call completes the caller's still-open INVITE transaction with
+  the picker's SDP as the answer, answers the picker's own INVITE with the
+  caller's original SDP, and CANCELs every other still-ringing fork of that
+  call (the whole target, not just one leg, for a ring-all/hunt group pickup).
+  The two resulting dialogs (different Call-IDs) are bridged via
+  `Session::peerCallID`, whose relay `onBye()` now actually implements
+  (reusing #72's empty-From/To guard so a session with no captured dialog
+  headers is skipped rather than sent a malformed BYE) — previously set by
+  `ParkOrbit`'s retrieve/ring-back paths but never wired up, so a hangup on
+  either bridged leg now also cleans up Park's retrieved-call session
+  bookkeeping (CDR, pool slot) instead of leaking it; Park doesn't capture
+  dialog headers yet, so its bridged peer still doesn't get a wire BYE.
+- Race handling: `onOk()` now drops a late 200 OK from a call's
+  already-superseded (CANCELed) fork instead of resurrecting/stealing an
+  already-connected session — a CANCEL and a 2xx can legally cross on the
+  wire. Whichever side answers first wins; the other gets `486 Busy Here` (no
+  ringing call to pick up) or is CANCELed, never both.
+- `RequestsHandler::onInvite`'s direct (non-group) call path now always
+  retains the original INVITE on its `Session` (previously only when a
+  conditional forward was configured) — needed so pickup can tell which
+  extension a direct call is ringing without answering it first.
+- New tests: `tests/CallPickup_test.cpp` (directed pickup, group pickup
+  picking the oldest ringing call, the race in both directions, the
+  cross-dialog BYE bridge teardown, and a Park-retrieve BYE confirming the
+  #72-style guard prevents a malformed empty-header BYE) and
+  `tests/Pbx_test.cpp` (the pure `isGroupPickupCode`/`directedPickupTarget`
+  parsers).
+
 ## Unreleased (issue-106-104-108-112-misc-bugs) - 2026-08-19
 
 Four small, independently-filed correctness bugs plus one CI hygiene fix,

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -43,12 +43,6 @@ signaling and tracks state. See **Non-Goals** below for the hard scope boundary.
 * **Acceptance**: a phone subscribed to ext X gets NOTIFY on X ringing/answered/idle; subscription table is capacity-capped; expiry refresh handled; no unbounded fan-out. A real-hardware smoke-test pass on a BLF-capable phone is tracked separately above (`hardware-testing` label).
 * **Notes**: Promotes `FEATURE_ROADMAP.md` P2 "BLF / presence." Pairs with provisioning (BLF keys are provisionable).
 
-### 🔵 Issue #68: [Feature] Directed Call Pickup (pickup groups)
-* **Status**: ⏳ Open / Planned (Backlog)
-* **Labels**: `feature`, `sip`, `call-control`
-* **Description**: Answer a ringing peer's call from your own phone via a pickup code (`*8` group pickup or `**<ext>` directed). Reuses the fork/`Session` machinery and the registrar's view of in-progress INVITEs; the call lands P2P on the picker — no server media.
-* **Acceptance**: while ext A rings, ext B dials the pickup code and connects to the caller with P2P SDP; only same-pickup-group calls eligible; race with A answering resolves cleanly (one wins, other `486`/cancel).
-
 ### ⚪ Non-Goals (hard scope boundary)
 pocket-dial's default call path stays **LAN-only, peer-to-peer media** — every feature above is
 signaling-only and needs none of the below. **Out of scope, intentionally not implemented here:**
@@ -218,6 +212,25 @@ the N conference `RtpSender`s share the fixed server media port, so the first bi
 fall back to ephemeral source ports. Note that #75 is one of the entries where this tracker's
 numbering has diverged from GitHub's — GitHub issue 75 is an unrelated, closed Phase-1 item. Full
 detail: https://github.com/GlomarGadaffi/pocket-dial/pull/124
+
+---
+
+### 🟢 Issue #68: [Feature] Directed Call Pickup (pickup groups)
+* **Status**: ✅ Resolved 2026-08-28 (`*8` group pickup, `**<ext>` directed pickup)
+* **Labels**: `feature`, `sip`, `call-control`
+
+#### Resolution
+Implemented as a new virtual-extension intercept in `onInvite`, following the exact `onParkInvite` (#65) / `isPageZoneExt`/`findPageZone` (#66) pattern: `*8` and `**<ext>` are dialed as the To user-part of an INVITE, just like the `700`-`709` park orbits and `980`-`989` page zones (`isValidAor` already allowed `*` in an AOR for this reason).
+
+**Pickup groups reuse ring-group membership as-is** — a deliberate reuse, not a new config table. Two extensions are pickup-eligible for each other iff `setRingGroup`/`getRingGroups` already has them as co-members of the same group (RingAll or Hunt; pickup only cares who's in the list, not how it rings). An operator who already set up a "sales" or "support" ring group gets a pickup group for free, with no new dashboard/NVS surface to add or keep in sync. Both `*8` and `**<ext>` are restricted to the picker's own group — the acceptance criteria ("only same-pickup-group calls eligible") don't carve out directed pickup, so an unrestricted-directed-pickup design (closer to some commercial PBXes) was considered and rejected in favor of matching the written criteria exactly.
+
+Picking up a call: `RequestsHandler::findRingingSessionAmong` scans `_sessions` for the oldest `Invited` session ringing one of the eligible candidate extensions (a direct call's target comes from its now-always-retained original INVITE; a broadcast/ring-all/hunt call's from its `pendingTargets`). `onPickup` then draws the picker's `Session` and both 200 OK messages *before* any mutation (the pool-exhaustion discipline `#101A`/`#71` established), completes the caller's still-open INVITE transaction with the picker's SDP as the answer, answers the picker's own INVITE with the caller's original SDP, and sends a CANCEL to every other still-ringing fork of that call (`buildCancel`, already used by the hunt-group timeout path) — picking up any one member of a ring-all/hunt group ends the whole group ring, exactly like a normal answer does.
+
+The two resulting SIP dialogs (different Call-IDs — the picker dialed a brand-new INVITE) are bridged via `Session::peerCallID` + `setDialogHeaders`, mirroring the pattern `sweepSessionTimers` already uses to BYE both legs of a single session, generalized across two. `onBye` gained a `peerCallID`-aware branch: a hangup on either bridged leg is translated into a freshly-built, correctly-addressed BYE on the *other* leg's own dialog (`buildServerBye`) rather than a raw relay, which would carry the wrong Call-ID and get rejected `481` by the peer's phone. The branch reuses #72's exact guard (skip a BYE built from an empty From/To rather than emit the malformed packet #72 was filed against) — `ParkOrbit`'s retrieve/ring-back paths also set `peerCallID` but never call `setDialogHeaders()`, so this relay is a no-op for them today; a park leg still gets the `endCall()`/CDR cleanup, just not a peer-phone BYE, which is strictly better than the previous behavior (a stray BYE 404'd back at the sender) without pickup's PR reaching into park's own state machine to wire up headers it doesn't otherwise need.
+
+**The race** ("whichever side answers first wins, the other never both connects"): `onOk` now drops a late 200 OK for a session that's already connected to someone else (state no longer `Invited`, and the responder isn't the already-connected `dest`) instead of blindly overwriting the winner — a CANCEL and a 2xx can legally cross on the wire per RFC 3261. Losing the race gets `486 Busy Here` in both directions: the target answering first leaves pickup nothing to find (486, target's dest untouched); pickup answering first and then a late answer from the CANCELed fork is silently dropped (matches the existing precedent for a post-connect broadcast answer).
+
+New tests: `tests/CallPickup_test.cpp` — directed pickup (target CANCELed, swapped-SDP 200 OKs, both sessions bridged), group pickup (oldest ringing call wins, the newer one is left alone), a non-peer picker (486, target undisturbed), the race in both directions, the cross-dialog BYE bridge teardown (asserted at the wire level: the picker's BYE carries the *picker's own* Call-ID, never the caller's), and a Park-retrieve BYE pinning the #72-style guard (session cleanup happens, but no malformed empty-header BYE is ever sent). Plus `tests/Pbx_test.cpp` coverage for the pure `isGroupPickupCode`/`directedPickupTarget` parsers. Host-tested (211 tests passing, one pre-existing unrelated timing-flaky `AdminHttpGate` test excluded).
 
 ---
 

--- a/src/SIP/PbxConfig.hpp
+++ b/src/SIP/PbxConfig.hpp
@@ -168,6 +168,43 @@ namespace pbx
 		}
 		return out;
 	}
+
+	// ── Directed / group call pickup (Issue #68) ──────────────────────────────
+	//
+	// Design choice: pickup groups are NOT a new config table. They reuse
+	// ring-group membership (RingGroup::members, above) exactly as-is: two
+	// extensions are pickup-eligible for each other iff they are both members
+	// of at least one configured ring group — regardless of that group's mode
+	// (RingAll or Hunt; pickup only cares who's in the list, not how it rings).
+	// An operator who already set up a "sales" or "support" ring group gets a
+	// pickup group for free, with no new dashboard/NVS surface to add or keep
+	// in sync. The acceptance criteria for this feature ("only same-pickup-
+	// group calls eligible") is written without carving out directed pickup,
+	// so BOTH *8 (group) and **<ext> (directed) are restricted to the picker's
+	// own ring-group co-members — see RequestsHandler::pickupPeersOf().
+	//
+	// *8 is the group-pickup code; **<ext> is directed pickup of a specific
+	// extension. Both are dialed as the To user-part of an INVITE, exactly
+	// like the 700-709 park orbits and 980-989 page zones (isValidAor already
+	// allows '*' in an AOR for this reason).
+
+	// True iff `ext` is the group-pickup star code.
+	inline bool isGroupPickupCode(const std::string& ext)
+	{
+		return ext == "*8";
+	}
+
+	// Extracts the target extension from a directed-pickup code ("**204" ->
+	// "204"). Returns "" for anything not prefixed "**" and for "**" with no
+	// extension following it — both are treated as "no target" by the caller.
+	inline std::string directedPickupTarget(const std::string& ext)
+	{
+		if (ext.size() > 2 && ext[0] == '*' && ext[1] == '*')
+		{
+			return ext.substr(2);
+		}
+		return {};
+	}
 }
 
 #endif

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -904,6 +904,25 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 		}
 	}
 
+	// Directed / group call pickup (Issue #68): *8 answers the oldest ringing
+	// call among the picker's ring-group co-members; **<ext> answers a named
+	// extension's ringing call. Both are restricted to the picker's own
+	// pickup group (same ring-group co-membership check) — see
+	// PbxConfig.hpp's doc comment for why directed pickup isn't exempted.
+	if (pbx::isGroupPickupCode(destNumber))
+	{
+		onPickup(data, caller.value(), pickupPeersOf(caller.value()->getNumber()));
+		return;
+	}
+	if (std::string target = pbx::directedPickupTarget(destNumber); !target.empty())
+	{
+		auto peers = pickupPeersOf(caller.value()->getNumber());
+		bool eligible = target != caller.value()->getNumber() &&
+			std::find(peers.begin(), peers.end(), target) != peers.end();
+		onPickup(data, caller.value(), eligible ? std::vector<std::string>{ target } : std::vector<std::string>{});
+		return;
+	}
+
 	// Ring / hunt groups (Class A sweep): a configured group extension (e.g. 6xx)
 	// maps to an ordered member list. Ring-all reuses the broadcast fork (without the
 	// intercom auto-answer headers, so members ring normally); hunt rings members one
@@ -1006,16 +1025,14 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	}
 	_sessions.emplace(data->getCallID(), newSession);
 
-	// Retain the original INVITE on the session if the callee has ANY conditional
-	// forward (busy or no-answer), so onBusy()/tick() can re-drive it to the forward
-	// target. CFB (busy) is handled in onBusy(); CFNA arms a one-shot ring timer that
-	// tick() fires after NO_ANSWER_TIMEOUT (CANCEL original leg, INVITE the target).
+	// Retain the original INVITE on every direct-call session — not only when
+	// the callee has a conditional forward (busy/no-answer) configured.
+	// onBusy()/tick() already relied on this for CFB/CFNA; it's now also how
+	// isSessionRingingExt() finds "who's ringing" for call pickup (Issue #68)
+	// without needing to pre-populate Session::dest before an answer exists.
+	newSession->setInviteMessage(data);
 	std::string cfb  = getForwardTarget(destNumber, "busy");
 	std::string cfna = getForwardTarget(destNumber, "noanswer");
-	if (!cfb.empty() || !cfna.empty())
-	{
-		newSession->setInviteMessage(data);
-	}
 	if (!cfna.empty() && cfna != destNumber)
 	{
 		newSession->setNoAnswerTarget(cfna);
@@ -1537,6 +1554,50 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
+	// Cross-dialog bridge teardown (Issue #68 call pickup — and, as a
+	// byproduct, ParkOrbit's retrieve/ring-back legs, which set peerCallID
+	// too but had no relay wired up for it before this). A BYE here ends ONE
+	// of two independently-dialogued legs that only the server's own
+	// bookkeeping links together; relaying the raw BYE as-is (its own
+	// Call-ID) would be rejected 481 by the peer's phone (wrong dialog), so a
+	// peer-addressed BYE has to be built fresh from the PEER session's own
+	// dialog identifiers — exactly what sweepSessionTimers() already does for
+	// a single session's own two legs, generalized here across two sessions.
+	if (session.has_value() && !session.value()->getPeerCallID().empty())
+	{
+		std::string peerCallId = session.value()->getPeerCallID();
+		if (auto peerSession = getSession(peerCallId); peerSession.has_value())
+		{
+			auto peer = peerSession.value();
+			// Issue #72's guard, reused: a BYE with an empty From or To is
+			// malformed and phones drop it. onPickup() always captures both
+			// via setDialogHeaders(), but ParkOrbit's retrieve/ring-back legs
+			// (the other peerCallID-setting path) don't yet — so a park leg
+			// still gets the endCall() cleanup below, just not a peer-phone
+			// BYE, rather than emitting a "From: \r\nTo: \r\n" packet.
+			if (auto notify = peer->getSrc();
+				notify && !peer->getDialogFrom().empty() && !peer->getDialogTo().empty())
+			{
+				auto bye = buildServerBye(notify->getNumber(), notify->getAddress(),
+					peerCallId, peer->getDialogTo(), peer->getDialogFrom());
+				if (bye) _outbox.emplace_back(notify->getAddress(), std::move(bye));
+			}
+			endCall(peerCallId, peer->getSrc() ? peer->getSrc()->getNumber() : "",
+				peer->getDest() ? peer->getDest()->getNumber() : "", "peer leg ended (bridged call)");
+		}
+
+		auto response = getMessageFromPool(*data);
+		if (response)
+		{
+			response->setHeader(SipMessageTypes::OK);
+			response->setVia(std::string(data->getVia()) + ";received=" + _localIp);
+			response->clearBody();
+			_outbox.emplace_back(data->getSource(), std::move(response));
+		}
+		endCall(data->getCallID(), data->getFromNumber(), data->getToNumber(), "bridged call ended");
+		return;
+	}
+
 	setCallState(data->getCallID(), Session::State::Bye);
 	endHandle(data->getToNumber(), data);
 }
@@ -1691,6 +1752,21 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 
 			auto client = findClient(data->getToNumber());
 			if (!client.has_value())
+			{
+				return;
+			}
+
+			// Issue #68 pickup race: once this session is already connected to
+			// someone ELSE (a directed/group pickup answered first), a late
+			// 200 OK from this call's now-superseded (CANCELed) fork must not
+			// resurrect/steal the session — a CANCEL and a 2xx can legally
+			// cross on the wire. Silently drop it, same treatment the
+			// isBroadcast() branch above already gives a post-connect answer.
+			// A genuine retransmit of the WINNING answer (dest already ==
+			// this responder) still falls through to the normal path below.
+			if (session.value()->getState() != Session::State::Invited &&
+				!(session.value()->getDest() &&
+					session.value()->getDest()->getNumber() == client.value()->getNumber()))
 			{
 				return;
 			}
@@ -4701,6 +4777,209 @@ const pbx::PageZone* RequestsHandler::findPageZone(const std::string& extension)
 bool RequestsHandler::isPageZoneDialog(const std::string& extension) const
 {
 	return pbx::isPageZoneExt(extension) && _pageZones.find(extension) != _pageZones.end();
+}
+
+// ── Directed / group call pickup (Issue #68) ──────────────────────────────────
+// See PbxConfig.hpp's isGroupPickupCode/directedPickupTarget doc comment: pickup
+// groups are ring-group membership, reused as-is.
+
+std::vector<std::string> RequestsHandler::pickupPeersOf(const std::string& ext) const
+{
+	std::vector<std::string> peers;
+	for (const auto& [groupExt, group] : _ringGroups)
+	{
+		bool isMember = false;
+		for (const auto& m : group.members)
+		{
+			if (m == ext) { isMember = true; break; }
+		}
+		if (!isMember) continue;
+
+		for (const auto& m : group.members)
+		{
+			if (m == ext) continue;
+			if (std::find(peers.begin(), peers.end(), m) == peers.end())
+			{
+				peers.push_back(m);
+			}
+		}
+	}
+	return peers;
+}
+
+bool RequestsHandler::isSessionRingingExt(const std::shared_ptr<Session>& session, const std::string& ext) const
+{
+	if (!session || session->getState() != Session::State::Invited)
+	{
+		return false;
+	}
+	if (session->isBroadcast())
+	{
+		// Ring-all / hunt: the currently-ringing member(s) live in
+		// pendingTargets (hunt keeps exactly one entry there at a time).
+		for (const auto& t : session->getPendingTargets())
+		{
+			if (t && t->getNumber() == ext) return true;
+		}
+		return false;
+	}
+	// Direct (proxied 1:1) call: the callee extension is the stored original
+	// INVITE's own To user-part — always retained now (see onInvite's direct-
+	// call branch), not only when a conditional forward is configured.
+	auto inv = session->getInviteMessage();
+	return inv && inv->getToNumber() == ext;
+}
+
+std::shared_ptr<Session> RequestsHandler::findRingingSessionAmong(const std::vector<std::string>& candidates,
+	std::string& outCallId, std::string& outExt) const
+{
+	std::shared_ptr<Session> best;
+	std::chrono::steady_clock::time_point bestStart;
+	for (const auto& [callId, session] : _sessions)
+	{
+		if (!session) continue;
+		for (const auto& ext : candidates)
+		{
+			if (!isSessionRingingExt(session, ext)) continue;
+			if (!best || session->getStartTime() < bestStart)
+			{
+				best = session;
+				bestStart = session->getStartTime();
+				outCallId = callId;
+				outExt = ext;
+			}
+			break;   // this session matched; no need to try its other candidates
+		}
+	}
+	return best;
+}
+
+void RequestsHandler::onPickup(const std::shared_ptr<SipMessage>& data, const std::shared_ptr<SipClient>& picker,
+	const std::vector<std::string>& candidates)
+{
+	auto reject486 = [&]()
+	{
+		auto resp = getMessageFromPool(*data);
+		if (!resp) return;   // pool exhausted: drop, peer retransmits (#101A)
+		resp->setHeader(SipMessageTypes::BUSY);
+		resp->clearBody();
+		resp->setVia(std::string(data->getVia()) + ";received=" + _localIp);
+		resp->setContact(buildContact(picker->getNumber()));
+		_outbox.emplace_back(data->getSource(), std::move(resp));
+	};
+
+	std::string ringingCallId, ringingExt;
+	auto ringing = candidates.empty() ? nullptr
+		: findRingingSessionAmong(candidates, ringingCallId, ringingExt);
+	if (!ringing)
+	{
+		// Nothing eligible is ringing right now (wrong/no pickup group, no
+		// ringing call for a directed target, or the race already lost — see
+		// onOk's late-answer guard). Acceptance criterion: 486, never a hang.
+		reject486();
+		return;
+	}
+
+	auto originalCaller = ringing->getSrc();
+	auto invite = ringing->getInviteMessage();
+	if (!originalCaller || !invite || !invite->hasSdp() || !data->hasSdp())
+	{
+		// Can't build a valid P2P O/A without both SDPs — decline cleanly
+		// rather than half-connect the call.
+		reject486();
+		return;
+	}
+
+	// Draw the picker's session and BOTH 200 OKs before mutating anything
+	// (#101A / #71 discipline): a refusal here must leave the original call
+	// still ringing, not half-torn-down.
+	auto pickerSession = allocateSession(std::string(data->getCallID()), picker);
+	if (!pickerSession)
+	{
+		auto resp = getMessageFromPool(*data);
+		if (resp)
+		{
+			resp->setHeader("SIP/2.0 503 Service Unavailable");
+			resp->clearBody();
+			resp->setContact(buildContact(picker->getNumber()));
+			_outbox.emplace_back(data->getSource(), std::move(resp));
+		}
+		return;
+	}
+	auto okToCaller = getMessageFromPool(*invite);
+	if (!okToCaller) return;   // pool exhausted: drop, original call keeps ringing (#101A)
+	auto okToPicker = getMessageFromPool(*data);
+	if (!okToPicker) return;   // pool exhausted: drop, original call keeps ringing (#101A)
+
+	// ── Cancel every other still-ringing fork of the picked-up call ─────────
+	if (ringing->isBroadcast())
+	{
+		for (const auto& t : ringing->getPendingTargets())
+		{
+			auto cancel = buildCancel(invite, t);
+			if (cancel) _outbox.emplace_back(t->getAddress(), std::move(cancel));
+		}
+		ringing->setPendingTargets({});
+	}
+	else if (auto target = findClient(ringingExt); target.has_value())
+	{
+		auto cancel = buildCancel(invite, target.value());
+		if (cancel) _outbox.emplace_back(target.value()->getAddress(), std::move(cancel));
+	}
+	ringing->clearRingTimer();
+
+	// ── Complete the caller's original (still-open) INVITE transaction with
+	// the picker's SDP as the answer ────────────────────────────────────────
+	const std::string callerToTag = IDGen::GenerateID(9);
+	std::string callerTo(invite->getTo());
+	callerTo += ";tag=" + callerToTag;
+
+	okToCaller->setHeader(SipMessageTypes::OK);
+	okToCaller->setVia(std::string(invite->getVia()) + ";received=" + _localIp);
+	okToCaller->setTo(callerTo);
+	okToCaller->setContact(buildContact(picker->getNumber()));
+	okToCaller->setBody(std::string(data->getBody()));
+	okToCaller->enforceG711();
+	okToCaller->syncContentLength();
+
+	// ── Answer the picker's own INVITE with the caller's original SDP ───────
+	const std::string pickerToTag = IDGen::GenerateID(9);
+	std::string toForPicker(data->getTo());
+	toForPicker += ";tag=" + pickerToTag;
+
+	okToPicker->setHeader(SipMessageTypes::OK);
+	okToPicker->setVia(std::string(data->getVia()) + ";received=" + _localIp);
+	okToPicker->setTo(toForPicker);
+	okToPicker->setContact(buildContact(ringingExt));
+	okToPicker->setBody(std::string(invite->getBody()));
+	okToPicker->enforceG711();
+	okToPicker->syncContentLength();
+
+	// ── Bridge the two independent dialogs. Both legs are REAL registered
+	// clients (unlike ParkOrbit's orbit stand-in), so neither session needs a
+	// virtual peer — but the Call-IDs still differ, so peerCallID + the
+	// dialog headers captured here are what let onBye's peerCallID branch
+	// translate a hangup on one leg into a correctly-addressed BYE on the
+	// other's own dialog. ──────────────────────────────────────────────────
+	ringing->setDest(picker);
+	ringing->setLocalTag(callerToTag);
+	ringing->setState(Session::State::Connected);
+	ringing->setPeerCallID(std::string(data->getCallID()));
+	ringing->setDialogHeaders(std::string(invite->getFrom()), callerTo);
+
+	pickerSession->setDest(originalCaller);
+	pickerSession->setInviteMessage(data);
+	pickerSession->setLocalTag(pickerToTag);
+	pickerSession->setPeerCallID(ringingCallId);
+	pickerSession->setDialogHeaders(std::string(data->getFrom()), toForPicker);
+	pickerSession->setState(Session::State::Connected);
+	_sessions.emplace(data->getCallID(), pickerSession);
+
+	_outbox.emplace_back(originalCaller->getAddress(), std::move(okToCaller));
+	_outbox.emplace_back(data->getSource(), std::move(okToPicker));
+
+	queueLog("Pickup: " + picker->getNumber() + " picked up " + ringingExt +
+		"'s ringing call from " + originalCaller->getNumber());
 }
 
 void RequestsHandler::setPageZone(const std::string& zoneExt, const std::string& members)

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -487,6 +487,40 @@ private:
 		const std::shared_ptr<SipClient>& caller,
 		const std::string& destNumber);
 
+	// ── Directed / group call pickup (Issue #68) ──────────────────────────────
+	// See PbxConfig.hpp's isGroupPickupCode/directedPickupTarget doc comment for
+	// why pickup groups reuse ring-group membership rather than adding a new
+	// config table. All four assume the caller holds _mutex (called from
+	// onInvite()/onOk()/onBye(), which already do).
+
+	// Every OTHER extension co-membered with `ext` in any configured ring
+	// group, deduped and order-preserving. Empty if `ext` is in no group.
+	std::vector<std::string> pickupPeersOf(const std::string& ext) const;
+
+	// True iff `session` is currently ringing `ext` (state == Invited AND
+	// either it's `ext`'s stored direct-call invite, or `ext` is one of its
+	// broadcast/ring-all/hunt pendingTargets).
+	bool isSessionRingingExt(const std::shared_ptr<Session>& session, const std::string& ext) const;
+
+	// Scans _sessions for the OLDEST Invited session ringing any of
+	// `candidates` (directed pickup passes a single-element vector; group
+	// pickup passes the picker's full peer list). On a match, fills
+	// `outCallId`/`outExt` with the winning session's Call-ID and which
+	// candidate it was ringing. Returns nullptr if none match.
+	std::shared_ptr<Session> findRingingSessionAmong(const std::vector<std::string>& candidates,
+		std::string& outCallId, std::string& outExt) const;
+
+	// Shared core for *8 and **<ext>: picks up the oldest Invited session
+	// ringing any of `candidates` (empty means "not eligible" — the caller
+	// already resolved eligibility/self-pickup before calling this), answers
+	// `picker`'s INVITE with the ringing call's SDP (and vice versa), cancels
+	// every other still-ringing fork of that call, and bridges the two
+	// resulting dialogs via Session::peerCallID (see onBye's peerCallID
+	// branch for teardown). 486 Busy Here on no match / pool exhaustion (the
+	// original call is left untouched either way).
+	void onPickup(const std::shared_ptr<SipMessage>& data, const std::shared_ptr<SipClient>& picker,
+		const std::vector<std::string>& candidates);
+
 	// Fan an INVITE out to a set of targets (the reusable core extracted from the
 	// 999 all-page path). `targets` are pre-selected registered clients; `intercom`
 	// adds the 999 auto-answer headers (true for 999, false for a ring group so it

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,13 @@ add_executable(sip_parser_tests
     # build their requests by hand, so only a byte-level assertion catches header
     # defects like a doubled "Call-ID:" in the park retrieve re-INVITE.
     ParkOrbit_test.cpp
+    # Issue #68: directed (**<ext>) and group (*8) call pickup — reuses ring-
+    # group membership as the pickup-group table (see PbxConfig.hpp). Drives
+    # RequestsHandler::handle() end to end (REGISTER/INVITE/OK/BYE) so the
+    # CANCEL-the-loser fork, the swapped-SDP 200 OKs, the answer-first-wins
+    # race in both directions, and the cross-dialog BYE bridge are all
+    # asserted at the wire level.
+    CallPickup_test.cpp
     RegisterBeeper_test.cpp
     BlfSubscriptions_test.cpp
     DashboardSnapshot_test.cpp

--- a/tests/CallPickup_test.cpp
+++ b/tests/CallPickup_test.cpp
@@ -1,0 +1,461 @@
+// CallPickup_test.cpp — Issue #68: directed (**<ext>) and group (*8) call
+// pickup.
+//
+// Pickup groups reuse ring-group membership as-is (see PbxConfig.hpp's
+// isGroupPickupCode/directedPickupTarget doc comment): two extensions are
+// pickup-eligible for each other iff setRingGroup() has them in the same
+// group's member list. These tests drive the whole thing through
+// RequestsHandler::handle() with real SIP packets (REGISTER, INVITE, OK, BYE)
+// — the same style as DtmfClassCodes_test.cpp — and capture every outbound
+// message via the onHandledEvent callback so the CANCEL-the-loser and the
+// swapped-SDP 200 OKs are asserted at the wire level, not just via internal
+// state.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "RequestsHandler.hpp"
+#include "SipMessage.hpp"
+#include "SipMessageTypes.h"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <WinSock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	sockaddr_in addrFor(const std::string& ip)
+	{
+		sockaddr_in s{};
+		s.sin_family = AF_INET;
+		s.sin_addr.s_addr = inet_addr(ip.c_str());
+		s.sin_port = htons(5060);
+		return s;
+	}
+
+	std::shared_ptr<SipMessage> makeRegister(const std::string& ext, const std::string& ip,
+		const std::string& callId)
+	{
+		std::string raw =
+			"REGISTER sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + ip + ":5060;branch=z9hG4bKr" + callId + "\r\n"
+			"From: <sip:" + ext + "@server>;tag=rt" + callId + "\r\n"
+			"To: <sip:" + ext + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 REGISTER\r\n"
+			"Contact: <sip:" + ext + "@" + ip + ":5060>;expires=3600\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, addrFor(ip));
+	}
+
+	std::string sdpBody(const std::string& mediaIp)
+	{
+		return
+			"v=0\r\n"
+			"o=- 1 1 IN IP4 " + mediaIp + "\r\n"
+			"s=call\r\n"
+			"c=IN IP4 " + mediaIp + "\r\n"
+			"t=0 0\r\n"
+			"m=audio 4000 RTP/AVP 0\r\n";
+	}
+
+	// A fresh, out-of-dialog INVITE — used both for the original caller->callee
+	// call and for the picker's own **ext/*8 dial (which is, from the server's
+	// point of view, just another INVITE to a virtual extension).
+	std::shared_ptr<SipMessage> makeInvite(const std::string& fromExt, const std::string& toExt,
+		const std::string& fromIp, const std::string& callId)
+	{
+		const std::string body = sdpBody(fromIp);
+		std::string raw =
+			"INVITE sip:" + toExt + "@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + fromIp + ":5060;branch=z9hG4bK" + callId + "\r\n"
+			"From: <sip:" + fromExt + "@server>;tag=from" + callId + "\r\n"
+			"To: <sip:" + toExt + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Contact: <sip:" + fromExt + "@" + fromIp + ":5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		return RequestsHandler::getMessageFromPool(raw, addrFor(fromIp));
+	}
+
+	// The ORIGINAL callee answering its own fork directly (used only by the
+	// "target answers first" race test — everywhere else the callee never
+	// answers, that's the whole point of picking it up).
+	std::shared_ptr<SipMessage> makeOk(const std::string& callerExt, const std::string& calleeExt,
+		const std::string& calleeIp, const std::string& callId)
+	{
+		const std::string body = sdpBody(calleeIp);
+		std::string raw =
+			"SIP/2.0 200 OK\r\n"
+			"Via: SIP/2.0/UDP 192.168.9.1:5060;branch=z9hG4bK" + callId + "\r\n"
+			"From: <sip:" + callerExt + "@server>;tag=from" + callId + "\r\n"
+			"To: <sip:" + calleeExt + "@server>;tag=to" + callId + "\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Contact: <sip:" + calleeExt + "@" + calleeIp + ":5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		return RequestsHandler::getMessageFromPool(raw, addrFor(calleeIp));
+	}
+
+	std::shared_ptr<SipMessage> makeBye(const std::string& fromExt, const std::string& toExt,
+		const std::string& fromIp, const std::string& callId)
+	{
+		std::string raw =
+			"BYE sip:" + toExt + "@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + fromIp + ":5060;branch=z9hG4bKbye" + callId + "\r\n"
+			"From: <sip:" + fromExt + "@server>;tag=byefrom" + callId + "\r\n"
+			"To: <sip:" + toExt + "@server>;tag=byeto" + callId + "\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 2 BYE\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, addrFor(fromIp));
+	}
+
+	// Records every message the handler ever enqueued, keyed by destination IP,
+	// so assertions can look for "was a CANCEL sent to 192.168.9.20" without
+	// caring which handle() call produced it.
+	struct Sent
+	{
+		std::string destIp;
+		std::string raw;
+	};
+
+	std::string ipOf(const sockaddr_in& a)
+	{
+		char buf[INET_ADDRSTRLEN]{};
+		inet_ntop(AF_INET, &a.sin_addr, buf, sizeof(buf));
+		return buf;
+	}
+
+	bool anyTo(const std::vector<Sent>& sent, const std::string& ip,
+		const std::string& needle)
+	{
+		for (const auto& s : sent)
+		{
+			if (s.destIp == ip && s.raw.find(needle) != std::string::npos) return true;
+		}
+		return false;
+	}
+
+	size_t countTo(const std::vector<Sent>& sent, const std::string& ip)
+	{
+		size_t n = 0;
+		for (const auto& s : sent) if (s.destIp == ip) ++n;
+		return n;
+	}
+
+	// SipMessage::getCallID() (and therefore the _sessions map key) is the
+	// FULL "Call-ID: <value>" header line, not the bare value used to build
+	// the raw messages above.
+	std::string sessionKey(const std::string& callId)
+	{
+		return "Call-ID: " + callId;
+	}
+}
+
+// ── Directed pickup ────────────────────────────────────────────────────────
+
+TEST(CallPickup, DirectedPickupCancelsTargetAndBridgesCallerToPicker)
+{
+	std::vector<Sent> sent;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&](const sockaddr_in& to, std::shared_ptr<SipMessage> msg) {
+			sent.push_back({ ipOf(to), msg->toString() });
+		});
+
+	handler.handle(makeRegister("200", "192.168.9.10", "reg-caller"));
+	handler.handle(makeRegister("100", "192.168.9.20", "reg-target"));
+	handler.handle(makeRegister("102", "192.168.9.30", "reg-picker"));
+	handler.setRingGroup("600", "100,102", "ringall");
+
+	handler.handle(makeInvite("200", "100", "192.168.9.10", "call-1"));
+	auto ringing = handler.getSession(sessionKey("call-1"));
+	ASSERT_TRUE(ringing.has_value());
+	EXPECT_EQ(ringing.value()->getState(), Session::State::Invited);
+
+	handler.handle(makeInvite("102", "**100", "192.168.9.30", "pickup-1"));
+
+	// The target's fork must be CANCELed — it never gets to answer.
+	EXPECT_TRUE(anyTo(sent, "192.168.9.20", "CANCEL sip:100@"))
+		<< "target's ringing fork must be cancelled once picked up";
+
+	// The caller's original (still-open) INVITE transaction is completed with
+	// the PICKER's SDP as the answer.
+	bool callerGotPickerSdp = false;
+	for (const auto& s : sent)
+	{
+		if (s.destIp == "192.168.9.10" && s.raw.rfind("SIP/2.0 200 OK", 0) == 0 &&
+			s.raw.find("c=IN IP4 192.168.9.30") != std::string::npos)
+		{
+			callerGotPickerSdp = true;
+		}
+	}
+	EXPECT_TRUE(callerGotPickerSdp) << "caller must be answered with the picker's SDP";
+
+	// The picker's own INVITE is answered with the CALLER's original SDP.
+	bool pickerGotCallerSdp = false;
+	for (const auto& s : sent)
+	{
+		if (s.destIp == "192.168.9.30" && s.raw.rfind("SIP/2.0 200 OK", 0) == 0 &&
+			s.raw.find("c=IN IP4 192.168.9.10") != std::string::npos)
+		{
+			pickerGotCallerSdp = true;
+		}
+	}
+	EXPECT_TRUE(pickerGotCallerSdp) << "picker must be answered with the caller's original SDP";
+
+	// Internal state: the original session is now Connected to the picker;
+	// the picker's own session is Connected to the caller.
+	auto orig = handler.getSession(sessionKey("call-1"));
+	ASSERT_TRUE(orig.has_value());
+	EXPECT_EQ(orig.value()->getState(), Session::State::Connected);
+	ASSERT_NE(orig.value()->getDest(), nullptr);
+	EXPECT_EQ(orig.value()->getDest()->getNumber(), "102");
+
+	auto pickerSession = handler.getSession(sessionKey("pickup-1"));
+	ASSERT_TRUE(pickerSession.has_value());
+	EXPECT_EQ(pickerSession.value()->getState(), Session::State::Connected);
+	ASSERT_NE(pickerSession.value()->getDest(), nullptr);
+	EXPECT_EQ(pickerSession.value()->getDest()->getNumber(), "200");
+}
+
+TEST(CallPickup, DirectedPickupOfNonPeerExtensionGets486AndLeavesTargetRinging)
+{
+	std::vector<Sent> sent;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&](const sockaddr_in& to, std::shared_ptr<SipMessage> msg) {
+			sent.push_back({ ipOf(to), msg->toString() });
+		});
+
+	handler.handle(makeRegister("200", "192.168.9.10", "reg-caller2"));
+	handler.handle(makeRegister("100", "192.168.9.20", "reg-target2"));
+	handler.handle(makeRegister("104", "192.168.9.40", "reg-outsider"));
+	// 104 is NOT in any ring group with 100 — no shared pickup group.
+
+	handler.handle(makeInvite("200", "100", "192.168.9.10", "call-2"));
+	sent.clear();
+
+	handler.handle(makeInvite("104", "**100", "192.168.9.40", "pickup-2"));
+
+	EXPECT_TRUE(anyTo(sent, "192.168.9.40", "486 Busy Here"))
+		<< "a picker outside the target's pickup group must be refused";
+	EXPECT_FALSE(anyTo(sent, "192.168.9.20", "CANCEL"))
+		<< "an ineligible pickup attempt must not disturb the still-ringing target";
+
+	auto s = handler.getSession(sessionKey("call-2"));
+	ASSERT_TRUE(s.has_value());
+	EXPECT_EQ(s.value()->getState(), Session::State::Invited);
+}
+
+// ── Group pickup ───────────────────────────────────────────────────────────
+
+TEST(CallPickup, GroupPickupAnswersTheOldestRingingCallInTheGroup)
+{
+	std::vector<Sent> sent;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&](const sockaddr_in& to, std::shared_ptr<SipMessage> msg) {
+			sent.push_back({ ipOf(to), msg->toString() });
+		});
+
+	handler.handle(makeRegister("201", "192.168.9.11", "reg-c1"));
+	handler.handle(makeRegister("202", "192.168.9.12", "reg-c2"));
+	handler.handle(makeRegister("100", "192.168.9.21", "reg-A"));
+	handler.handle(makeRegister("101", "192.168.9.22", "reg-B"));
+	handler.handle(makeRegister("103", "192.168.9.33", "reg-picker3"));
+	handler.setRingGroup("601", "100,101,103", "ringall");
+
+	// 100 starts ringing first (the OLDER call)...
+	handler.handle(makeInvite("201", "100", "192.168.9.11", "call-old"));
+	std::this_thread::sleep_for(std::chrono::milliseconds(15));
+	// ...then 101 starts ringing (the NEWER call).
+	handler.handle(makeInvite("202", "101", "192.168.9.12", "call-new"));
+	sent.clear();
+
+	handler.handle(makeInvite("103", "*8", "192.168.9.33", "pickup-3"));
+
+	// The OLDER call (100 <- 201) is the one picked up: 100's fork is
+	// cancelled and 201 is bridged to the picker.
+	EXPECT_TRUE(anyTo(sent, "192.168.9.21", "CANCEL sip:100@"))
+		<< "the older ringing member's fork must be cancelled";
+	EXPECT_FALSE(anyTo(sent, "192.168.9.22", "CANCEL"))
+		<< "the newer ringing call must be left alone";
+
+	auto oldSession = handler.getSession(sessionKey("call-old"));
+	ASSERT_TRUE(oldSession.has_value());
+	EXPECT_EQ(oldSession.value()->getState(), Session::State::Connected);
+
+	auto newSession = handler.getSession(sessionKey("call-new"));
+	ASSERT_TRUE(newSession.has_value());
+	EXPECT_EQ(newSession.value()->getState(), Session::State::Invited)
+		<< "the newer call must still be ringing untouched";
+}
+
+// ── The race: whoever answers first wins, the other never both connects ────
+
+TEST(CallPickup, RaceTargetAnswersFirst_PickupThenGets486)
+{
+	std::vector<Sent> sent;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&](const sockaddr_in& to, std::shared_ptr<SipMessage> msg) {
+			sent.push_back({ ipOf(to), msg->toString() });
+		});
+
+	handler.handle(makeRegister("200", "192.168.9.10", "reg-caller4"));
+	handler.handle(makeRegister("100", "192.168.9.20", "reg-target4"));
+	handler.handle(makeRegister("102", "192.168.9.30", "reg-picker4"));
+	handler.setRingGroup("602", "100,102", "ringall");
+
+	handler.handle(makeInvite("200", "100", "192.168.9.10", "call-4"));
+	// The target answers on its own, before anyone tries to pick it up.
+	handler.handle(makeOk("200", "100", "192.168.9.20", "call-4"));
+
+	auto connected = handler.getSession(sessionKey("call-4"));
+	ASSERT_TRUE(connected.has_value());
+	EXPECT_EQ(connected.value()->getState(), Session::State::Connected);
+	ASSERT_NE(connected.value()->getDest(), nullptr);
+	EXPECT_EQ(connected.value()->getDest()->getNumber(), "100");
+
+	sent.clear();
+	handler.handle(makeInvite("102", "**100", "192.168.9.30", "pickup-4"));
+
+	EXPECT_TRUE(anyTo(sent, "192.168.9.30", "486 Busy Here"))
+		<< "the target already answered — pickup must lose the race";
+	EXPECT_FALSE(anyTo(sent, "192.168.9.20", "CANCEL"))
+		<< "an already-answered call must never be cancelled";
+
+	// dest must still be the target — the picker never took over.
+	auto after = handler.getSession(sessionKey("call-4"));
+	ASSERT_TRUE(after.has_value());
+	ASSERT_NE(after.value()->getDest(), nullptr);
+	EXPECT_EQ(after.value()->getDest()->getNumber(), "100");
+}
+
+TEST(CallPickup, RacePickupFirst_LateAnswerFromCancelledTargetIsDropped)
+{
+	std::vector<Sent> sent;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&](const sockaddr_in& to, std::shared_ptr<SipMessage> msg) {
+			sent.push_back({ ipOf(to), msg->toString() });
+		});
+
+	handler.handle(makeRegister("200", "192.168.9.10", "reg-caller5"));
+	handler.handle(makeRegister("100", "192.168.9.20", "reg-target5"));
+	handler.handle(makeRegister("102", "192.168.9.30", "reg-picker5"));
+	handler.setRingGroup("603", "100,102", "ringall");
+
+	handler.handle(makeInvite("200", "100", "192.168.9.10", "call-5"));
+	handler.handle(makeInvite("102", "**100", "192.168.9.30", "pickup-5"));
+
+	auto afterPickup = handler.getSession(sessionKey("call-5"));
+	ASSERT_TRUE(afterPickup.has_value());
+	ASSERT_NE(afterPickup.value()->getDest(), nullptr);
+	EXPECT_EQ(afterPickup.value()->getDest()->getNumber(), "102");
+
+	size_t caller200MessagesBefore = countTo(sent, "192.168.9.10");
+
+	// The target's phone answers anyway (CANCEL/200 crossed on the wire) —
+	// this must be silently dropped, not resurrect/steal the session.
+	handler.handle(makeOk("200", "100", "192.168.9.20", "call-5"));
+
+	EXPECT_EQ(countTo(sent, "192.168.9.10"), caller200MessagesBefore)
+		<< "a late answer from the cancelled fork must not reach the caller";
+
+	auto stillPicker = handler.getSession(sessionKey("call-5"));
+	ASSERT_TRUE(stillPicker.has_value());
+	ASSERT_NE(stillPicker.value()->getDest(), nullptr);
+	EXPECT_EQ(stillPicker.value()->getDest()->getNumber(), "102")
+		<< "the late answer must not overwrite the pickup winner";
+}
+
+// ── Bridge teardown ──────────────────────────────────────────────────────
+
+TEST(CallPickup, CallerHangupTearsDownBothBridgedDialogsViaPeerCallId)
+{
+	std::vector<Sent> sent;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&](const sockaddr_in& to, std::shared_ptr<SipMessage> msg) {
+			sent.push_back({ ipOf(to), msg->toString() });
+		});
+
+	handler.handle(makeRegister("200", "192.168.9.10", "reg-caller6"));
+	handler.handle(makeRegister("100", "192.168.9.20", "reg-target6"));
+	handler.handle(makeRegister("102", "192.168.9.30", "reg-picker6"));
+	handler.setRingGroup("604", "100,102", "ringall");
+
+	handler.handle(makeInvite("200", "100", "192.168.9.10", "call-6"));
+	handler.handle(makeInvite("102", "**100", "192.168.9.30", "pickup-6"));
+	ASSERT_TRUE(handler.getSession(sessionKey("call-6")).has_value());
+	ASSERT_TRUE(handler.getSession(sessionKey("pickup-6")).has_value());
+
+	sent.clear();
+	handler.handle(makeBye("200", "100", "192.168.9.10", "call-6"));
+
+	// The picker's phone must receive a BYE — but addressed within ITS OWN
+	// dialog (pickup-6's Call-ID), never the caller's (call-6): a raw relay
+	// of the caller's own BYE would carry the wrong Call-ID and the picker's
+	// phone would reject it 481.
+	bool pickerGotOwnDialogBye = false;
+	bool pickerGotWrongCallId = false;
+	for (const auto& s : sent)
+	{
+		if (s.destIp != "192.168.9.30") continue;
+		if (s.raw.rfind("BYE sip:", 0) != 0) continue;
+		if (s.raw.find("Call-ID: pickup-6") != std::string::npos) pickerGotOwnDialogBye = true;
+		if (s.raw.find("Call-ID: call-6\r\n") != std::string::npos) pickerGotWrongCallId = true;
+	}
+	EXPECT_TRUE(pickerGotOwnDialogBye) << "picker's teardown BYE must use its own Call-ID";
+	EXPECT_FALSE(pickerGotWrongCallId) << "the caller's Call-ID must never be relayed to the picker";
+
+	// Both legs are gone.
+	EXPECT_FALSE(handler.getSession(sessionKey("call-6")).has_value());
+	EXPECT_FALSE(handler.getSession(sessionKey("pickup-6")).has_value());
+}
+
+// onBye's new peerCallID branch also fires for ParkOrbit's retrieve bridge
+// (it sets peerCallID too), which never calls setDialogHeaders(). This pins
+// the #72-style guard: such a leg must get session cleanup WITHOUT emitting
+// the malformed "From: \r\nTo: \r\n" BYE that guard exists to prevent.
+TEST(CallPickup, ParkRetrieveBridgeByeGetsCleanupWithoutMalformedBye)
+{
+	std::vector<Sent> sent;
+	RequestsHandler handler("192.168.9.1", 5060,
+		[&](const sockaddr_in& to, std::shared_ptr<SipMessage> msg) {
+			sent.push_back({ ipOf(to), msg->toString() });
+		});
+
+	handler.handle(makeRegister("100", "192.168.9.50", "reg-parked"));
+	handler.handle(makeRegister("101", "192.168.9.51", "reg-retriever"));
+
+	// 100 parks itself on orbit 700.
+	handler.handle(makeInvite("100", "700", "192.168.9.50", "park-call"));
+	ASSERT_TRUE(handler.getSession(sessionKey("park-call")).has_value());
+
+	// 101 retrieves it from the same orbit — this bridges park-call and
+	// retrieve-call via peerCallID, exactly like a pickup, but WITHOUT ever
+	// calling setDialogHeaders() on either session.
+	handler.handle(makeInvite("101", "700", "192.168.9.51", "retrieve-call"));
+	ASSERT_TRUE(handler.getSession(sessionKey("retrieve-call")).has_value());
+
+	sent.clear();
+	handler.handle(makeBye("101", "700", "192.168.9.51", "retrieve-call"));
+
+	for (const auto& s : sent)
+	{
+		EXPECT_EQ(s.raw.find("From: \r\n"), std::string::npos)
+			<< "empty-header BYE (Issue #72 class) must never be sent:\n" << s.raw;
+		EXPECT_EQ(s.raw.find("To: \r\n"), std::string::npos)
+			<< "empty-header BYE (Issue #72 class) must never be sent:\n" << s.raw;
+	}
+
+	// Both sessions are still cleaned up (CDR + pool slot) even though no
+	// peer-phone BYE could be built for the park leg.
+	EXPECT_FALSE(handler.getSession(sessionKey("retrieve-call")).has_value());
+	EXPECT_FALSE(handler.getSession(sessionKey("park-call")).has_value());
+}

--- a/tests/Pbx_test.cpp
+++ b/tests/Pbx_test.cpp
@@ -88,6 +88,28 @@ TEST(Pbx, JoinRoundTripsSplit) {
     EXPECT_EQ(pbx::joinMembers(m), "600,601,602");
 }
 
+// ── Call pickup codes (Issue #68) ─────────────────────────────────────────────
+
+TEST(Pbx, IsGroupPickupCodeMatchesOnlyStarEight) {
+    EXPECT_TRUE(pbx::isGroupPickupCode("*8"));
+    EXPECT_FALSE(pbx::isGroupPickupCode("*80"));
+    EXPECT_FALSE(pbx::isGroupPickupCode("8"));
+    EXPECT_FALSE(pbx::isGroupPickupCode(""));
+}
+
+TEST(Pbx, DirectedPickupTargetExtractsExtensionAfterDoubleStar) {
+    EXPECT_EQ(pbx::directedPickupTarget("**204"), "204");
+    EXPECT_EQ(pbx::directedPickupTarget("**100"), "100");
+}
+
+TEST(Pbx, DirectedPickupTargetEmptyForNonMatchingInput) {
+    EXPECT_EQ(pbx::directedPickupTarget("**"), "");      // no extension named
+    EXPECT_EQ(pbx::directedPickupTarget("*8"), "");       // that's the group code
+    EXPECT_EQ(pbx::directedPickupTarget("*204"), "");     // single star, not directed pickup
+    EXPECT_EQ(pbx::directedPickupTarget("204"), "");      // plain extension
+    EXPECT_EQ(pbx::directedPickupTarget(""), "");
+}
+
 // ── Call-forward config value type ───────────────────────────────────────────
 
 TEST(Pbx, ForwardConfigEmptyByDefault) {


### PR DESCRIPTION
Resolves ISSUES.md tracker issue #68 (see the clarification below) -- the GitHub `Closes` keyword is deliberately not used since GitHub issue #68 is an unrelated, already-closed item.

(Clarification: ISSUES.md's `#68` — "Directed Call Pickup (pickup groups)" — is this project's own tracker entry for this feature, which is what this PR resolves. GitHub's issue #68 on this repo is an unrelated, already-closed CI/cppcheck item; the "Closes #68." above will link to that unrelated closed issue rather than to any GitHub issue for this feature, since there isn't one — it's ISSUES.md-only.)

## Summary

Implements ISSUES.md tracker Issue #68 ("Directed Call Pickup / pickup groups") — `*8` group pickup and `**<ext>` directed pickup — following the existing `onParkInvite` (#65) / `isPageZoneExt`/`findPageZone` (#66) virtual-extension-intercept pattern in `onInvite`.

- **Pickup groups reuse ring-group membership as-is** (no new config table): two extensions are pickup-eligible for each other iff `setRingGroup` already has them as co-members of the same group. Both `*8` and `**<ext>` are restricted to the picker's own group, per the acceptance text.
- Picking up a call completes the caller's still-open INVITE transaction with the picker's SDP, answers the picker's own INVITE with the caller's original SDP, and CANCELs every other still-ringing fork of that call (direct or ring-all/hunt group).
- The two resulting dialogs (different Call-IDs) are bridged via `Session::peerCallID`, whose relay `onBye()` now implements — reusing Issue #72's empty-header guard, since `ParkOrbit`'s own `peerCallID`-bridged legs never call `setDialogHeaders()` and would otherwise hit that exact malformed-BYE bug class. A park leg now gets proper session/CDR cleanup on hangup instead of leaking; it just doesn't get a peer-phone BYE (headers were never captured) — see the resolution notes in `ISSUES.md` for the full reasoning.
- `onOk()` now drops a late 200 OK from a call's already-cancelled/superseded fork instead of overwriting the winning session, so the "whoever answers first wins" race resolves cleanly in both directions (486 or silent drop, never both connecting).
- `RequestsHandler::onInvite`'s direct-call path now always retains the original INVITE on its `Session` (previously only when a conditional forward was configured), which is how pickup finds "who's ringing" without pre-populating `Session::dest`.

Full design rationale and resolution write-up: `ISSUES.md`'s new `Issue #68` entry (moved to Resolved Issues) and `CHANGELOG.md`.

## Test plan

- [x] `env -u IDF_PATH cmake -B build -S . -DCMAKE_BUILD_TYPE=Release` + `cmake --build build --config Release` — clean MSVC Release build, no new warnings.
- [x] `ctest --test-dir build/tests -C Release --output-on-failure` — 211/211 host tests passing.
- [x] New `tests/CallPickup_test.cpp` (7 tests): directed pickup end-to-end (target CANCELed, swapped-SDP 200 OKs, both sessions bridged), a non-peer picker (486, target left ringing), group pickup picking the *oldest* ringing call in the group, the answer-first-wins race in both directions (target-answers-first → picker gets 486; pickup-first → a late answer from the cancelled fork is dropped), the cross-dialog BYE bridge teardown (asserted at the wire level), and a Park-retrieve BYE regression pin for the new `onBye` guard.
- [x] New `tests/Pbx_test.cpp` coverage for the pure `isGroupPickupCode`/`directedPickupTarget` parsers.
- [x] One pre-existing, unrelated `AdminHttpGate.Trigger_ExpiresAfterTtl_ClosesAutomatically` timing-flaky test observed failing/passing independently of this change (confirmed via repeated isolated runs before this PR's changes were made).

## Reviewer notes

- Hold/resume (re-INVITE) across a pickup bridge would relay with the wrong Call-ID and get 481'd by the peer — same pre-existing limitation as Park/broadcast bridges (tracked separately, e.g. #74's broadcast hold/resume gap), not new machinery introduced here.
- A picked-up call produces two CDR entries: the original leg's callee field reads the *original* target extension (a dialog's To user-part is immutable per RFC 3261, so it can't be rewritten to the picker), while the picker's own leg's CDR entry is fully accurate (picker ↔ caller).
- The `onOk` late-answer drop matches the existing broadcast branch's silent-drop precedent for a post-connect answer — no new ACK+BYE glare machinery was built, consistent with the codebase's existing risk posture there.
- A near-simultaneous double-hangup (both legs BYE at once) can result in one stale BYE being forwarded to an already-torn-down dialog; the receiving phone ignores it via normal dialog/Call-ID matching — same class of harmless stray-message edge case as existing ACK/park paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk3ufrZzhv4XLWC6DHQ243
