### PR TITLE
refactor(sip): extract message pool, feature config, and CDR ring from RequestsHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ Thumbs.db
 # Build output, managed deps, and scratch (added 2026-06-03)
 # build_*/ catches any alternate/side-by-side build dir (build_desktop, build_v5_eth, ...)
 build_*/
+# build-wsl/: the WSL host-test build dir (hyphen, not underscore — build_*/ above
+# does not match it). Without this, `git stash -u` sweeps its generated CMake/gtest
+# content into the stash as "untracked".
+build-wsl/
 managed_components/
 dependencies.lock
 scratch/

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -91,6 +91,7 @@ idf_component_register(SRCS ${MAIN_SRC}
                             "../src/Helpers/ArpLookup.cpp"
                             "../src/Helpers/OtaUpdater.cpp"
                             "../src/SIP/SipMessagePool.cpp"
+                            "../src/SIP/PbxFeatureConfig.cpp"
                             "../src/SIP/RequestsHandler.cpp"
                             "../src/SIP/TransactionLayer.cpp"
                             "../src/SIP/Registrar.cpp"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -92,6 +92,7 @@ idf_component_register(SRCS ${MAIN_SRC}
                             "../src/Helpers/OtaUpdater.cpp"
                             "../src/SIP/SipMessagePool.cpp"
                             "../src/SIP/PbxFeatureConfig.cpp"
+                            "../src/SIP/CdrRing.cpp"
                             "../src/SIP/RequestsHandler.cpp"
                             "../src/SIP/TransactionLayer.cpp"
                             "../src/SIP/Registrar.cpp"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -90,6 +90,7 @@ idf_component_register(SRCS ${MAIN_SRC}
                             "../src/Helpers/SipSecretStore.cpp"
                             "../src/Helpers/ArpLookup.cpp"
                             "../src/Helpers/OtaUpdater.cpp"
+                            "../src/SIP/SipMessagePool.cpp"
                             "../src/SIP/RequestsHandler.cpp"
                             "../src/SIP/TransactionLayer.cpp"
                             "../src/SIP/Registrar.cpp"

--- a/src/SIP/CallDetailRecord.hpp
+++ b/src/SIP/CallDetailRecord.hpp
@@ -3,8 +3,8 @@
 
 // CallDetailRecord.hpp — fixed-footprint Call Detail Record (CDR) types.
 //
-// A CDR is written exactly once, as a call tears down (see RequestsHandler::
-// recordCdr, invoked from endCall()). Records are kept in a fixed-capacity ring
+// A CDR is written exactly once, as a call tears down (see CdrRing::record,
+// invoked from RequestsHandler::endCall()). Records are kept in a fixed-capacity ring
 // buffer (POCKETDIAL_CDR_RECORDS) so the memory cost is paid statically at boot
 // and never grows on the heap — consistent with the SIP object pools (see
 // PoolConfig.hpp). The newest record overwrites the oldest once the ring is full.

--- a/src/SIP/CdrRing.cpp
+++ b/src/SIP/CdrRing.cpp
@@ -1,0 +1,188 @@
+// CdrRing.cpp: the CDR ring buffer, extracted out of RequestsHandler.
+#include "CdrRing.hpp"
+
+#include <chrono>
+#include <cstdlib>
+
+#include "PbxPersist.hpp"
+
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+#include "nvs_flash.h"
+#include "nvs.h"
+#endif
+
+namespace
+{
+	using pbxpersist::deserializeBlob;
+
+	// NVS namespace holding the persisted CDR ring (distinct from
+	// pbxpersist::kNvsNamespace — the CDR blob has its own key shape and is
+	// unrelated to the PBX feature-config tables).
+	constexpr auto NVS_CDR_NS = "cdrlog";
+
+	// Same clock RequestsHandler::nowEpochMs() uses; duplicated here rather than
+	// reached through an engine indirection, since it is stateless and this
+	// class otherwise needs no engine service at all (see class comment).
+	uint64_t nowEpochMs()
+	{
+		return static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count());
+	}
+}
+
+void CdrRing::record(const std::shared_ptr<Session>& session,
+	std::string_view srcNumber, std::string_view destNumber)
+{
+	CallDetailRecord rec;
+	rec.caller = std::string(srcNumber);
+	rec.callee = std::string(destNumber);
+
+	uint64_t startMs = nowEpochMs();
+	uint32_t durationSec = 0;
+	CdrResult result = CdrResult::Failed;
+
+	if (session)
+	{
+		auto now = std::chrono::steady_clock::now();
+		startMs = static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				session->getStartTime().time_since_epoch()).count());
+
+		switch (session->getState())
+		{
+			// Both Connected and Bye are "answered": a normal call ends via BYE, which
+			// sets the state to Bye (NOT Connected) just before endCall() runs, while
+			// the echo (777) path tears down straight from Connected. Session::setState
+			// resets _startTime to the connect instant on the Connected transition and
+			// the later Bye transition does NOT touch it, so getStartTime() still marks
+			// the answer instant in both cases — talk time is now - startTime.
+			case Session::State::Connected:
+			case Session::State::Held:   // call torn down mid-hold → still Answered (#73)
+			case Session::State::Bye:
+				result = CdrResult::Answered;
+				{
+					int64_t secs = static_cast<int64_t>(
+						std::chrono::duration_cast<std::chrono::seconds>(
+							now - session->getStartTime()).count());
+					if (secs < 0) secs = 0;
+					durationSec = static_cast<uint32_t>(secs);
+				}
+				break;
+			case Session::State::Busy:        result = CdrResult::Busy;        break;
+			case Session::State::Cancel:      result = CdrResult::Cancelled;   break;
+			case Session::State::Unavailable: result = CdrResult::Unavailable; break;
+			default:                          result = CdrResult::Failed;      break;
+		}
+	}
+
+	rec.startMs = startMs;
+	rec.durationSec = durationSec;
+	rec.result = result;
+
+	// Fixed ring write: overwrite the oldest slot once full (no heap growth).
+	_ring[_head] = std::move(rec);
+	_head = (_head + 1) % POCKETDIAL_CDR_RECORDS;
+	if (_count < POCKETDIAL_CDR_RECORDS)
+	{
+		++_count;
+	}
+
+	// Persist the ring so records survive reboot (write-through on teardown; no-op
+	// on host). Caller (RequestsHandler::endCall) holds _mutex. See persist()
+	// for the wear note.
+	persist();
+}
+
+std::vector<CallDetailRecord> CdrRing::snapshot() const
+{
+	std::vector<CallDetailRecord> out;
+	out.reserve(_count);
+	for (size_t i = 0; i < _count; ++i)
+	{
+		// _head points one past the newest; walk backwards with wrap.
+		size_t idx = (_head + POCKETDIAL_CDR_RECORDS - 1 - i) % POCKETDIAL_CDR_RECORDS;
+		out.push_back(_ring[idx]);
+	}
+	return out;
+}
+
+std::string CdrRing::lastCallerFor(std::string_view calleeExt) const
+{
+	for (size_t i = 0; i < _count; ++i)
+	{
+		size_t idx = (_head + POCKETDIAL_CDR_RECORDS - 1 - i) % POCKETDIAL_CDR_RECORDS;
+		if (_ring[idx].callee == calleeExt && !_ring[idx].caller.empty())
+		{
+			return _ring[idx].caller;
+		}
+	}
+	return std::string();
+}
+
+void CdrRing::load()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	nvs_handle_t h;
+	if (nvs_open(NVS_CDR_NS, NVS_READWRITE, &h) != ESP_OK)
+	{
+		return;
+	}
+	size_t len = 0;
+	if (nvs_get_str(h, "ring", nullptr, &len) == ESP_OK && len > 0)
+	{
+		std::string buf(len, '\0');
+		if (nvs_get_str(h, "ring", buf.data(), &len) == ESP_OK)
+		{
+			if (!buf.empty() && buf.back() == '\0') buf.pop_back();
+			// Record: caller \t callee \t startMs \t durationSec \t result(int)
+			for (const auto& rec : deserializeBlob(buf))
+			{
+				if (rec.size() < 5) continue;
+				if (_count >= POCKETDIAL_CDR_RECORDS) break;
+				CallDetailRecord r;
+				r.caller = rec[0];
+				r.callee = rec[1];
+				r.startMs = static_cast<uint64_t>(strtoull(rec[2].c_str(), nullptr, 10));
+				r.durationSec = static_cast<uint32_t>(strtoul(rec[3].c_str(), nullptr, 10));
+				int ri = atoi(rec[4].c_str());
+				r.result = (ri >= 0 && ri <= static_cast<int>(CdrResult::Failed))
+					? static_cast<CdrResult>(ri) : CdrResult::Failed;
+				// Records were serialized oldest-first; append preserving order.
+				_ring[_head] = std::move(r);
+				_head = (_head + 1) % POCKETDIAL_CDR_RECORDS;
+				++_count;
+			}
+		}
+	}
+	nvs_close(h);
+#endif
+}
+
+void CdrRing::persist()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	// Serialize the ring oldest-first (same order load() replays). Bounded by
+	// POCKETDIAL_CDR_RECORDS, so the blob is fixed-footprint. Write-through on each
+	// teardown: the CDR ring is small (default 32) and calls end infrequently
+	// relative to flash endurance, so a per-call rewrite is acceptable — see summary.
+	std::string blob;
+	for (size_t i = 0; i < _count; ++i)
+	{
+		size_t idx = (_head + POCKETDIAL_CDR_RECORDS - _count + i) % POCKETDIAL_CDR_RECORDS;
+		const CallDetailRecord& r = _ring[idx];
+		blob += r.caller; blob += '\t';
+		blob += r.callee; blob += '\t';
+		blob += std::to_string(r.startMs); blob += '\t';
+		blob += std::to_string(r.durationSec); blob += '\t';
+		blob += std::to_string(static_cast<int>(r.result)); blob += '\n';
+	}
+	nvs_handle_t h;
+	if (nvs_open(NVS_CDR_NS, NVS_READWRITE, &h) == ESP_OK)
+	{
+		nvs_set_str(h, "ring", blob.c_str());
+		nvs_commit(h);
+		nvs_close(h);
+	}
+#endif
+}

--- a/src/SIP/CdrRing.hpp
+++ b/src/SIP/CdrRing.hpp
@@ -1,0 +1,56 @@
+#ifndef CDR_RING_HPP
+#define CDR_RING_HPP
+
+#include <array>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "CallDetailRecord.hpp"
+#include "Session.hpp"
+
+// ── Call Detail Record ring buffer, extracted out of RequestsHandler ─────────
+// Fixed capacity (POCKETDIAL_CDR_RECORDS), no heap growth: writes wrap and
+// overwrite the oldest slot. Unlike PbxFeatureConfig (see PbxFeatureConfig.hpp),
+// this machine takes no PbxEnv reference: record() never logs and nothing about
+// a CDR write refreshes the dashboard snapshot immediately — the snapshot's
+// `cdr` view is rebuilt only from tick()'s periodic sweep, via snapshot(), same
+// as before this split (see RequestsHandler::tick()).
+//
+// Locking: every method assumes the caller holds the engine's _mutex, same
+// convention as every other extracted machine — except load(), called once
+// from the constructor before any handler is dispatching.
+class CdrRing
+{
+public:
+	// Write one record into the ring as a call ends. Caller holds _mutex.
+	// `session` (may be null) supplies the start time / final state used to
+	// derive duration and result; src/dest provide the parties when the
+	// session lookup can't (e.g. the virtual 777/999 extensions reuse a shared
+	// dummy client). Write-through persists to NVS (no-op on host).
+	void record(const std::shared_ptr<Session>& session,
+		std::string_view srcNumber, std::string_view destNumber);
+
+	// Newest-first copy of the ring, for the dashboard snapshot. Caller holds
+	// _mutex.
+	std::vector<CallDetailRecord> snapshot() const;
+
+	// *69: extension of the last party that called `calleeExt`, walking
+	// newest to oldest; empty string if none found. Caller holds _mutex.
+	std::string lastCallerFor(std::string_view calleeExt) const;
+
+	// Boot-time reload from NVS. Construction is single-threaded (no handler
+	// is dispatching yet), so this runs without holding _mutex, same as
+	// before this split.
+	void load();
+
+private:
+	void persist();
+
+	std::array<CallDetailRecord, POCKETDIAL_CDR_RECORDS> _ring{};
+	size_t _head = 0;   // index of the NEXT slot to write
+	size_t _count = 0;  // caps at POCKETDIAL_CDR_RECORDS
+};
+
+#endif

--- a/src/SIP/PbxFeatureConfig.cpp
+++ b/src/SIP/PbxFeatureConfig.cpp
@@ -1,0 +1,560 @@
+// PbxFeatureConfig.cpp: the five PBX feature tables (DND, forwards, ring
+// groups, page zones, dial plan), extracted out of RequestsHandler.
+#include "PbxFeatureConfig.hpp"
+
+#include <algorithm>
+
+#include "PbxPersist.hpp"
+
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+#include "nvs_flash.h"
+#include "nvs.h"
+#endif
+
+namespace
+{
+	using pbxpersist::deserializeBlob;
+}
+
+// ── Do Not Disturb ──────────────────────────────────────────────────────────
+
+void PbxFeatureConfig::setDndLocked(const std::string& extension, bool on)
+{
+	if (on)
+	{
+		// Bound the map so a flood of distinct extensions can't grow the heap
+		// without limit. Mirror the client-pool cap; reject new keys past it.
+		if (_dnd.find(extension) == _dnd.end() &&
+			_dnd.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
+		{
+			_env.log("DND set ignored (table full) for extension " + extension, true);
+		}
+		else
+		{
+			_dnd[extension] = true;
+		}
+	}
+	else
+	{
+		// Turning DND off frees the slot, so the map only ever holds the
+		// extensions that are actively in DND (bounded by registrations).
+		_dnd.erase(extension);
+	}
+	_env.log("DND " + std::string(on ? "enabled" : "disabled") + " for extension " + extension);
+
+	// Refresh the DND view in the dashboard snapshot immediately so the UI
+	// reflects the change without waiting for the next tick(). Same refresh
+	// regardless of whether the mutation came from the HTTP setter or a DTMF
+	// CLASS code (Issue #77) — both funnel through here.
+	_onChanged(Table::Dnd);
+}
+
+bool PbxFeatureConfig::isDndEnabled(const std::string& extension) const
+{
+	// Internal lookup: invoked from onInvite() which already holds _mutex, so this
+	// must NOT take _mutex (std::mutex is non-recursive). Bounded map lookup.
+	auto it = _dnd.find(extension);
+	return it != _dnd.end() && it->second;
+}
+
+std::vector<std::string> PbxFeatureConfig::dndSnapshot() const
+{
+	std::vector<std::string> result;
+	result.reserve(_dnd.size());
+	for (const auto& [ext, enabled] : _dnd)
+	{
+		if (enabled) result.push_back(ext);
+	}
+	return result;
+}
+
+// ── Call forwarding (CFU/CFB/CFNA) ───────────────────────────────────────────
+
+std::string PbxFeatureConfig::getForwardTarget(const std::string& extension, const std::string& trigger) const
+{
+	// Internal lookup invoked from onInvite()/onBusy()/tick(), all of which already
+	// hold _mutex — must NOT lock (non-recursive). Bounded map lookup.
+	auto it = _forwards.find(extension);
+	if (it == _forwards.end())
+	{
+		return {};
+	}
+	if (trigger == "always")   return it->second.always;
+	if (trigger == "busy")     return it->second.busy;
+	if (trigger == "noanswer") return it->second.noAnswer;
+	return {};
+}
+
+void PbxFeatureConfig::setForwardLocked(const std::string& extension, const std::string& trigger, const std::string& target)
+{
+	// Reject the virtual extensions outright; they are not real endpoints.
+	// Previously only the HTTP-facing setForward() applied this guard — the
+	// DTMF *73/*72NNNN inline path skipped it entirely (Issue #77), so a
+	// crafted mid-dialog INFO with From: 777/999 could set up a "forward" on
+	// a virtual extension. Routing both callers through here closes that gap.
+	// "888" is ConferenceRoom::EXT (the meet-me conference) — not referenced
+	// by name here so this file stays decoupled from ConferenceRoom.hpp.
+	if (extension == "777" || extension == "999" || extension == "888")
+	{
+		_env.log("Forward set ignored for virtual extension " + extension, true);
+	}
+	else
+	{
+		auto it = _forwards.find(extension);
+		bool isNew = (it == _forwards.end());
+
+		// Bound the table like _dnd: refuse a brand-new extension past the cap.
+		if (isNew && _forwards.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
+		{
+			_env.log("Forward set ignored (table full) for extension " + extension, true);
+		}
+		else
+		{
+			pbx::ForwardConfig& cfg = _forwards[extension];
+			if (trigger == "always")        cfg.always   = target;
+			else if (trigger == "busy")     cfg.busy     = target;
+			else if (trigger == "noanswer") cfg.noAnswer = target;
+
+			// Drop the entry entirely once no trigger remains set, so the map only
+			// holds actively-forwarded extensions (bounded by registrations).
+			if (cfg.empty())
+			{
+				_forwards.erase(extension);
+			}
+			_env.log("Forward " + trigger + " for " + extension +
+				(target.empty() ? " cleared" : (" -> " + target)));
+			persistForwards();
+		}
+	}
+
+	// Refresh the dashboard snapshot immediately (mirror setDnd). Same refresh
+	// regardless of whether the mutation came from the HTTP setter or a DTMF
+	// CLASS code (Issue #77) — both funnel through here.
+	_onChanged(Table::Forwards);
+}
+
+std::vector<std::tuple<std::string, std::string, std::string, std::string>> PbxFeatureConfig::forwardsSnapshot() const
+{
+	std::vector<std::tuple<std::string, std::string, std::string, std::string>> result;
+	result.reserve(_forwards.size());
+	for (const auto& [ext, cfg] : _forwards)
+	{
+		result.emplace_back(ext, cfg.always, cfg.busy, cfg.noAnswer);
+	}
+	return result;
+}
+
+// ── Ring / hunt groups ───────────────────────────────────────────────────────
+
+const pbx::RingGroup* PbxFeatureConfig::findRingGroup(const std::string& extension) const
+{
+	// Internal lookup from onInvite() (already holds _mutex). Bounded map lookup.
+	auto it = _ringGroups.find(extension);
+	return (it == _ringGroups.end()) ? nullptr : &it->second;
+}
+
+void PbxFeatureConfig::setRingGroup(const std::string& groupExt, const std::string& members, const std::string& mode)
+{
+	// "888" is ConferenceRoom::EXT — see setForwardLocked above for why this
+	// file spells it out instead of including ConferenceRoom.hpp.
+	if (groupExt == "777" || groupExt == "999" || groupExt == "888")
+	{
+		_env.log("Ring group ignored for reserved extension " + groupExt, true);
+	}
+	else
+	{
+		std::vector<std::string> list = pbx::splitMembers(members);
+		if (list.empty())
+		{
+			// Empty membership deletes the group.
+			_ringGroups.erase(groupExt);
+			_env.log("Ring group " + groupExt + " deleted");
+			persistRingGroups();
+		}
+		else
+		{
+			bool isNew = (_ringGroups.find(groupExt) == _ringGroups.end());
+			if (isNew && _ringGroups.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
+			{
+				_env.log("Ring group ignored (table full) for " + groupExt, true);
+			}
+			else
+			{
+				pbx::RingGroup& g = _ringGroups[groupExt];
+				g.members = std::move(list);
+				g.mode = (mode == "hunt") ? pbx::GroupMode::Hunt : pbx::GroupMode::RingAll;
+				_env.log("Ring group " + groupExt + " (" +
+					(g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall") + ") = " +
+					pbx::joinMembers(g.members));
+				persistRingGroups();
+			}
+		}
+	}
+
+	// Refresh dashboard snapshot immediately.
+	_onChanged(Table::RingGroups);
+}
+
+std::vector<std::tuple<std::string, std::string, std::string>> PbxFeatureConfig::ringGroupsSnapshot() const
+{
+	std::vector<std::tuple<std::string, std::string, std::string>> result;
+	result.reserve(_ringGroups.size());
+	for (const auto& [ext, g] : _ringGroups)
+	{
+		result.emplace_back(ext,
+			g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall",
+			pbx::joinMembers(g.members));
+	}
+	return result;
+}
+
+// ── Paging zones (980–989) ────────────────────────────────────────────────────
+
+const pbx::PageZone* PbxFeatureConfig::findPageZone(const std::string& extension) const
+{
+	auto it = _pageZones.find(extension);
+	return (it == _pageZones.end()) ? nullptr : &it->second;
+}
+
+bool PbxFeatureConfig::isPageZoneDialog(const std::string& extension) const
+{
+	return pbx::isPageZoneExt(extension) && _pageZones.find(extension) != _pageZones.end();
+}
+
+void PbxFeatureConfig::setPageZone(const std::string& zoneExt, const std::string& members)
+{
+	if (!pbx::isPageZoneExt(zoneExt))
+	{
+		_env.log("Page zone ignored for non-zone extension " + zoneExt +
+			" (zones are 980-989)", true);
+	}
+	else
+	{
+		std::vector<std::string> list = pbx::splitZoneMembers(members);
+		if (list.empty())
+		{
+			_pageZones.erase(zoneExt);
+			_env.log("Page zone " + zoneExt + " deleted");
+			persistPageZones();
+		}
+		else
+		{
+			bool isNew = (_pageZones.find(zoneExt) == _pageZones.end());
+			if (isNew && _pageZones.size() >= static_cast<size_t>(POCKETDIAL_MAX_PAGE_ZONES))
+			{
+				_env.log("Page zone ignored (table full) for " + zoneExt, true);
+			}
+			else
+			{
+				pbx::PageZone& z = _pageZones[zoneExt];
+				z.members = std::move(list);
+				_env.log("Page zone " + zoneExt + " = " + pbx::joinMembers(z.members));
+				persistPageZones();
+			}
+		}
+	}
+
+	_onChanged(Table::PageZones);
+}
+
+std::vector<std::pair<std::string, std::string>> PbxFeatureConfig::pageZonesSnapshot() const
+{
+	std::vector<std::pair<std::string, std::string>> result;
+	result.reserve(_pageZones.size());
+	for (const auto& [ext, z] : _pageZones)
+	{
+		result.emplace_back(ext, pbx::joinMembers(z.members));
+	}
+	return result;
+}
+
+// ── Dial plan (Issue #69) ─────────────────────────────────────────────────────
+
+void PbxFeatureConfig::setDialRule(const std::string& pattern, const std::string& action,
+	const std::string& target)
+{
+	// Validate once, here, so a bad rule can never reach the SIP thread — and
+	// so the NVS blob (tab/newline delimited) can never be corrupted by a
+	// smuggled separator. Same "log and drop" contract as setRingGroup.
+	if (!pbx::isDialTokenSafe(pattern))
+	{
+		_env.log("Dial rule ignored: invalid pattern \"" + pattern + "\"", true);
+	}
+	else if (pattern == "777" || pattern == "999" || pattern == "440")
+	{
+		// These are handled above the dial plan in onInvite(), so a rule here
+		// would never fire. Refuse it instead of accepting a dead rule.
+		_env.log("Dial rule ignored: " + pattern +
+			" is a reserved extension and is routed before the dial plan", true);
+	}
+	else if (target.empty())
+	{
+		// Empty target deletes the rule (mirrors setRingGroup's empty member list).
+		if (_dialPlan.erase(pattern))
+		{
+			_env.log("Dial rule " + pattern + " deleted");
+			persistDialPlan();
+		}
+	}
+	else if (!pbx::isDialTokenSafe(target))
+	{
+		_env.log("Dial rule ignored: invalid target \"" + target + "\"", true);
+	}
+	else
+	{
+		pbx::DialActionType parsed;
+		if (!pbx::parseDialAction(action, parsed))
+		{
+			_env.log("Dial rule ignored: unknown action \"" + action +
+				"\" (want group|page|park)", true);
+		}
+		else if (parsed == pbx::DialActionType::PageZone && !pbx::isPageZoneExt(target))
+		{
+			_env.log("Dial rule ignored: page target " + target +
+				" is not a paging zone (zones are 980-989)", true);
+		}
+		else if (parsed == pbx::DialActionType::ParkOrbit && !pbx::isParkOrbitExt(target))
+		{
+			_env.log("Dial rule ignored: park target " + target +
+				" is not a park orbit for this build", true);
+		}
+		else
+		{
+			pbx::DialRule rule;
+			rule.pattern = pattern;
+			rule.action = parsed;
+			rule.target = target;
+			if (!_dialPlan.upsert(rule))
+			{
+				_env.log("Dial rule ignored (table full) for " + pattern, true);
+			}
+			else
+			{
+				_env.log("Dial rule " + pattern + " -> " +
+					pbx::dialActionName(parsed) + " " + target);
+				persistDialPlan();
+			}
+		}
+	}
+
+	// Refresh dashboard snapshot immediately (mirrors setRingGroup).
+	_onChanged(Table::DialRules);
+}
+
+std::vector<std::tuple<std::string, std::string, std::string>> PbxFeatureConfig::dialRulesSnapshot() const
+{
+	std::vector<std::tuple<std::string, std::string, std::string>> result;
+	result.reserve(_dialPlan.size());
+	for (const auto& r : _dialPlan.rules())
+	{
+		result.emplace_back(r.pattern, pbx::dialActionName(r.action), r.target);
+	}
+	return result;
+}
+
+// ── Directed / group call pickup (Issue #68) ──────────────────────────────────
+// See PbxConfig.hpp's isGroupPickupCode/directedPickupTarget doc comment: pickup
+// groups are ring-group membership, reused as-is.
+
+std::vector<std::string> PbxFeatureConfig::pickupPeersOf(const std::string& ext) const
+{
+	std::vector<std::string> peers;
+	for (const auto& [groupExt, group] : _ringGroups)
+	{
+		bool isMember = false;
+		for (const auto& m : group.members)
+		{
+			if (m == ext) { isMember = true; break; }
+		}
+		if (!isMember) continue;
+
+		for (const auto& m : group.members)
+		{
+			if (m == ext) continue;
+			if (std::find(peers.begin(), peers.end(), m) == peers.end())
+			{
+				peers.push_back(m);
+			}
+		}
+	}
+	return peers;
+}
+
+// ── NVS persistence ────────────────────────────────────────────────────────
+//
+// All five helpers are no-ops on host (the in-memory maps/ring ARE the store) and
+// gate their NVS access on ESP_PLATFORM. Each table is serialized as a single blob
+// (one record per line; fields tab-separated) under one NVS key, so a mutation
+// rewrites exactly one key — bounded size, low flash wear. Records are bounded by
+// POCKETDIAL_MAX_CLIENTS / POCKETDIAL_MAX_PAGE_ZONES, so the blob can never grow
+// without limit. The AOR charset (isValidAor) excludes tab/newline, so the
+// delimiters are safe. Callers hold _mutex (except construction-time loads, which
+// run single-threaded before any handler dispatches).
+
+void PbxFeatureConfig::loadPbxConfig()
+{
+	if (_pbxConfigLoaded)
+	{
+		return;
+	}
+	_pbxConfigLoaded = true;
+
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	nvs_handle_t h;
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) != ESP_OK)
+	{
+		return;
+	}
+
+	auto readBlob = [&](const char* key) -> std::string {
+		size_t len = 0;
+		if (nvs_get_str(h, key, nullptr, &len) != ESP_OK || len == 0)
+		{
+			return {};
+		}
+		std::string buf(len, '\0');
+		if (nvs_get_str(h, key, buf.data(), &len) != ESP_OK)
+		{
+			return {};
+		}
+		if (!buf.empty() && buf.back() == '\0') buf.pop_back(); // drop NUL terminator
+		return buf;
+	};
+
+	// Forwards: ext \t always \t busy \t noAnswer
+	for (const auto& rec : deserializeBlob(readBlob("forwards")))
+	{
+		if (rec.size() < 4 || rec[0].empty()) continue;
+		if (_forwards.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS)) break;
+		pbx::ForwardConfig cfg;
+		cfg.always = rec[1];
+		cfg.busy = rec[2];
+		cfg.noAnswer = rec[3];
+		if (!cfg.empty()) _forwards[rec[0]] = std::move(cfg);
+	}
+
+	// Ring groups: ext \t mode \t m1,m2,...
+	for (const auto& rec : deserializeBlob(readBlob("groups")))
+	{
+		if (rec.size() < 3 || rec[0].empty()) continue;
+		if (_ringGroups.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS)) break;
+		pbx::RingGroup g;
+		g.mode = (rec[1] == "hunt") ? pbx::GroupMode::Hunt : pbx::GroupMode::RingAll;
+		g.members = pbx::splitMembers(rec[2]);
+		if (!g.members.empty()) _ringGroups[rec[0]] = std::move(g);
+	}
+
+	// Page zones: ext \t m1,m2,...
+	for (const auto& rec : deserializeBlob(readBlob("pzones")))
+	{
+		if (rec.size() < 2 || rec[0].empty()) continue;
+		if (_pageZones.size() >= static_cast<size_t>(POCKETDIAL_MAX_PAGE_ZONES)) break;
+		pbx::PageZone z;
+		z.members = pbx::splitZoneMembers(rec[1]);
+		if (!z.members.empty()) _pageZones[rec[0]] = std::move(z);
+	}
+
+	// Dial plan (Issue #69): pattern \t action \t target, one record per rule, in
+	// evaluation order. DialPlan::upsert() enforces POCKETDIAL_MAX_DIAL_RULES on
+	// its own, so a blob written by a build with a larger cap simply stops being
+	// applied at this build's ceiling instead of overflowing it. Records that no
+	// longer validate (an unknown action, or a park target outside a shrunken
+	// POCKETDIAL_PARK_SLOTS) are dropped rather than loaded.
+	for (const auto& rec : deserializeBlob(readBlob("dplan")))
+	{
+		if (rec.size() < 3 || rec[0].empty() || rec[2].empty()) continue;
+		pbx::DialRule rule;
+		if (!pbx::parseDialAction(rec[1], rule.action)) continue;
+		if (!pbx::isDialTokenSafe(rec[0]) || !pbx::isDialTokenSafe(rec[2])) continue;
+		if (rule.action == pbx::DialActionType::PageZone && !pbx::isPageZoneExt(rec[2])) continue;
+		if (rule.action == pbx::DialActionType::ParkOrbit && !pbx::isParkOrbitExt(rec[2])) continue;
+		rule.pattern = rec[0];
+		rule.target = rec[2];
+		if (!_dialPlan.upsert(rule)) break;   // table full at this build's cap
+	}
+
+	nvs_close(h);
+#endif
+}
+
+void PbxFeatureConfig::persistForwards()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	std::string blob;
+	for (const auto& [ext, cfg] : _forwards)
+	{
+		blob += ext; blob += '\t';
+		blob += cfg.always; blob += '\t';
+		blob += cfg.busy; blob += '\t';
+		blob += cfg.noAnswer; blob += '\n';
+	}
+	nvs_handle_t h;
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) == ESP_OK)
+	{
+		nvs_set_str(h, "forwards", blob.c_str());
+		nvs_commit(h);
+		nvs_close(h);
+	}
+#endif
+}
+
+void PbxFeatureConfig::persistRingGroups()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	std::string blob;
+	for (const auto& [ext, g] : _ringGroups)
+	{
+		blob += ext; blob += '\t';
+		blob += (g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall"); blob += '\t';
+		blob += pbx::joinMembers(g.members); blob += '\n';
+	}
+	nvs_handle_t h;
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) == ESP_OK)
+	{
+		nvs_set_str(h, "groups", blob.c_str());
+		nvs_commit(h);
+		nvs_close(h);
+	}
+#endif
+}
+
+void PbxFeatureConfig::persistPageZones()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	std::string blob;
+	for (const auto& [ext, z] : _pageZones)
+	{
+		blob += ext; blob += '\t';
+		blob += pbx::joinMembers(z.members); blob += '\n';
+	}
+	nvs_handle_t h;
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) == ESP_OK)
+	{
+		nvs_set_str(h, "pzones", blob.c_str());
+		nvs_commit(h);
+		nvs_close(h);
+	}
+#endif
+}
+
+void PbxFeatureConfig::persistDialPlan()
+{
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+	// Order matters here in a way it does not for the maps above: the blob is
+	// written (and replayed) in table order, because that IS the evaluation order.
+	std::string blob;
+	for (const auto& r : _dialPlan.rules())
+	{
+		blob += r.pattern; blob += '\t';
+		blob += pbx::dialActionName(r.action); blob += '\t';
+		blob += r.target; blob += '\n';
+	}
+	nvs_handle_t h;
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) == ESP_OK)
+	{
+		nvs_set_str(h, "dplan", blob.c_str());
+		nvs_commit(h);
+		nvs_close(h);
+	}
+#endif
+}

--- a/src/SIP/PbxFeatureConfig.hpp
+++ b/src/SIP/PbxFeatureConfig.hpp
@@ -1,0 +1,143 @@
+#ifndef PBX_FEATURE_CONFIG_HPP
+#define PBX_FEATURE_CONFIG_HPP
+
+#include <functional>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "PbxConfig.hpp"
+#include "DialPlan.hpp"
+#include "PbxEnv.hpp"
+
+// Owns the five bounded, NVS-persisted PBX feature tables that used to live
+// directly on RequestsHandler: DND flags, call-forward config, ring/hunt
+// groups, paging zones, and the dial plan rule table. Every method here
+// assumes the caller already holds RequestsHandler's _mutex — same
+// caller-holds-lock convention as the other decomposed machines
+// (TransactionLayer, Registrar, ...). This one is reached through a plain
+// `PbxEnv&` reference (for logging only, via the existing PbxEnv::log()) plus
+// a narrow `OnChanged` callback, rather than the full PbxEnv surface: it needs
+// no message pool, no sessions, no outbox — just data, validation, and NVS.
+//
+// The OnChanged callback exists because three of these setters (setRingGroup,
+// setPageZone, setDialRule) and the two "Locked" DND/forward mutators refresh
+// RequestsHandler's dashboard snapshot IMMEDIATELY on every mutation (Issue
+// #77) — including from RequestsHandler::onDtmfInfo, which calls
+// setDndLocked()/setForwardLocked() directly while already holding _mutex, not
+// through the public HTTP-facing setters. That immediate-refresh contract has
+// to survive the move, and RequestsHandler owns the snapshot/_snapshotMutex
+// (per the decomposition's rule that snapshot mirroring stays in the engine),
+// so this class can only ASK the engine to refresh, not do it directly.
+class PbxFeatureConfig
+{
+public:
+	// Which table changed, for the OnChanged callback -> RequestsHandler's
+	// refreshPbxConfigSnapshot(Table) switch.
+	enum class Table { Dnd, Forwards, RingGroups, PageZones, DialRules };
+	using OnChanged = std::function<void(Table)>;
+
+	PbxFeatureConfig(PbxEnv& env, OnChanged onChanged)
+		: _env(env), _onChanged(std::move(onChanged)) {}
+
+	// ── Do Not Disturb ────────────────────────────────────────────────────────
+	// Lock-already-held mutation core (Issue #77): shared by the public
+	// RequestsHandler::setDnd() (after it takes _mutex) and
+	// RequestsHandler::onDtmfInfo()'s *60/*80 CLASS codes (already inside
+	// _mutex via handle()), so both paths refresh the dashboard snapshot the
+	// same way instead of onDtmfInfo leaving it stale.
+	void setDndLocked(const std::string& extension, bool on);
+	// Internal lookup used by onInvite(). Caller MUST already hold _mutex —
+	// bounded map lookup, no locking of its own.
+	bool isDndEnabled(const std::string& extension) const;
+	// Snapshot-shaped view (extensions currently in DND) for
+	// RequestsHandler::refreshPbxConfigSnapshot() and tick()'s periodic full
+	// rebuild. Caller holds _mutex — this performs no locking of its own.
+	std::vector<std::string> dndSnapshot() const;
+
+	// ── Call forwarding (CFU/CFB/CFNA) ───────────────────────────────────────
+	// Internal lookup used by onInvite()/onBusy()/tick(). Caller MUST already
+	// hold _mutex. Returns "" when no forward of that trigger is configured.
+	std::string getForwardTarget(const std::string& extension, const std::string& trigger) const;
+	// Lock-already-held mutation core (Issue #77), same sharing rationale as
+	// setDndLocked above (onDtmfInfo's *73/*72NNNN CLASS codes).
+	void setForwardLocked(const std::string& extension, const std::string& trigger, const std::string& target);
+	std::vector<std::tuple<std::string, std::string, std::string, std::string>> forwardsSnapshot() const;
+
+	// ── Ring / hunt groups ────────────────────────────────────────────────────
+	// Internal lookup from onInvite(). Caller MUST already hold _mutex.
+	const pbx::RingGroup* findRingGroup(const std::string& extension) const;
+	// Full validate + mutate + persist + snapshot-refresh, called from
+	// RequestsHandler::setRingGroup() after it takes _mutex.
+	void setRingGroup(const std::string& groupExt, const std::string& members, const std::string& mode);
+	std::vector<std::tuple<std::string, std::string, std::string>> ringGroupsSnapshot() const;
+
+	// ── Paging zones (980–989) ────────────────────────────────────────────────
+	const pbx::PageZone* findPageZone(const std::string& extension) const;
+	bool isPageZoneDialog(const std::string& extension) const;
+	void setPageZone(const std::string& zoneExt, const std::string& members);
+	std::vector<std::pair<std::string, std::string>> pageZonesSnapshot() const;
+
+	// ── Dial plan (Issue #69) ─────────────────────────────────────────────────
+	void setDialRule(const std::string& pattern, const std::string& action, const std::string& target);
+	std::vector<std::tuple<std::string, std::string, std::string>> dialRulesSnapshot() const;
+	// Read-only access for routeDialPlan() (still in RequestsHandler.cpp until
+	// the fork/group engine extraction) to call .empty()/.match() on directly.
+	const pbx::DialPlan& dialPlan() const { return _dialPlan; }
+
+	// ── Directed / group call pickup (Issue #68) ──────────────────────────────
+	// Every OTHER extension co-membered with `ext` in any configured ring
+	// group, deduped and order-preserving. Empty if `ext` is in no group. Pure
+	// membership query over _ringGroups — the rest of pickup (session-ringing
+	// lookups) stays with RequestsHandler until the pickup/INVITE-dispatch
+	// extraction. Caller holds _mutex.
+	std::vector<std::string> pickupPeersOf(const std::string& ext) const;
+
+	// Boot-time reload of all five tables from NVS. No-op on host (the maps are
+	// the store). Construction is single-threaded (no handler is dispatching
+	// yet), so this needs no lock; called once from RequestsHandler's
+	// constructor, guarded by _pbxConfigLoaded against being re-run.
+	void loadPbxConfig();
+
+private:
+	void persistForwards();
+	void persistRingGroups();
+	void persistPageZones();
+	void persistDialPlan();
+
+	PbxEnv& _env;
+	OnChanged _onChanged;
+
+	// DND state, keyed by extension. Bounded by the client-pool depth: an entry
+	// is only created when DND is turned ON, and turning it OFF erases the
+	// entry, so the map can never hold more than POCKETDIAL_MAX_CLIENTS live
+	// extensions. (A std::shared_ptr<SipClient> flag would be lost across
+	// re-REGISTER / pool eviction; keying by extension keeps DND sticky.)
+	std::unordered_map<std::string, bool> _dnd;
+
+	// Call-forwarding config, keyed by extension (Class A sweep). Same
+	// bounding/stickiness rationale as _dnd: an entry exists only while at
+	// least one trigger is set, and is bounded by POCKETDIAL_MAX_CLIENTS.
+	std::unordered_map<std::string, pbx::ForwardConfig> _forwards;
+
+	// Ring/hunt groups, keyed by the group extension (e.g. 6xx). Bounded by
+	// POCKETDIAL_MAX_CLIENTS groups; each member list is bounded by
+	// splitMembers().
+	std::unordered_map<std::string, pbx::RingGroup> _ringGroups;
+
+	// Paging zones, keyed by the zone extension (980–989). Bounded by
+	// POCKETDIAL_MAX_PAGE_ZONES; member lists bounded by splitZoneMembers().
+	std::unordered_map<std::string, pbx::PageZone> _pageZones;
+
+	// Dial-plan rule table (Issue #69). An ORDERED vector, not a map: first
+	// match wins, so evaluation order is the semantics. Hard-capped at
+	// POCKETDIAL_MAX_DIAL_RULES by DialPlan::upsert(). Empty by default, and an
+	// empty table is a no-op on routing.
+	pbx::DialPlan _dialPlan;
+
+	bool _pbxConfigLoaded = false;
+};
+
+#endif

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1,5 +1,6 @@
 // RequestsHandler.cpp: Issues #24 and #28 resolved.
 #include "RequestsHandler.hpp"
+#include "SipMessagePool.hpp"
 #include <atomic>
 #include <sstream>
 #include <cctype>
@@ -33,8 +34,6 @@
 	#include "esp_system.h"
 	#include "esp_idf_version.h"
 #endif
-
-std::vector<std::shared_ptr<SipMessage>> RequestsHandler::_messagePool;
 
 // File-scope static helpers defined later in this translation unit.
 static bool sameAddress(const sockaddr_in&, const sockaddr_in&);
@@ -82,14 +81,7 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 	{
 		_sessionPool.push_back(std::make_shared<Session>());
 	}
-	if (_messagePool.empty())
-	{
-		_messagePool.reserve(POCKETDIAL_MSG_POOL);
-		for (int i = 0; i < POCKETDIAL_MSG_POOL; ++i)
-		{
-			_messagePool.push_back(std::make_shared<SipSdpMessage>("", sockaddr_in{}));
-		}
-	}
+	sipmsgpool::ensureInitialized();
 	_virtualPeerPool.reserve(POCKETDIAL_VIRTUAL_PEERS);
 	for (int i = 0; i < POCKETDIAL_VIRTUAL_PEERS; ++i)
 	{
@@ -116,61 +108,16 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 	refreshDeviceSnapshot();
 }
 
-// ── Message pool synchronization (Issue #101(A) / #101(E)) ──────────────────
-//
-// Leaf lock guarding the static _messagePool. LEAF means exactly that: nothing
-// inside its critical section may acquire another lock, ever. That is what makes
-// it safe to take whether or not the caller already holds _mutex, with no lock
-// ordering to reason about.
-//
-// It is needed because handing a slot out is a check-then-take (scan for
-// use_count()==1, then copy the shared_ptr) over a pool reachable from two
-// tasks at once:
-//
-//   * the UDP receive task (UdpServer.cpp:134) -> SipServer::onNewMessage ->
-//     SipMessageFactory::createMessage -> getMessageFromPool, holding NO lock —
-//     handle() only takes _mutex afterwards, on the already-allocated message;
-//   * the tick task (esp_main.cpp:192, or SipServer::tickLoop on desktop) ->
-//     tick() -> TransactionLayer::sweep -> messageFromPool, under _mutex.
-//
-// Unsynchronized, both could observe use_count()==1 on the same slot and both
-// take it, then reset() it concurrently — two owners writing the same
-// SipMessage, reallocating its strings under each other. _mutex on one side does
-// not help: a lock only excludes other holders of that same lock. Found by the
-// #101(E) audit, fixed here because it lives in the function #101(A) rewrites.
-static std::mutex s_msgPoolMutex;
-
-// Heap-fallback messages currently alive. Atomic because the decrement happens
-// in the deleter, which runs wherever the last reference happens to drop —
-// commonly on the socket-send path after the outbox is drained, outside every
-// lock we hold here.
-static std::atomic<std::size_t> s_msgHeapFallbacksInFlight{0};
-
-namespace
-{
-	// Releases a bounded heap-fallback message and gives its budget back.
-	//
-	// MUST NOT take s_msgPoolMutex (or any lock): the last reference can drop
-	// while that mutex is held — dropping a superseded message inside the pool
-	// critical section would self-deadlock on a non-recursive mutex. An atomic
-	// decrement is all this is allowed to do.
-	struct HeapFallbackDeleter
-	{
-		void operator()(SipMessage* p) const noexcept
-		{
-			delete p;
-			s_msgHeapFallbacksInFlight.fetch_sub(1, std::memory_order_relaxed);
-		}
-	};
-}
-
-// Same bounded-fallback bookkeeping for the virtual-peer pool. Separate budget:
-// a virtual peer is a long-lived per-park-slot stand-in, not a per-packet object.
+// Same bounded-fallback bookkeeping for the virtual-peer pool as the message
+// pool uses (SipMessagePool.cpp). Separate budget: a virtual peer is a
+// long-lived per-park-slot stand-in, not a per-packet object.
 static std::atomic<std::size_t> s_vpeerHeapFallbacksInFlight{0};
 
 namespace
 {
-	// Same no-locking rule as HeapFallbackDeleter above.
+	// Same no-locking rule as SipMessagePool's HeapFallbackDeleter: the last
+	// reference can drop while a pool-critical-section lock is held elsewhere,
+	// so the deleter must not itself take any lock.
 	struct VpeerFallbackDeleter
 	{
 		void operator()(SipClient* p) const noexcept
@@ -181,107 +128,17 @@ namespace
 	};
 }
 
-// Two distinct signals, deliberately. `Fallback` fires the moment the fixed pool
-// runs dry and the heap fallback takes over — pressure building, nothing lost yet.
-// `Refused` fires once the fallback budget is spent too and packets are actually
-// being dropped. Collapsing them (as an earlier cut of #101(A) did) removes the
-// only early warning an operator gets and reports trouble solely after the damage.
-enum class PoolPressure { Fallback, Refused };
-
-static void logPoolExhausted(const char* poolName, PoolPressure level,
-	std::atomic<std::size_t>& warnCount)
-{
-	// Rate-limited 1-in-100: a flood that drains the pool would otherwise also
-	// flood the log pipe. The running total is kept in the message so the sampling
-	// does not hide the true magnitude.
-	const std::size_t n = warnCount.fetch_add(1, std::memory_order_relaxed) + 1;
-	if ((n - 1) % 100 == 0)
-	{
-		std::cerr << "[WARNING] " << poolName << " pool exhausted ("
-			<< n << " total)! "
-			<< (level == PoolPressure::Fallback
-				? "Falling back to bounded heap allocation.\n"
-				: "Fallback budget spent — DROPPING packets.\n");
-	}
-}
-
-std::shared_ptr<SipMessage> RequestsHandler::acquirePooledMessage()
-{
-	std::lock_guard<std::mutex> poolLock(s_msgPoolMutex);
-
-	for (auto& msg : _messagePool)
-	{
-		if (msg.use_count() == 1)
-		{
-			// The mutex serializes TAKERS, but the previous owner released this
-			// slot outside it — typically on the send path once the drained outbox
-			// goes out of scope. use_count() is only an atomic load, so on its own
-			// it establishes no happens-before with that releasing thread, and the
-			// reset() we are about to authorize reads the message's existing string
-			// and vector internals before overwriting them. This fence pairs with
-			// the release the refcount decrement performs, so those writes are
-			// visible before we hand the slot on.
-			std::atomic_thread_fence(std::memory_order_acquire);
-			// Copy INSIDE the lock: the copy is what publishes use_count()==2 and
-			// so what makes this slot invisible to the other task's scan. Callers
-			// initialize it (reset() / operator=) after we return, by which point
-			// they own it exclusively — keeping the critical section to a scan.
-			return msg;
-		}
-	}
-
-	// Pool drawn down: fall back to the heap, but only up to a fixed number alive
-	// at once (Issue #101(A)). Past that, refuse and let the caller drop. Both
-	// transitions are logged, from here rather than the callers, so the two
-	// getMessageFromPool overloads share one rate-limit counter per pool instead
-	// of each sampling 1-in-100 independently under the same label.
-	static std::atomic<std::size_t> msgWarnCount{0};
-	if (s_msgHeapFallbacksInFlight.load(std::memory_order_relaxed) >= POCKETDIAL_MSG_HEAP_FALLBACK_MAX)
-	{
-		logPoolExhausted("SIP Message", PoolPressure::Refused, msgWarnCount);
-		return nullptr;
-	}
-	logPoolExhausted("SIP Message", PoolPressure::Fallback, msgWarnCount);
-
-	SipMessage* raw = nullptr;
-	try
-	{
-		raw = new SipSdpMessage("", sockaddr_in{});
-	}
-	catch (const std::bad_alloc&)
-	{
-		return nullptr;   // budget untouched — nothing was handed out
-	}
-
-	s_msgHeapFallbacksInFlight.fetch_add(1, std::memory_order_relaxed);
-	try
-	{
-		return std::shared_ptr<SipMessage>(raw, HeapFallbackDeleter{});
-	}
-	catch (const std::bad_alloc&)
-	{
-		// The shared_ptr constructor takes ownership of `raw` before it can throw,
-		// and the standard requires it to run the deleter if it does. So `raw` is
-		// already deleted and the counter already decremented — undoing either
-		// here would be a double free / double decrement.
-		return nullptr;
-	}
-}
-
+// Forwarders onto the static pool in SipMessagePool.cpp (Issue #53 / #101(A) /
+// #101(E)). Kept as public statics on RequestsHandler because SipMessageFactory,
+// the handler table, and the test suite all call them by this name.
 std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(std::string_view message, sockaddr_in src)
 {
-	std::shared_ptr<SipMessage> msg = acquirePooledMessage();
-	if (!msg) return nullptr;   // acquirePooledMessage() already logged the pressure
-	msg->reset(message, src);
-	return msg;
+	return sipmsgpool::getMessageFromPool(message, src);
 }
 
 std::shared_ptr<SipMessage> RequestsHandler::getMessageFromPool(const SipMessage& source)
 {
-	std::shared_ptr<SipMessage> msg = acquirePooledMessage();
-	if (!msg) return nullptr;   // acquirePooledMessage() already logged the pressure
-	*msg = source;
-	return msg;
+	return sipmsgpool::getMessageFromPool(source);
 }
 
 void RequestsHandler::initHandlers()
@@ -5266,7 +5123,7 @@ std::shared_ptr<SipClient> RequestsHandler::allocateVirtualPeer(std::string numb
 	// is (Issue #101(A)). Past the ceiling this returns nullptr and the caller
 	// abandons the park/BLF operation rather than allocating without limit.
 	//
-	// No pool lock here, unlike acquirePooledMessage(): _virtualPeerPool is a
+	// No pool lock here, unlike SipMessagePool's acquirePooledMessage(): _virtualPeerPool is a
 	// per-instance member and every caller — the internal sites and ParkOrbit via
 	// PbxEnv::allocVirtualPeer — already runs under _mutex. The counter is still
 	// atomic because its decrement happens in the deleter, which runs wherever
@@ -5274,10 +5131,10 @@ std::shared_ptr<SipClient> RequestsHandler::allocateVirtualPeer(std::string numb
 	static std::atomic<std::size_t> vpeerWarnCount{0};
 	if (s_vpeerHeapFallbacksInFlight.load(std::memory_order_relaxed) >= POCKETDIAL_VPEER_HEAP_FALLBACK_MAX)
 	{
-		logPoolExhausted("Virtual-peer", PoolPressure::Refused, vpeerWarnCount);
+		sipmsgpool::logPoolExhausted("Virtual-peer", sipmsgpool::PoolPressure::Refused, vpeerWarnCount);
 		return nullptr;
 	}
-	logPoolExhausted("Virtual-peer", PoolPressure::Fallback, vpeerWarnCount);
+	sipmsgpool::logPoolExhausted("Virtual-peer", sipmsgpool::PoolPressure::Fallback, vpeerWarnCount);
 
 	SipClient* raw = nullptr;
 	try

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -57,7 +57,9 @@ namespace
 	// NVS namespaces / keys for the persisted PBX config and CDR ring. Kept short
 	// (NVS keys are capped at 15 chars). Forward/group entries are stored one blob
 	// per extension so a single mutation rewrites only its own key (low flash wear).
-	constexpr auto NVS_PBX_NS  = "pbxcfg";
+	// The PBX-config namespace itself is pbxpersist::kNvsNamespace (PbxPersist.hpp)
+	// now — used here too (loadAdminHttpTtl/loadAdminExt/saveAdminExt) so there is
+	// exactly one definition of "pbxcfg" in the codebase.
 	constexpr auto NVS_CDR_NS  = "cdrlog";
 }
 
@@ -91,7 +93,7 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 	// Reload persisted PBX config (call-forward / ring groups) and the CDR ring from
 	// NVS so they survive reboot. No-ops on host. Construction is single-threaded
 	// (no handler is dispatching yet), so these run without holding _mutex.
-	loadPbxConfig();
+	_cfg.loadPbxConfig();
 	loadCdrRing();
 	// Task 2B: load the admin extension from NVS (defaults to "1001" if absent).
 	loadAdminExt();
@@ -561,7 +563,7 @@ void RequestsHandler::onCancel(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
-	if (destNumber == "999" || isPageZoneDialog(destNumber))
+	if (destNumber == "999" || _cfg.isPageZoneDialog(destNumber))
 	{
 		auto session = getSession(data->getCallID());
 		if (session.has_value())
@@ -792,7 +794,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// normal routing (and 404s, since 98x is not a real extension/group target).
 	if (pbx::isPageZoneExt(destNumber))
 	{
-		if (const pbx::PageZone* zone = findPageZone(destNumber))
+		if (const pbx::PageZone* zone = _cfg.findPageZone(destNumber))
 		{
 			routePageZone(data, caller.value(), *zone);
 			return;
@@ -832,12 +834,12 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// PbxConfig.hpp's doc comment for why directed pickup isn't exempted.
 	if (pbx::isGroupPickupCode(destNumber))
 	{
-		onPickup(data, caller.value(), pickupPeersOf(caller.value()->getNumber()));
+		onPickup(data, caller.value(), _cfg.pickupPeersOf(caller.value()->getNumber()));
 		return;
 	}
 	if (std::string target = pbx::directedPickupTarget(destNumber); !target.empty())
 	{
-		auto peers = pickupPeersOf(caller.value()->getNumber());
+		auto peers = _cfg.pickupPeersOf(caller.value()->getNumber());
 		bool eligible = target != caller.value()->getNumber() &&
 			std::find(peers.begin(), peers.end(), target) != peers.end();
 		onPickup(data, caller.value(), eligible ? std::vector<std::string>{ target } : std::vector<std::string>{});
@@ -849,7 +851,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// intercom auto-answer headers, so members ring normally); hunt rings members one
 	// at a time, driven from tick(). Resolved before DND because a group ext is not a
 	// real endpoint and so never carries its own DND/forward config.
-	if (const pbx::RingGroup* group = findRingGroup(destNumber))
+	if (const pbx::RingGroup* group = _cfg.findRingGroup(destNumber))
 	{
 		routeRingGroup(data, caller.value(), destNumber, *group);
 		return;
@@ -873,7 +875,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// Call Forward Unconditional (CFU): if the destination has an "always" forward
 	// target, redirect the call to that target before ringing the original callee.
 	{
-		std::string cfu = getForwardTarget(destNumber, "always");
+		std::string cfu = _cfg.getForwardTarget(destNumber, "always");
 		if (!cfu.empty() && cfu != destNumber)
 		{
 			queueLog("CFU: forwarding " + destNumber + " -> " + cfu);
@@ -889,7 +891,7 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// with 480 Temporarily Unavailable instead of ringing it. This branch is reached
 	// only for ordinary extensions — the virtual 777 (echo) and 999 (broadcast)
 	// extensions are handled above and so are never affected by DND.
-	if (isDndEnabled(destNumber))
+	if (_cfg.isDndEnabled(destNumber))
 	{
 		auto response = getMessageFromPool(*data);
 		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
@@ -952,8 +954,8 @@ void RequestsHandler::onInvite(std::shared_ptr<SipMessage> data)
 	// isSessionRingingExt() finds "who's ringing" for call pickup (Issue #68)
 	// without needing to pre-populate Session::dest before an answer exists.
 	newSession->setInviteMessage(data);
-	std::string cfb  = getForwardTarget(destNumber, "busy");
-	std::string cfna = getForwardTarget(destNumber, "noanswer");
+	std::string cfb  = _cfg.getForwardTarget(destNumber, "busy");
+	std::string cfna = _cfg.getForwardTarget(destNumber, "noanswer");
 	if (!cfna.empty() && cfna != destNumber)
 	{
 		newSession->setNoAnswerTarget(cfna);
@@ -1325,7 +1327,7 @@ void RequestsHandler::onBusy(std::shared_ptr<SipMessage> data)
 	if (session.has_value())
 	{
 		std::string busyExt(data->getFromNumber());
-		std::string cfb = getForwardTarget(busyExt, "busy");
+		std::string cfb = _cfg.getForwardTarget(busyExt, "busy");
 		if (!cfb.empty() && cfb != busyExt)
 		{
 			auto inviteMsg = session.value()->getInviteMessage();
@@ -1435,7 +1437,7 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
-	if (destNumber == "999" || isPageZoneDialog(destNumber))
+	if (destNumber == "999" || _cfg.isPageZoneDialog(destNumber))
 	{
 		auto response = getMessageFromPool(*data);
 		if (!response) return;   // pool exhausted: drop, peer retransmits (#101A)
@@ -2668,51 +2670,12 @@ std::optional<RequestsHandler::ProvisioningInfo> RequestsHandler::findProvisioni
 	return std::nullopt;
 }
 
-void RequestsHandler::setDndLocked(const std::string& extension, bool on)
-{
-	if (on)
-	{
-		// Bound the map so a flood of distinct extensions can't grow the heap
-		// without limit. Mirror the client-pool cap; reject new keys past it.
-		if (_dnd.find(extension) == _dnd.end() &&
-			_dnd.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
-		{
-			queueLog("DND set ignored (table full) for extension " + extension, true);
-		}
-		else
-		{
-			_dnd[extension] = true;
-		}
-	}
-	else
-	{
-		// Turning DND off frees the slot, so the map only ever holds the
-		// extensions that are actively in DND (bounded by registrations).
-		_dnd.erase(extension);
-	}
-	queueLog("DND " + std::string(on ? "enabled" : "disabled") + " for extension " + extension);
-
-	// Refresh the DND view in the dashboard snapshot immediately so the UI
-	// reflects the change without waiting for the next tick(). Same refresh
-	// regardless of whether the mutation came from the HTTP setter or a DTMF
-	// CLASS code (Issue #77) — both funnel through here.
-	{
-		std::lock_guard<std::mutex> snapLock(_snapshotMutex);
-		_snapshot.dnd.clear();
-		_snapshot.dnd.reserve(_dnd.size());
-		for (const auto& [ext, enabled] : _dnd)
-		{
-			if (enabled) _snapshot.dnd.push_back(ext);
-		}
-	}
-}
-
 void RequestsHandler::setDnd(const std::string& extension, bool on)
 {
 	std::vector<std::pair<bool, std::string>> localLogs;
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
-		setDndLocked(extension, on);
+		_cfg.setDndLocked(extension, on);
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}
@@ -2724,14 +2687,6 @@ void RequestsHandler::setDnd(const std::string& extension, bool on)
 	}
 }
 
-bool RequestsHandler::isDndEnabled(const std::string& extension)
-{
-	// Internal lookup: invoked from onInvite() which already holds _mutex, so this
-	// must NOT take _mutex (std::mutex is non-recursive). Bounded map lookup.
-	auto it = _dnd.find(extension);
-	return it != _dnd.end() && it->second;
-}
-
 std::vector<std::string> RequestsHandler::getDndExtensions()
 {
 	std::lock_guard<std::mutex> lock(_snapshotMutex);
@@ -2740,81 +2695,12 @@ std::vector<std::string> RequestsHandler::getDndExtensions()
 
 // ── Call forwarding (CFU/CFB/CFNA) ───────────────────────────────────────────
 
-std::string RequestsHandler::getForwardTarget(const std::string& extension, const std::string& trigger) const
-{
-	// Internal lookup invoked from onInvite()/onBusy()/tick(), all of which already
-	// hold _mutex — must NOT lock (non-recursive). Bounded map lookup.
-	auto it = _forwards.find(extension);
-	if (it == _forwards.end())
-	{
-		return {};
-	}
-	if (trigger == "always")   return it->second.always;
-	if (trigger == "busy")     return it->second.busy;
-	if (trigger == "noanswer") return it->second.noAnswer;
-	return {};
-}
-
-void RequestsHandler::setForwardLocked(const std::string& extension, const std::string& trigger, const std::string& target)
-{
-	// Reject the virtual extensions outright; they are not real endpoints.
-	// Previously only the HTTP-facing setForward() applied this guard — the
-	// DTMF *73/*72NNNN inline path skipped it entirely (Issue #77), so a
-	// crafted mid-dialog INFO with From: 777/999 could set up a "forward" on
-	// a virtual extension. Routing both callers through here closes that gap.
-	if (extension == "777" || extension == "999" || extension == ConferenceRoom::EXT)
-	{
-		queueLog("Forward set ignored for virtual extension " + extension, true);
-	}
-	else
-	{
-		auto it = _forwards.find(extension);
-		bool isNew = (it == _forwards.end());
-
-		// Bound the table like _dnd: refuse a brand-new extension past the cap.
-		if (isNew && _forwards.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
-		{
-			queueLog("Forward set ignored (table full) for extension " + extension, true);
-		}
-		else
-		{
-			pbx::ForwardConfig& cfg = _forwards[extension];
-			if (trigger == "always")        cfg.always   = target;
-			else if (trigger == "busy")     cfg.busy     = target;
-			else if (trigger == "noanswer") cfg.noAnswer = target;
-
-			// Drop the entry entirely once no trigger remains set, so the map only
-			// holds actively-forwarded extensions (bounded by registrations).
-			if (cfg.empty())
-			{
-				_forwards.erase(extension);
-			}
-			queueLog("Forward " + trigger + " for " + extension +
-				(target.empty() ? " cleared" : (" -> " + target)));
-			persistForwards();
-		}
-	}
-
-	// Refresh the dashboard snapshot immediately (mirror setDnd). Same refresh
-	// regardless of whether the mutation came from the HTTP setter or a DTMF
-	// CLASS code (Issue #77) — both funnel through here.
-	{
-		std::lock_guard<std::mutex> snapLock(_snapshotMutex);
-		_snapshot.forwards.clear();
-		_snapshot.forwards.reserve(_forwards.size());
-		for (const auto& [ext, cfg] : _forwards)
-		{
-			_snapshot.forwards.emplace_back(ext, cfg.always, cfg.busy, cfg.noAnswer);
-		}
-	}
-}
-
 void RequestsHandler::setForward(const std::string& extension, const std::string& trigger, const std::string& target)
 {
 	std::vector<std::pair<bool, std::string>> localLogs;
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
-		setForwardLocked(extension, trigger, target);
+		_cfg.setForwardLocked(extension, trigger, target);
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}
@@ -2834,66 +2720,12 @@ std::vector<std::tuple<std::string, std::string, std::string, std::string>> Requ
 
 // ── Ring / hunt groups ───────────────────────────────────────────────────────
 
-const pbx::RingGroup* RequestsHandler::findRingGroup(const std::string& extension) const
-{
-	// Internal lookup from onInvite() (already holds _mutex). Bounded map lookup.
-	auto it = _ringGroups.find(extension);
-	return (it == _ringGroups.end()) ? nullptr : &it->second;
-}
-
 void RequestsHandler::setRingGroup(const std::string& groupExt, const std::string& members, const std::string& mode)
 {
 	std::vector<std::pair<bool, std::string>> localLogs;
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
-
-		if (groupExt == "777" || groupExt == "999" || groupExt == ConferenceRoom::EXT)
-		{
-			queueLog("Ring group ignored for reserved extension " + groupExt, true);
-		}
-		else
-		{
-			std::vector<std::string> list = pbx::splitMembers(members);
-			if (list.empty())
-			{
-				// Empty membership deletes the group.
-				_ringGroups.erase(groupExt);
-				queueLog("Ring group " + groupExt + " deleted");
-				persistRingGroups();
-			}
-			else
-			{
-				bool isNew = (_ringGroups.find(groupExt) == _ringGroups.end());
-				if (isNew && _ringGroups.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS))
-				{
-					queueLog("Ring group ignored (table full) for " + groupExt, true);
-				}
-				else
-				{
-					pbx::RingGroup& g = _ringGroups[groupExt];
-					g.members = std::move(list);
-					g.mode = (mode == "hunt") ? pbx::GroupMode::Hunt : pbx::GroupMode::RingAll;
-					queueLog("Ring group " + groupExt + " (" +
-						(g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall") + ") = " +
-						pbx::joinMembers(g.members));
-					persistRingGroups();
-				}
-			}
-		}
-
-		// Refresh dashboard snapshot immediately.
-		{
-			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
-			_snapshot.ringGroups.clear();
-			_snapshot.ringGroups.reserve(_ringGroups.size());
-			for (const auto& [ext, g] : _ringGroups)
-			{
-				_snapshot.ringGroups.emplace_back(ext,
-					g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall",
-					pbx::joinMembers(g.members));
-			}
-		}
-
+		_cfg.setRingGroup(groupExt, members, mode);
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}
@@ -2909,6 +2741,33 @@ std::vector<std::tuple<std::string, std::string, std::string>> RequestsHandler::
 {
 	std::lock_guard<std::mutex> lock(_snapshotMutex);
 	return _snapshot.ringGroups;
+}
+
+// Mirrors one of _cfg's five tables into the dashboard snapshot (Issue #77);
+// see PbxFeatureConfig's class comment and RequestsHandler.hpp's _cfg member
+// comment for why this indirection exists. Caller holds _mutex (this is
+// invoked synchronously from inside _cfg's Locked mutation cores).
+void RequestsHandler::refreshPbxConfigSnapshot(PbxFeatureConfig::Table t)
+{
+	std::lock_guard<std::mutex> snapLock(_snapshotMutex);
+	switch (t)
+	{
+	case PbxFeatureConfig::Table::Dnd:
+		_snapshot.dnd = _cfg.dndSnapshot();
+		break;
+	case PbxFeatureConfig::Table::Forwards:
+		_snapshot.forwards = _cfg.forwardsSnapshot();
+		break;
+	case PbxFeatureConfig::Table::RingGroups:
+		_snapshot.ringGroups = _cfg.ringGroupsSnapshot();
+		break;
+	case PbxFeatureConfig::Table::PageZones:
+		_snapshot.pageZones = _cfg.pageZonesSnapshot();
+		break;
+	case PbxFeatureConfig::Table::DialRules:
+		_snapshot.dialRules = _cfg.dialRulesSnapshot();
+		break;
+	}
 }
 
 // ── Action dispatch shared by the built-in codes and the dial plan (#69) ─────
@@ -3030,12 +2889,12 @@ bool RequestsHandler::routeDialPlan(const std::shared_ptr<SipMessage>& data,
 {
 	// Fast path: the table is empty on a default install, so the overwhelmingly
 	// common case costs one size check and nothing else.
-	if (_dialPlan.empty())
+	if (_cfg.dialPlan().empty())
 	{
 		return false;
 	}
 
-	const pbx::DialRule* rule = _dialPlan.match(destNumber);
+	const pbx::DialRule* rule = _cfg.dialPlan().match(destNumber);
 	if (!rule)
 	{
 		return false;   // fallthrough — routing continues exactly as it did pre-#69
@@ -3047,7 +2906,7 @@ bool RequestsHandler::routeDialPlan(const std::shared_ptr<SipMessage>& data,
 	switch (rule->action)
 	{
 	case pbx::DialActionType::RingGroup:
-		if (const pbx::RingGroup* group = findRingGroup(rule->target))
+		if (const pbx::RingGroup* group = _cfg.findRingGroup(rule->target))
 		{
 			routeRingGroup(data, caller, rule->target, *group);
 			return true;
@@ -3055,7 +2914,7 @@ bool RequestsHandler::routeDialPlan(const std::shared_ptr<SipMessage>& data,
 		break;
 
 	case pbx::DialActionType::PageZone:
-		if (const pbx::PageZone* zone = findPageZone(rule->target))
+		if (const pbx::PageZone* zone = _cfg.findPageZone(rule->target))
 		{
 			routePageZone(data, caller, *zone);
 			return true;
@@ -3101,82 +2960,7 @@ void RequestsHandler::setDialRule(const std::string& pattern, const std::string&
 	std::vector<std::pair<bool, std::string>> localLogs;
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
-
-		// Validate once, here, so a bad rule can never reach the SIP thread — and
-		// so the NVS blob (tab/newline delimited) can never be corrupted by a
-		// smuggled separator. Same "log and drop" contract as setRingGroup.
-		if (!pbx::isDialTokenSafe(pattern))
-		{
-			queueLog("Dial rule ignored: invalid pattern \"" + pattern + "\"", true);
-		}
-		else if (pattern == "777" || pattern == "999" || pattern == "440")
-		{
-			// These are handled above the dial plan in onInvite(), so a rule here
-			// would never fire. Refuse it instead of accepting a dead rule.
-			queueLog("Dial rule ignored: " + pattern +
-				" is a reserved extension and is routed before the dial plan", true);
-		}
-		else if (target.empty())
-		{
-			// Empty target deletes the rule (mirrors setRingGroup's empty member list).
-			if (_dialPlan.erase(pattern))
-			{
-				queueLog("Dial rule " + pattern + " deleted");
-				persistDialPlan();
-			}
-		}
-		else if (!pbx::isDialTokenSafe(target))
-		{
-			queueLog("Dial rule ignored: invalid target \"" + target + "\"", true);
-		}
-		else
-		{
-			pbx::DialActionType parsed;
-			if (!pbx::parseDialAction(action, parsed))
-			{
-				queueLog("Dial rule ignored: unknown action \"" + action +
-					"\" (want group|page|park)", true);
-			}
-			else if (parsed == pbx::DialActionType::PageZone && !pbx::isPageZoneExt(target))
-			{
-				queueLog("Dial rule ignored: page target " + target +
-					" is not a paging zone (zones are 980-989)", true);
-			}
-			else if (parsed == pbx::DialActionType::ParkOrbit && !pbx::isParkOrbitExt(target))
-			{
-				queueLog("Dial rule ignored: park target " + target +
-					" is not a park orbit for this build", true);
-			}
-			else
-			{
-				pbx::DialRule rule;
-				rule.pattern = pattern;
-				rule.action = parsed;
-				rule.target = target;
-				if (!_dialPlan.upsert(rule))
-				{
-					queueLog("Dial rule ignored (table full) for " + pattern, true);
-				}
-				else
-				{
-					queueLog("Dial rule " + pattern + " -> " +
-						pbx::dialActionName(parsed) + " " + target);
-					persistDialPlan();
-				}
-			}
-		}
-
-		// Refresh dashboard snapshot immediately (mirrors setRingGroup).
-		{
-			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
-			_snapshot.dialRules.clear();
-			_snapshot.dialRules.reserve(_dialPlan.size());
-			for (const auto& r : _dialPlan.rules())
-			{
-				_snapshot.dialRules.emplace_back(r.pattern, pbx::dialActionName(r.action), r.target);
-			}
-		}
-
+		_cfg.setDialRule(pattern, action, target);
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}
@@ -3558,36 +3342,18 @@ void RequestsHandler::tick()
 		}
 
 		// DND view: extensions currently in DND.
-		nextSnapshot.dnd.reserve(_dnd.size());
-		for (const auto& [ext, enabled] : _dnd)
-		{
-			if (enabled) nextSnapshot.dnd.push_back(ext);
-		}
+		nextSnapshot.dnd = _cfg.dndSnapshot();
 
 		// Call-forward view.
-		nextSnapshot.forwards.reserve(_forwards.size());
-		for (const auto& [ext, cfg] : _forwards)
-		{
-			nextSnapshot.forwards.emplace_back(ext, cfg.always, cfg.busy, cfg.noAnswer);
-		}
+		nextSnapshot.forwards = _cfg.forwardsSnapshot();
 
 		// Ring/hunt-group view.
-		nextSnapshot.ringGroups.reserve(_ringGroups.size());
-		for (const auto& [ext, g] : _ringGroups)
-		{
-			nextSnapshot.ringGroups.emplace_back(ext,
-				g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall",
-				pbx::joinMembers(g.members));
-		}
+		nextSnapshot.ringGroups = _cfg.ringGroupsSnapshot();
 
-		// Dial-plan rules (Issue #69), in table order. Rebuilt from _dialPlan here
-		// alongside ringGroups rather than mirrored out of band like pageZones, so
-		// the snapshot swap below can never blank or re-order them.
-		nextSnapshot.dialRules.reserve(_dialPlan.size());
-		for (const auto& r : _dialPlan.rules())
-		{
-			nextSnapshot.dialRules.emplace_back(r.pattern, pbx::dialActionName(r.action), r.target);
-		}
+		// Dial-plan rules (Issue #69), in table order. Rebuilt from _cfg's dial
+		// plan here alongside ringGroups rather than mirrored out of band like
+		// pageZones, so the snapshot swap below can never blank or re-order them.
+		nextSnapshot.dialRules = _cfg.dialRulesSnapshot();
 
 		// Parked calls view: {orbit, parkedExt, parker, secondsParked}. This full
 		// rebuild already reflects anything _park.sweep() just did above, so clear
@@ -3786,186 +3552,15 @@ void RequestsHandler::queueLog(std::string msg, bool isError)
 	_logQueue.push_back({isError, std::move(msg)});
 }
 
-// ── NVS persistence: PBX config (forwards / ring groups) + CDR ring ──────────
+// ── NVS persistence: CDR ring ─────────────────────────────────────────────────
 //
-// All five helpers are no-ops on host (the in-memory maps/ring ARE the store) and
-// gate their NVS access on ESP_PLATFORM. Each table is serialized as a single blob
-// (one record per line; fields tab-separated) under one NVS key, so a mutation
-// rewrites exactly one key — bounded size, low flash wear. Records are bounded by
-// POCKETDIAL_MAX_CLIENTS / POCKETDIAL_CDR_RECORDS, so the blob can never grow
-// without limit. The AOR charset (isValidAor) excludes tab/newline, so the
-// delimiters are safe. Callers hold _mutex (except construction-time loads, which
-// run single-threaded before any handler dispatches).
+// The PBX-config side of this (forwards / ring groups / page zones / dial plan:
+// loadPbxConfig, persistForwards, persistRingGroups, persistPageZones,
+// persistDialPlan) now lives on PbxFeatureConfig (see _cfg). deserializeBlob is
+// still used directly below by loadCdrRing, which has its own NVS namespace
+// (NVS_CDR_NS) and record shape.
 
 using pbxpersist::deserializeBlob;
-
-void RequestsHandler::loadPbxConfig()
-{
-	if (_pbxConfigLoaded)
-	{
-		return;
-	}
-	_pbxConfigLoaded = true;
-
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) != ESP_OK)
-	{
-		return;
-	}
-
-	auto readBlob = [&](const char* key) -> std::string {
-		size_t len = 0;
-		if (nvs_get_str(h, key, nullptr, &len) != ESP_OK || len == 0)
-		{
-			return {};
-		}
-		std::string buf(len, '\0');
-		if (nvs_get_str(h, key, buf.data(), &len) != ESP_OK)
-		{
-			return {};
-		}
-		if (!buf.empty() && buf.back() == '\0') buf.pop_back(); // drop NUL terminator
-		return buf;
-	};
-
-	// Forwards: ext \t always \t busy \t noAnswer
-	for (const auto& rec : deserializeBlob(readBlob("forwards")))
-	{
-		if (rec.size() < 4 || rec[0].empty()) continue;
-		if (_forwards.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS)) break;
-		pbx::ForwardConfig cfg;
-		cfg.always = rec[1];
-		cfg.busy = rec[2];
-		cfg.noAnswer = rec[3];
-		if (!cfg.empty()) _forwards[rec[0]] = std::move(cfg);
-	}
-
-	// Ring groups: ext \t mode \t m1,m2,...
-	for (const auto& rec : deserializeBlob(readBlob("groups")))
-	{
-		if (rec.size() < 3 || rec[0].empty()) continue;
-		if (_ringGroups.size() >= static_cast<size_t>(POCKETDIAL_MAX_CLIENTS)) break;
-		pbx::RingGroup g;
-		g.mode = (rec[1] == "hunt") ? pbx::GroupMode::Hunt : pbx::GroupMode::RingAll;
-		g.members = pbx::splitMembers(rec[2]);
-		if (!g.members.empty()) _ringGroups[rec[0]] = std::move(g);
-	}
-
-	// Page zones: ext \t m1,m2,...
-	for (const auto& rec : deserializeBlob(readBlob("pzones")))
-	{
-		if (rec.size() < 2 || rec[0].empty()) continue;
-		if (_pageZones.size() >= static_cast<size_t>(POCKETDIAL_MAX_PAGE_ZONES)) break;
-		pbx::PageZone z;
-		z.members = pbx::splitZoneMembers(rec[1]);
-		if (!z.members.empty()) _pageZones[rec[0]] = std::move(z);
-	}
-
-	// Dial plan (Issue #69): pattern \t action \t target, one record per rule, in
-	// evaluation order. DialPlan::upsert() enforces POCKETDIAL_MAX_DIAL_RULES on
-	// its own, so a blob written by a build with a larger cap simply stops being
-	// applied at this build's ceiling instead of overflowing it. Records that no
-	// longer validate (an unknown action, or a park target outside a shrunken
-	// POCKETDIAL_PARK_SLOTS) are dropped rather than loaded.
-	for (const auto& rec : deserializeBlob(readBlob("dplan")))
-	{
-		if (rec.size() < 3 || rec[0].empty() || rec[2].empty()) continue;
-		pbx::DialRule rule;
-		if (!pbx::parseDialAction(rec[1], rule.action)) continue;
-		if (!pbx::isDialTokenSafe(rec[0]) || !pbx::isDialTokenSafe(rec[2])) continue;
-		if (rule.action == pbx::DialActionType::PageZone && !pbx::isPageZoneExt(rec[2])) continue;
-		if (rule.action == pbx::DialActionType::ParkOrbit && !pbx::isParkOrbitExt(rec[2])) continue;
-		rule.pattern = rec[0];
-		rule.target = rec[2];
-		if (!_dialPlan.upsert(rule)) break;   // table full at this build's cap
-	}
-
-	nvs_close(h);
-#endif
-}
-
-void RequestsHandler::persistForwards()
-{
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-	std::string blob;
-	for (const auto& [ext, cfg] : _forwards)
-	{
-		blob += ext; blob += '\t';
-		blob += cfg.always; blob += '\t';
-		blob += cfg.busy; blob += '\t';
-		blob += cfg.noAnswer; blob += '\n';
-	}
-	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
-	{
-		nvs_set_str(h, "forwards", blob.c_str());
-		nvs_commit(h);
-		nvs_close(h);
-	}
-#endif
-}
-
-void RequestsHandler::persistRingGroups()
-{
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-	std::string blob;
-	for (const auto& [ext, g] : _ringGroups)
-	{
-		blob += ext; blob += '\t';
-		blob += (g.mode == pbx::GroupMode::Hunt ? "hunt" : "ringall"); blob += '\t';
-		blob += pbx::joinMembers(g.members); blob += '\n';
-	}
-	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
-	{
-		nvs_set_str(h, "groups", blob.c_str());
-		nvs_commit(h);
-		nvs_close(h);
-	}
-#endif
-}
-
-void RequestsHandler::persistPageZones()
-{
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-	std::string blob;
-	for (const auto& [ext, z] : _pageZones)
-	{
-		blob += ext; blob += '\t';
-		blob += pbx::joinMembers(z.members); blob += '\n';
-	}
-	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
-	{
-		nvs_set_str(h, "pzones", blob.c_str());
-		nvs_commit(h);
-		nvs_close(h);
-	}
-#endif
-}
-
-void RequestsHandler::persistDialPlan()
-{
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-	// Order matters here in a way it does not for the maps above: the blob is
-	// written (and replayed) in table order, because that IS the evaluation order.
-	std::string blob;
-	for (const auto& r : _dialPlan.rules())
-	{
-		blob += r.pattern; blob += '\t';
-		blob += pbx::dialActionName(r.action); blob += '\t';
-		blob += r.target; blob += '\n';
-	}
-	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
-	{
-		nvs_set_str(h, "dplan", blob.c_str());
-		nvs_commit(h);
-		nvs_close(h);
-	}
-#endif
-}
 
 // ── Registrar mode + device registry persistence (STAGE 2) ───────────────────
 
@@ -3973,7 +3568,7 @@ void RequestsHandler::loadAdminHttpTtl()
 {
 #if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
 	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) != ESP_OK)
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) != ESP_OK)
 	{
 		return;
 	}
@@ -4061,7 +3656,7 @@ void RequestsHandler::loadAdminExt()
 {
 #if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
 	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) != ESP_OK)
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) != ESP_OK)
 	{
 		return;
 	}
@@ -4082,7 +3677,7 @@ void RequestsHandler::saveAdminExt(const std::string& ext)
 	_adminExt = ext;
 #if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
 	nvs_handle_t h;
-	if (nvs_open(NVS_PBX_NS, NVS_READWRITE, &h) == ESP_OK)
+	if (nvs_open(pbxpersist::kNvsNamespace, NVS_READWRITE, &h) == ESP_OK)
 	{
 		nvs_set_str(h, "admin_ext", ext.c_str());
 		nvs_commit(h);
@@ -4351,7 +3946,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 		// uses (we're already inside _mutex here, via handle()) so the
 		// dashboard snapshot refreshes immediately instead of only on the
 		// next unrelated HTTP-side setDnd() call.
-		setDndLocked(callerExt, true);
+		_cfg.setDndLocked(callerExt, true);
 		accum.digits.clear();
 		return;
 	}
@@ -4359,7 +3954,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 	// *80 — Disable SCR/DND for caller's extension.
 	if (seq == "*80")
 	{
-		setDndLocked(callerExt, false);
+		_cfg.setDndLocked(callerExt, false);
 		accum.digits.clear();
 		return;
 	}
@@ -4371,7 +3966,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 		// "always" trigger exactly like the old inline erase did, but also
 		// refreshes the dashboard snapshot and applies the virtual-extension
 		// guard that the old inline path skipped.
-		setForwardLocked(callerExt, "always", "");
+		_cfg.setForwardLocked(callerExt, "always", "");
 		accum.digits.clear();
 		return;
 	}
@@ -4446,7 +4041,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 			// the virtual-extension guard setForward() has always had (which
 			// this inline path used to skip), and refreshes the dashboard
 			// snapshot immediately instead of leaving it stale.
-			setForwardLocked(callerExt, "always", target);
+			_cfg.setForwardLocked(callerExt, "always", target);
 			accum.digits.clear();
 			return;
 		}
@@ -4724,45 +4319,11 @@ void RequestsHandler::sweepSessionTimers(std::chrono::steady_clock::time_point n
 }
 
 // ── Paging zones (980–989) ────────────────────────────────────────────────────
-
-const pbx::PageZone* RequestsHandler::findPageZone(const std::string& extension) const
-{
-	auto it = _pageZones.find(extension);
-	return (it == _pageZones.end()) ? nullptr : &it->second;
-}
-
-bool RequestsHandler::isPageZoneDialog(const std::string& extension) const
-{
-	return pbx::isPageZoneExt(extension) && _pageZones.find(extension) != _pageZones.end();
-}
+// findPageZone/isPageZoneDialog now live on _cfg (PbxFeatureConfig).
 
 // ── Directed / group call pickup (Issue #68) ──────────────────────────────────
 // See PbxConfig.hpp's isGroupPickupCode/directedPickupTarget doc comment: pickup
 // groups are ring-group membership, reused as-is.
-
-std::vector<std::string> RequestsHandler::pickupPeersOf(const std::string& ext) const
-{
-	std::vector<std::string> peers;
-	for (const auto& [groupExt, group] : _ringGroups)
-	{
-		bool isMember = false;
-		for (const auto& m : group.members)
-		{
-			if (m == ext) { isMember = true; break; }
-		}
-		if (!isMember) continue;
-
-		for (const auto& m : group.members)
-		{
-			if (m == ext) continue;
-			if (std::find(peers.begin(), peers.end(), m) == peers.end())
-			{
-				peers.push_back(m);
-			}
-		}
-	}
-	return peers;
-}
 
 bool RequestsHandler::isSessionRingingExt(const std::shared_ptr<Session>& session, const std::string& ext) const
 {
@@ -4944,48 +4505,7 @@ void RequestsHandler::setPageZone(const std::string& zoneExt, const std::string&
 	std::vector<std::pair<bool, std::string>> localLogs;
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
-
-		if (!pbx::isPageZoneExt(zoneExt))
-		{
-			queueLog("Page zone ignored for non-zone extension " + zoneExt +
-				" (zones are 980-989)", true);
-		}
-		else
-		{
-			std::vector<std::string> list = pbx::splitZoneMembers(members);
-			if (list.empty())
-			{
-				_pageZones.erase(zoneExt);
-				queueLog("Page zone " + zoneExt + " deleted");
-				persistPageZones();
-			}
-			else
-			{
-				bool isNew = (_pageZones.find(zoneExt) == _pageZones.end());
-				if (isNew && _pageZones.size() >= static_cast<size_t>(POCKETDIAL_MAX_PAGE_ZONES))
-				{
-					queueLog("Page zone ignored (table full) for " + zoneExt, true);
-				}
-				else
-				{
-					pbx::PageZone& z = _pageZones[zoneExt];
-					z.members = std::move(list);
-					queueLog("Page zone " + zoneExt + " = " + pbx::joinMembers(z.members));
-					persistPageZones();
-				}
-			}
-		}
-
-		{
-			std::lock_guard<std::mutex> snapLock(_snapshotMutex);
-			_snapshot.pageZones.clear();
-			_snapshot.pageZones.reserve(_pageZones.size());
-			for (const auto& [ext, z] : _pageZones)
-			{
-				_snapshot.pageZones.emplace_back(ext, pbx::joinMembers(z.members));
-			}
-		}
-
+		_cfg.setPageZone(zoneExt, members);
 		localLogs = std::move(_logQueue);
 		_logQueue.clear();
 	}

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -54,13 +54,10 @@ namespace
 	// forward, or advancing to the next hunt-group member). Polled from tick().
 	constexpr auto NO_ANSWER_TIMEOUT = std::chrono::seconds(20);
 
-	// NVS namespaces / keys for the persisted PBX config and CDR ring. Kept short
-	// (NVS keys are capped at 15 chars). Forward/group entries are stored one blob
-	// per extension so a single mutation rewrites only its own key (low flash wear).
-	// The PBX-config namespace itself is pbxpersist::kNvsNamespace (PbxPersist.hpp)
-	// now — used here too (loadAdminHttpTtl/loadAdminExt/saveAdminExt) so there is
-	// exactly one definition of "pbxcfg" in the codebase.
-	constexpr auto NVS_CDR_NS  = "cdrlog";
+	// NVS namespace for the persisted PBX config, pbxcfg (loadAdminHttpTtl /
+	// loadAdminExt / saveAdminExt) is pbxpersist::kNvsNamespace (PbxPersist.hpp)
+	// so there is exactly one definition of "pbxcfg" in the codebase. The CDR
+	// ring's own namespace ("cdrlog") now lives on CdrRing.cpp.
 }
 
 RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
@@ -94,7 +91,7 @@ RequestsHandler::RequestsHandler(std::string serverIp, int serverPort,
 	// NVS so they survive reboot. No-ops on host. Construction is single-threaded
 	// (no handler is dispatching yet), so these run without holding _mutex.
 	_cfg.loadPbxConfig();
-	loadCdrRing();
+	_cdr.load();
 	// Task 2B: load the admin extension from NVS (defaults to "1001" if absent).
 	loadAdminExt();
 	// STAGE 2: load the registrar mode (defaults to the POCKETDIAL_OPEN_REGISTRAR
@@ -2218,7 +2215,7 @@ void RequestsHandler::endCall(std::string_view callID, std::string_view srcNumbe
 	if (_sessions.erase(std::string(callID)) > 0)
 	{
 		// Record exactly once per torn-down dialog (Phase 2 CDR).
-		recordCdr(ending, srcNumber, destNumber);
+		_cdr.record(ending, srcNumber, destNumber);
 
 		std::ostringstream message;
 		message << "Session has been disconnected between " << srcNumber << " and " << destNumber;
@@ -2251,68 +2248,6 @@ uint64_t RequestsHandler::nowEpochMs() const
 	return static_cast<uint64_t>(
 		std::chrono::duration_cast<std::chrono::milliseconds>(
 			std::chrono::steady_clock::now().time_since_epoch()).count());
-}
-
-void RequestsHandler::recordCdr(const std::shared_ptr<Session>& session,
-	std::string_view srcNumber, std::string_view destNumber)
-{
-	CallDetailRecord rec;
-	rec.caller = std::string(srcNumber);
-	rec.callee = std::string(destNumber);
-
-	uint64_t startMs = nowEpochMs();
-	uint32_t durationSec = 0;
-	CdrResult result = CdrResult::Failed;
-
-	if (session)
-	{
-		auto now = std::chrono::steady_clock::now();
-		startMs = static_cast<uint64_t>(
-			std::chrono::duration_cast<std::chrono::milliseconds>(
-				session->getStartTime().time_since_epoch()).count());
-
-		switch (session->getState())
-		{
-			// Both Connected and Bye are "answered": a normal call ends via BYE, which
-			// sets the state to Bye (NOT Connected) just before endCall() runs, while
-			// the echo (777) path tears down straight from Connected. Session::setState
-			// resets _startTime to the connect instant on the Connected transition and
-			// the later Bye transition does NOT touch it, so getStartTime() still marks
-			// the answer instant in both cases — talk time is now - startTime.
-			case Session::State::Connected:
-			case Session::State::Held:   // call torn down mid-hold → still Answered (#73)
-			case Session::State::Bye:
-				result = CdrResult::Answered;
-				{
-					int64_t secs = static_cast<int64_t>(
-						std::chrono::duration_cast<std::chrono::seconds>(
-							now - session->getStartTime()).count());
-					if (secs < 0) secs = 0;
-					durationSec = static_cast<uint32_t>(secs);
-				}
-				break;
-			case Session::State::Busy:        result = CdrResult::Busy;        break;
-			case Session::State::Cancel:      result = CdrResult::Cancelled;   break;
-			case Session::State::Unavailable: result = CdrResult::Unavailable; break;
-			default:                          result = CdrResult::Failed;      break;
-		}
-	}
-
-	rec.startMs = startMs;
-	rec.durationSec = durationSec;
-	rec.result = result;
-
-	// Fixed ring write: overwrite the oldest slot once full (no heap growth).
-	_cdrRing[_cdrHead] = std::move(rec);
-	_cdrHead = (_cdrHead + 1) % POCKETDIAL_CDR_RECORDS;
-	if (_cdrCount < POCKETDIAL_CDR_RECORDS)
-	{
-		++_cdrCount;
-	}
-
-	// Persist the ring so records survive reboot (write-through on teardown; no-op
-	// on host). Caller (endCall) holds _mutex. See persistCdrRing() for the wear note.
-	persistCdrRing();
 }
 
 void RequestsHandler::unregisterClient(std::string_view number)
@@ -3332,14 +3267,8 @@ void RequestsHandler::tick()
 			nextSnapshot.sessions.emplace_back(caller, callee, sessionStateToString(session->getState()), durationSec);
 		}
 
-		// CDR view: copy the ring out newest-first into the snapshot.
-		nextSnapshot.cdr.reserve(_cdrCount);
-		for (size_t i = 0; i < _cdrCount; ++i)
-		{
-			// _cdrHead points one past the newest; walk backwards with wrap.
-			size_t idx = (_cdrHead + POCKETDIAL_CDR_RECORDS - 1 - i) % POCKETDIAL_CDR_RECORDS;
-			nextSnapshot.cdr.push_back(_cdrRing[idx]);
-		}
+		// CDR view: newest-first copy of the ring into the snapshot.
+		nextSnapshot.cdr = _cdr.snapshot();
 
 		// DND view: extensions currently in DND.
 		nextSnapshot.dnd = _cfg.dndSnapshot();
@@ -3552,15 +3481,13 @@ void RequestsHandler::queueLog(std::string msg, bool isError)
 	_logQueue.push_back({isError, std::move(msg)});
 }
 
-// ── NVS persistence: CDR ring ─────────────────────────────────────────────────
+// ── NVS persistence ────────────────────────────────────────────────────────────
 //
-// The PBX-config side of this (forwards / ring groups / page zones / dial plan:
+// The PBX-config tables (forwards / ring groups / page zones / dial plan:
 // loadPbxConfig, persistForwards, persistRingGroups, persistPageZones,
-// persistDialPlan) now lives on PbxFeatureConfig (see _cfg). deserializeBlob is
-// still used directly below by loadCdrRing, which has its own NVS namespace
-// (NVS_CDR_NS) and record shape.
-
-using pbxpersist::deserializeBlob;
+// persistDialPlan) now live on PbxFeatureConfig (see _cfg), and the CDR ring
+// (load/persist, its own NVS namespace and record shape) now lives on CdrRing
+// (see _cdr) — both still no-ops on host.
 
 // ── Registrar mode + device registry persistence (STAGE 2) ───────────────────
 
@@ -3580,73 +3507,6 @@ void RequestsHandler::loadAdminHttpTtl()
 		_adminHttpTtlSec.store(v, std::memory_order_relaxed);
 	}
 	// else: keep the compile-time default (600s).
-#endif
-}
-
-void RequestsHandler::loadCdrRing()
-{
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-	nvs_handle_t h;
-	if (nvs_open(NVS_CDR_NS, NVS_READWRITE, &h) != ESP_OK)
-	{
-		return;
-	}
-	size_t len = 0;
-	if (nvs_get_str(h, "ring", nullptr, &len) == ESP_OK && len > 0)
-	{
-		std::string buf(len, '\0');
-		if (nvs_get_str(h, "ring", buf.data(), &len) == ESP_OK)
-		{
-			if (!buf.empty() && buf.back() == '\0') buf.pop_back();
-			// Record: caller \t callee \t startMs \t durationSec \t result(int)
-			for (const auto& rec : deserializeBlob(buf))
-			{
-				if (rec.size() < 5) continue;
-				if (_cdrCount >= POCKETDIAL_CDR_RECORDS) break;
-				CallDetailRecord r;
-				r.caller = rec[0];
-				r.callee = rec[1];
-				r.startMs = static_cast<uint64_t>(strtoull(rec[2].c_str(), nullptr, 10));
-				r.durationSec = static_cast<uint32_t>(strtoul(rec[3].c_str(), nullptr, 10));
-				int ri = atoi(rec[4].c_str());
-				r.result = (ri >= 0 && ri <= static_cast<int>(CdrResult::Failed))
-					? static_cast<CdrResult>(ri) : CdrResult::Failed;
-				// Records were serialized oldest-first; append preserving order.
-				_cdrRing[_cdrHead] = std::move(r);
-				_cdrHead = (_cdrHead + 1) % POCKETDIAL_CDR_RECORDS;
-				++_cdrCount;
-			}
-		}
-	}
-	nvs_close(h);
-#endif
-}
-
-void RequestsHandler::persistCdrRing()
-{
-#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
-	// Serialize the ring oldest-first (same order loadCdrRing replays). Bounded by
-	// POCKETDIAL_CDR_RECORDS, so the blob is fixed-footprint. Write-through on each
-	// teardown: the CDR ring is small (default 32) and calls end infrequently
-	// relative to flash endurance, so a per-call rewrite is acceptable — see summary.
-	std::string blob;
-	for (size_t i = 0; i < _cdrCount; ++i)
-	{
-		size_t idx = (_cdrHead + POCKETDIAL_CDR_RECORDS - _cdrCount + i) % POCKETDIAL_CDR_RECORDS;
-		const CallDetailRecord& r = _cdrRing[idx];
-		blob += r.caller; blob += '\t';
-		blob += r.callee; blob += '\t';
-		blob += std::to_string(r.startMs); blob += '\t';
-		blob += std::to_string(r.durationSec); blob += '\t';
-		blob += std::to_string(static_cast<int>(r.result)); blob += '\n';
-	}
-	nvs_handle_t h;
-	if (nvs_open(NVS_CDR_NS, NVS_READWRITE, &h) == ESP_OK)
-	{
-		nvs_set_str(h, "ring", blob.c_str());
-		nvs_commit(h);
-		nvs_close(h);
-	}
 #endif
 }
 
@@ -3975,16 +3835,7 @@ void RequestsHandler::onDtmfInfo(std::shared_ptr<SipMessage> data)
 	if (seq == "*69")
 	{
 		// Find the last CDR entry where callee == callerExt (i.e. last inbound call).
-		std::string lastCaller;
-		for (size_t i = 0; i < _cdrCount; ++i)
-		{
-			size_t idx = (_cdrHead + POCKETDIAL_CDR_RECORDS - 1 - i) % POCKETDIAL_CDR_RECORDS;
-			if (_cdrRing[idx].callee == callerExt && !_cdrRing[idx].caller.empty())
-			{
-				lastCaller = _cdrRing[idx].caller;
-				break;
-			}
-		}
+		std::string lastCaller = _cdr.lastCallerFor(callerExt);
 		if (!lastCaller.empty())
 		{
 			queueLog("*69 last caller for " + callerExt + " is " + lastCaller);

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -43,6 +43,7 @@
 #include "PcapCapture.hpp"
 #include "PbxConfig.hpp"
 #include "DialPlan.hpp"
+#include "PbxFeatureConfig.hpp"
 #include "RtpSender.hpp"
 #include "PbxEnv.hpp"
 #include "TransactionLayer.hpp"
@@ -441,30 +442,11 @@ private:
 		std::string_view srcNumber, std::string_view destNumber);
 	uint64_t nowEpochMs() const;
 
-	// Internal DND lookup used by onInvite(). Caller MUST already hold _mutex
-	// (std::mutex is non-recursive); does a bounded map lookup, no locking.
-	bool isDndEnabled(const std::string& extension);
-
-	// Lock-already-held mutation cores for setDnd()/setForward() (Issue #77).
-	// _mutex is non-recursive, and onDtmfInfo() runs inside handle()'s _mutex
-	// lock, so it cannot call the public setDnd()/setForward() without
-	// deadlocking. These do the actual map mutation + dashboard-snapshot
-	// refresh (queueLog only — no _mutex/_logQueue handling of their own) so
-	// both the public setters (after taking _mutex) and onDtmfInfo's CLASS
-	// code handling (already inside it) share one code path and one snapshot
-	// refresh, instead of onDtmfInfo writing _dnd/_forwards directly and
-	// leaving the dashboard snapshot stale until an unrelated HTTP-side call
-	// happens to touch the same extension.
-	void setDndLocked(const std::string& extension, bool on);
-	void setForwardLocked(const std::string& extension, const std::string& trigger, const std::string& target);
-
-	// Internal forward/group/zone lookups used by onInvite()/onBusy()/tick(). Caller
-	// MUST already hold _mutex (non-recursive) — bounded map lookups, no locking.
-	// getForwardTarget returns "" when no forward of that trigger is configured.
-	std::string getForwardTarget(const std::string& extension, const std::string& trigger) const;
-	const pbx::RingGroup* findRingGroup(const std::string& extension) const;
-	const pbx::PageZone* findPageZone(const std::string& extension) const;
-	bool isPageZoneDialog(const std::string& extension) const;
+	// DND/forward/ring-group/page-zone/dial-plan lookups and the Locked mutation
+	// cores that used to live here directly now live on the _cfg member (see
+	// PbxFeatureConfig.hpp) — callers throughout this file (onInvite(),
+	// onBusy(), tick(), onDtmfInfo()) reach them as _cfg.xxx(...), all while
+	// already holding _mutex, exactly as before.
 
 	// ── Dial-plan dispatch (Issue #69) ────────────────────────────────────────
 	// The two "route this INVITE to an already-shipped action" bodies, lifted
@@ -495,9 +477,10 @@ private:
 	// config table. All four assume the caller holds _mutex (called from
 	// onInvite()/onOk()/onBye(), which already do).
 
-	// Every OTHER extension co-membered with `ext` in any configured ring
-	// group, deduped and order-preserving. Empty if `ext` is in no group.
-	std::vector<std::string> pickupPeersOf(const std::string& ext) const;
+	// pickupPeersOf(ext) — every OTHER extension co-membered with `ext` in any
+	// configured ring group — now lives on _cfg (PbxFeatureConfig), a pure
+	// membership query over ring-group config; called here as
+	// _cfg.pickupPeersOf(...).
 
 	// True iff `session` is currently ringing `ext` (state == Invited AND
 	// either it's `ext`'s stored direct-call invite, or `ext` is one of its
@@ -683,8 +666,8 @@ private:
 		std::vector<std::pair<std::string, std::string>> pageZones;
 		// Dial-plan rules (Issue #69): {pattern, "group"|"page"|"park", target},
 		// in table order — the order they are evaluated in. Unlike pageZones this
-		// is rebuilt from _dialPlan every tick() alongside ringGroups, so it needs
-		// no out-of-band carry-over across the snapshot swap.
+		// is rebuilt from _cfg's dial plan every tick() alongside ringGroups, so
+		// it needs no out-of-band carry-over across the snapshot swap.
 		std::vector<std::tuple<std::string, std::string, std::string>> dialRules;
 		// Adopted devices (STAGE 2): {mac, ext, state, online}. Mirrored from the
 		// Registrar's registry under _mutex; copied out under _snapshotMutex.
@@ -706,36 +689,20 @@ private:
 	// drainOutbox() (outbound), both already under _mutex.
 	PcapCapture _pcapCapture;
 
-	// DND state, keyed by extension. Bounded by the client-pool depth: an entry is
-	// only created when DND is turned ON, and turning it OFF erases the entry, so
-	// the map can never hold more than POCKETDIAL_MAX_CLIENTS live extensions.
-	// Guarded by _mutex. (A std::shared_ptr<SipClient> flag would be lost across
-	// re-REGISTER / pool eviction; keying by extension keeps DND sticky.)
-	std::unordered_map<std::string, bool> _dnd;
-
-	// Call-forwarding config, keyed by extension (Class A sweep). Same bounding /
-	// stickiness rationale as _dnd: an entry exists only while at least one trigger
-	// is set, and is bounded by POCKETDIAL_MAX_CLIENTS. Guarded by _mutex; mirrored
-	// into the dashboard snapshot and persisted to NVS.
-	std::unordered_map<std::string, pbx::ForwardConfig> _forwards;
-
-	// Ring/hunt groups, keyed by the group extension (e.g. 6xx). Bounded by
-	// POCKETDIAL_MAX_CLIENTS groups; each member list is bounded by splitMembers().
-	// Guarded by _mutex; mirrored into the snapshot and persisted to NVS.
-	std::unordered_map<std::string, pbx::RingGroup> _ringGroups;
-
-	// Paging zones, keyed by the zone extension (980–989). Bounded by
-	// POCKETDIAL_MAX_PAGE_ZONES; member lists bounded by splitZoneMembers().
-	// Guarded by _mutex; mirrored into the snapshot and persisted to NVS.
-	std::unordered_map<std::string, pbx::PageZone> _pageZones;
-
-	// Dial-plan rule table (Issue #69). An ORDERED vector, not a map: first match
-	// wins, so evaluation order is the semantics. Hard-capped at
-	// POCKETDIAL_MAX_DIAL_RULES by DialPlan::upsert(). Guarded by _mutex; mirrored
-	// into the snapshot and persisted to NVS. Empty by default, and an empty table
-	// is a no-op on routing — every dialed number falls straight through to the
-	// pre-#69 extension-lookup path.
-	pbx::DialPlan _dialPlan;
+	// The five DND/forward/ring-group/page-zone/dial-plan tables live on _cfg now
+	// (PbxFeatureConfig.hpp) — data + validation + NVS persistence, all still
+	// guarded by this engine's _mutex (see PbxFeatureConfig's class comment for
+	// why it takes a callback instead of touching _snapshot/_snapshotMutex
+	// directly).
+	PbxFeatureConfig _cfg{*this,
+		[this](PbxFeatureConfig::Table t) { refreshPbxConfigSnapshot(t); }};
+	// Mirrors one of _cfg's five tables into the dashboard snapshot immediately
+	// after a mutation (Issue #77) — the callback _cfg invokes on every DND/
+	// forward/ring-group/page-zone/dial-rule change, whether it came from the
+	// public HTTP-facing setters or from onDtmfInfo()'s CLASS codes (already
+	// inside _mutex via handle()). Caller holds _mutex; takes _snapshotMutex
+	// internally, same nesting as every other snapshot refresh in this class.
+	void refreshPbxConfigSnapshot(PbxFeatureConfig::Table t);
 
 	// How long to wait between OPTIONS keepalive cycles, in minutes. Atomic so the
 	// TUI can read without taking _mutex. Persisted to NVS ("pbxcfg"/"rewarm_min").
@@ -758,15 +725,9 @@ private:
 	// cheap in-place path for an online-flag-only change. Caller holds _mutex.
 	void applyDeviceChange(Registrar::Change change);
 
-	// NVS persistence for _forwards / _ringGroups / _pageZones. No-ops on host (the
-	// maps are the store); on ESP they read/write the "pbxcfg" NVS namespace.
-	// Caller holds _mutex.
-	void loadPbxConfig();                 // boot-time reload into the maps
-	void persistForwards();               // write-through after a setForward mutation
-	void persistRingGroups();             // write-through after a setRingGroup mutation
-	void persistPageZones();              // write-through after a setPageZone mutation
-	void persistDialPlan();               // write-through after a setDialRule mutation
-	bool _pbxConfigLoaded = false;
+	// _cfg.loadPbxConfig() (boot-time reload) and the four persist* write-throughs
+	// now live on PbxFeatureConfig; NVS persistence for _forwards / _ringGroups /
+	// _pageZones / _dialPlan is unchanged, just relocated.
 
 	// Persistent CDR (Class A sweep). The CDR ring is flushed to the "cdrlog" NVS
 	// namespace on teardown (write-through) and reloaded on boot, so records survive

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -61,35 +61,16 @@ public:
 	RequestsHandler(std::string serverIp, int serverPort,
 		OnHandledEvent onHandledEvent);
 
-	// RETURNS NULL under sustained pressure — check it. The pool is bounded and
-	// its heap fallback is now bounded too (Issue #101(A)); once both are spent
-	// this refuses rather than allocating without limit. The contract for a
-	// caller that gets nullptr is to DROP: it cannot answer 503, because building
-	// the 503 would need a message out of the same empty pool. SIP over UDP
-	// retransmits, so a dropped packet costs latency, not the call.
-	// Issue #81: `message` is a view, never copied here — SipMessage::reset()
-	// below reads through it once, synchronously, to parse the pooled slot.
-	// Issue #105: taking it by view (not by value) also means a caller holding
-	// the original wire-received bytes (SipMessageFactory::createMessage, on
-	// behalf of SipServer::onNewMessage) keeps them intact after this returns.
+	// Forwarders onto the static pool in SipMessagePool.hpp/.cpp (Issue #53 /
+	// #101(A) / #101(E)) — kept as public statics here because SipMessageFactory,
+	// the handler table, and the test suite all call them as
+	// RequestsHandler::getMessageFromPool(...). See sipmsgpool::getMessageFromPool
+	// for the full contract (returns NULL under sustained pressure — check it;
+	// the caller's job on refusal is to drop, never to synthesize a response out
+	// of the same empty pool).
 	static std::shared_ptr<SipMessage> getMessageFromPool(std::string_view message, sockaddr_in src);
-	// Clones an already-parsed message into a free pool slot via a direct field
-	// copy (SipMessage's copy assignment is a plain owned-string/vector copy —
-	// no shared buffer to fix up). Used by every response-building call site that
-	// used to go through getMessageFromPool(source->toString(), source->getSource()),
-	// which paid a full serialize + reparse just to duplicate a message we had
-	// already parsed once (issue #76).
 	static std::shared_ptr<SipMessage> getMessageFromPool(const SipMessage& source);
 
-private:
-	// Hands out an uninitialized message the caller exclusively owns: a free
-	// (use_count()==1) pool slot, else a bounded heap fallback, else nullptr once
-	// POCKETDIAL_MSG_HEAP_FALLBACK_MAX are already alive (Issue #101(A)).
-	// Internally synchronized on a leaf mutex — the pool is reachable from the
-	// UDP receive task and the tick task at once. See the definition.
-	static std::shared_ptr<SipMessage> acquirePooledMessage();
-
-public:
 	// ── Media beachhead static helpers (pure; host-unit-tested) ──────────────────
 	// Build the server's own SDP body for the 440 answer (server media: PCMU on the
 	// server's RTP port). Pure formatter — exposed so tests can assert its body and
@@ -793,10 +774,10 @@ private:
 	void loadCdrRing();                   // boot-time reload of the ring
 	void persistCdrRing();                // flush the whole ring (bounded, fixed size)
 
-	// Pre-allocated static memory pools (Issue #53)
+	// Pre-allocated static memory pools (Issue #53). The SipMessage pool itself
+	// now lives in SipMessagePool.hpp/.cpp (static there, not a member here).
 	std::vector<std::shared_ptr<SipClient>> _clientPool;
 	std::vector<std::shared_ptr<Session>> _sessionPool;
-	static std::vector<std::shared_ptr<SipMessage>> _messagePool;
 	// Virtual-peer pool: transient SipClient slots for 777/440/park legs (Issue #70).
 	std::vector<std::shared_ptr<SipClient>> _virtualPeerPool;
 

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -44,6 +44,7 @@
 #include "PbxConfig.hpp"
 #include "DialPlan.hpp"
 #include "PbxFeatureConfig.hpp"
+#include "CdrRing.hpp"
 #include "RtpSender.hpp"
 #include "PbxEnv.hpp"
 #include "TransactionLayer.hpp"
@@ -434,12 +435,8 @@ private:
 	bool setCallState(std::string_view callID, Session::State state);
 	void endCall(std::string_view callID, std::string_view srcNumber, std::string_view destNumber, std::string_view reason = "");
 
-	// CDR: write one record into the ring as a call ends. Caller must hold _mutex.
-	// `session` (may be null) supplies the start time / final state used to derive
-	// duration and result; src/dest provide the parties when the session lookup
-	// can't (e.g. the virtual 777/999 extensions reuse a shared dummy client).
-	void recordCdr(const std::shared_ptr<Session>& session,
-		std::string_view srcNumber, std::string_view destNumber);
+	// CDR ring buffer moved to CdrRing.hpp (see _cdr below); endCall() now calls
+	// _cdr.record(...) directly, same "caller holds _mutex" contract as before.
 	uint64_t nowEpochMs() const;
 
 	// DND/forward/ring-group/page-zone/dial-plan lookups and the Locked mutation
@@ -678,12 +675,12 @@ private:
 	RegistrarSnapshot _snapshot;
 	std::mutex _snapshotMutex;
 
-	// CDR ring buffer (Phase 2). Fixed capacity, no heap growth: writes wrap and
-	// overwrite the oldest slot. All access is under _mutex. _cdrHead is the index
-	// of the NEXT slot to write; _cdrCount caps at POCKETDIAL_CDR_RECORDS.
-	std::array<CallDetailRecord, POCKETDIAL_CDR_RECORDS> _cdrRing;
-	size_t _cdrHead = 0;
-	size_t _cdrCount = 0;
+	// CDR ring buffer (Phase 2) now lives on CdrRing.hpp — data, NVS persistence,
+	// snapshot copy, and the *69 last-caller lookup, all still guarded by this
+	// engine's _mutex. See CdrRing.hpp's class comment for why it takes no
+	// PbxEnv reference (unlike _cfg above, nothing about a CDR write needs to
+	// refresh the dashboard snapshot immediately).
+	CdrRing _cdr;
 
 	// Issue #33: /api/pcap ring. Populated from handle() (inbound) and
 	// drainOutbox() (outbound), both already under _mutex.
@@ -729,11 +726,9 @@ private:
 	// now live on PbxFeatureConfig; NVS persistence for _forwards / _ringGroups /
 	// _pageZones / _dialPlan is unchanged, just relocated.
 
-	// Persistent CDR (Class A sweep). The CDR ring is flushed to the "cdrlog" NVS
-	// namespace on teardown (write-through) and reloaded on boot, so records survive
-	// reboot. No-ops on host. Caller holds _mutex.
-	void loadCdrRing();                   // boot-time reload of the ring
-	void persistCdrRing();                // flush the whole ring (bounded, fixed size)
+	// _cdr.load() (boot-time reload) and _cdr.record()'s write-through persist
+	// now live on CdrRing; the "cdrlog" NVS namespace and record shape are
+	// unchanged, just relocated.
 
 	// Pre-allocated static memory pools (Issue #53). The SipMessage pool itself
 	// now lives in SipMessagePool.hpp/.cpp (static there, not a member here).

--- a/src/SIP/SipMessagePool.cpp
+++ b/src/SIP/SipMessagePool.cpp
@@ -1,0 +1,172 @@
+// SipMessagePool.cpp: the static SipMessage pool, extracted verbatim out of
+// RequestsHandler (Issue #53 / #101(A) / #101(E)). See SipMessagePool.hpp.
+#include "SipMessagePool.hpp"
+
+#include <iostream>
+
+#include "SipSdpMessage.hpp"
+#include "PoolConfig.hpp"
+
+namespace sipmsgpool
+{
+	namespace
+	{
+		// The static, process-global message pool this file guards. Static
+		// because getMessageFromPool() is called by SipMessageFactory, which has
+		// no RequestsHandler instance to own it on.
+		std::vector<std::shared_ptr<SipMessage>> s_messagePool;
+
+		// ── Message pool synchronization (Issue #101(A) / #101(E)) ──────────────────
+		//
+		// Leaf lock guarding the static pool above. LEAF means exactly that: nothing
+		// inside its critical section may acquire another lock, ever. That is what makes
+		// it safe to take whether or not the caller already holds RequestsHandler's
+		// _mutex, with no lock ordering to reason about.
+		//
+		// It is needed because handing a slot out is a check-then-take (scan for
+		// use_count()==1, then copy the shared_ptr) over a pool reachable from two
+		// tasks at once:
+		//
+		//   * the UDP receive task (UdpServer.cpp:134) -> SipServer::onNewMessage ->
+		//     SipMessageFactory::createMessage -> getMessageFromPool, holding NO lock —
+		//     handle() only takes _mutex afterwards, on the already-allocated message;
+		//   * the tick task (esp_main.cpp:192, or SipServer::tickLoop on desktop) ->
+		//     tick() -> TransactionLayer::sweep -> messageFromPool, under _mutex.
+		//
+		// Unsynchronized, both could observe use_count()==1 on the same slot and both
+		// take it, then reset() it concurrently — two owners writing the same
+		// SipMessage, reallocating its strings under each other. _mutex on one side does
+		// not help: a lock only excludes other holders of that same lock. Found by the
+		// #101(E) audit, fixed here because it lives in the function #101(A) rewrites.
+		std::mutex s_msgPoolMutex;
+
+		// Heap-fallback messages currently alive. Atomic because the decrement happens
+		// in the deleter, which runs wherever the last reference happens to drop —
+		// commonly on the socket-send path after the outbox is drained, outside every
+		// lock we hold here.
+		std::atomic<std::size_t> s_msgHeapFallbacksInFlight{0};
+
+		// Releases a bounded heap-fallback message and gives its budget back.
+		//
+		// MUST NOT take s_msgPoolMutex (or any lock): the last reference can drop
+		// while that mutex is held — dropping a superseded message inside the pool
+		// critical section would self-deadlock on a non-recursive mutex. An atomic
+		// decrement is all this is allowed to do.
+		struct HeapFallbackDeleter
+		{
+			void operator()(SipMessage* p) const noexcept
+			{
+				delete p;
+				s_msgHeapFallbacksInFlight.fetch_sub(1, std::memory_order_relaxed);
+			}
+		};
+
+		std::shared_ptr<SipMessage> acquirePooledMessage()
+		{
+			std::lock_guard<std::mutex> poolLock(s_msgPoolMutex);
+
+			for (auto& msg : s_messagePool)
+			{
+				if (msg.use_count() == 1)
+				{
+					// The mutex serializes TAKERS, but the previous owner released this
+					// slot outside it — typically on the send path once the drained outbox
+					// goes out of scope. use_count() is only an atomic load, so on its own
+					// it establishes no happens-before with that releasing thread, and the
+					// reset() we are about to authorize reads the message's existing string
+					// and vector internals before overwriting them. This fence pairs with
+					// the release the refcount decrement performs, so those writes are
+					// visible before we hand the slot on.
+					std::atomic_thread_fence(std::memory_order_acquire);
+					// Copy INSIDE the lock: the copy is what publishes use_count()==2 and
+					// so what makes this slot invisible to the other task's scan. Callers
+					// initialize it (reset() / operator=) after we return, by which point
+					// they own it exclusively — keeping the critical section to a scan.
+					return msg;
+				}
+			}
+
+			// Pool drawn down: fall back to the heap, but only up to a fixed number alive
+			// at once (Issue #101(A)). Past that, refuse and let the caller drop. Both
+			// transitions are logged, from here rather than the callers, so the two
+			// getMessageFromPool overloads share one rate-limit counter per pool instead
+			// of each sampling 1-in-100 independently under the same label.
+			static std::atomic<std::size_t> msgWarnCount{0};
+			if (s_msgHeapFallbacksInFlight.load(std::memory_order_relaxed) >= POCKETDIAL_MSG_HEAP_FALLBACK_MAX)
+			{
+				logPoolExhausted("SIP Message", PoolPressure::Refused, msgWarnCount);
+				return nullptr;
+			}
+			logPoolExhausted("SIP Message", PoolPressure::Fallback, msgWarnCount);
+
+			SipMessage* raw = nullptr;
+			try
+			{
+				raw = new SipSdpMessage("", sockaddr_in{});
+			}
+			catch (const std::bad_alloc&)
+			{
+				return nullptr;   // budget untouched — nothing was handed out
+			}
+
+			s_msgHeapFallbacksInFlight.fetch_add(1, std::memory_order_relaxed);
+			try
+			{
+				return std::shared_ptr<SipMessage>(raw, HeapFallbackDeleter{});
+			}
+			catch (const std::bad_alloc&)
+			{
+				// The shared_ptr constructor takes ownership of `raw` before it can throw,
+				// and the standard requires it to run the deleter if it does. So `raw` is
+				// already deleted and the counter already decremented — undoing either
+				// here would be a double free / double decrement.
+				return nullptr;
+			}
+		}
+	}   // namespace
+
+	void logPoolExhausted(const char* poolName, PoolPressure level,
+		std::atomic<std::size_t>& warnCount)
+	{
+		// Rate-limited 1-in-100: a flood that drains the pool would otherwise also
+		// flood the log pipe. The running total is kept in the message so the sampling
+		// does not hide the true magnitude.
+		const std::size_t n = warnCount.fetch_add(1, std::memory_order_relaxed) + 1;
+		if ((n - 1) % 100 == 0)
+		{
+			std::cerr << "[WARNING] " << poolName << " pool exhausted ("
+				<< n << " total)! "
+				<< (level == PoolPressure::Fallback
+					? "Falling back to bounded heap allocation.\n"
+					: "Fallback budget spent — DROPPING packets.\n");
+		}
+	}
+
+	void ensureInitialized()
+	{
+		if (s_messagePool.empty())
+		{
+			s_messagePool.reserve(POCKETDIAL_MSG_POOL);
+			for (int i = 0; i < POCKETDIAL_MSG_POOL; ++i)
+			{
+				s_messagePool.push_back(std::make_shared<SipSdpMessage>("", sockaddr_in{}));
+			}
+		}
+	}
+
+	std::shared_ptr<SipMessage> getMessageFromPool(std::string_view message, sockaddr_in src)
+	{
+		std::shared_ptr<SipMessage> msg = acquirePooledMessage();
+		if (!msg) return nullptr;   // acquirePooledMessage() already logged the pressure
+		msg->reset(message, src);
+		return msg;
+	}
+
+	std::shared_ptr<SipMessage> getMessageFromPool(const SipMessage& source)
+	{
+		std::shared_ptr<SipMessage> msg = acquirePooledMessage();
+		if (!msg) return nullptr;   // acquirePooledMessage() already logged the pressure
+		*msg = source;
+		return msg;
+	}
+}

--- a/src/SIP/SipMessagePool.hpp
+++ b/src/SIP/SipMessagePool.hpp
@@ -1,0 +1,78 @@
+#ifndef SIP_MESSAGE_POOL_HPP
+#define SIP_MESSAGE_POOL_HPP
+
+#if defined(ESP_PLATFORM) || defined(ESP32) || defined(ARDUINO)
+#include <lwip/sockets.h>
+#elif defined(__linux__)
+#include <netinet/in.h>
+#elif defined _WIN32 || defined _WIN64
+#include <WinSock2.h>
+#endif
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string_view>
+#include <vector>
+
+class SipMessage;
+
+// The static, process-global SipMessage pool (Issue #53 / #101(A) / #101(E)).
+// Extracted verbatim out of RequestsHandler, which owned it as file-scope statics
+// before this split — see the lock-ordering essay in the .cpp for why the guarding
+// mutex must stay a LEAF (nothing inside its critical section may take another
+// lock). RequestsHandler::getMessageFromPool() stays the public entry point
+// callers use (SipMessageFactory, the handler table, tests); it forwards here.
+namespace sipmsgpool
+{
+	// Two distinct pool-pressure signals: `Fallback` fires the moment a pool runs
+	// dry and its heap fallback takes over (pressure building, nothing lost yet);
+	// `Refused` fires once the fallback budget is spent too and packets are
+	// actually being dropped. Collapsing them (as an earlier cut of #101(A) did)
+	// removes the only early warning an operator gets and reports trouble solely
+	// after the damage. Shared with RequestsHandler::allocateVirtualPeer(), which
+	// logs its own (separate) virtual-peer pool exhaustion through the same
+	// helper and label scheme — that is why this enum and logPoolExhausted() are
+	// exposed here rather than kept file-local.
+	enum class PoolPressure { Fallback, Refused };
+
+	// Rate-limited (1-in-100) exhaustion logger, shared by every bounded pool in
+	// the engine (the message pool here, and RequestsHandler's virtual-peer pool).
+	// The running total is kept in the message so sampling does not hide the true
+	// magnitude of a flood.
+	void logPoolExhausted(const char* poolName, PoolPressure level,
+		std::atomic<std::size_t>& warnCount);
+
+	// Idempotent prefill of the static pool to POCKETDIAL_MSG_POOL slots. Called
+	// once from RequestsHandler's constructor; safe to call from more than one
+	// constructor in the same process because it is guarded by an
+	// `if (empty())` check, matching the original inline prefill this replaces.
+	// Construction is single-threaded (no handler is dispatching yet), so this
+	// does not itself need synchronization.
+	void ensureInitialized();
+
+	// `rawBytes`/`src`: draw a pool slot and reset() it to hold this wire message.
+	// Returns NULL under sustained pressure — check it. The pool is bounded and
+	// its heap fallback is now bounded too (Issue #101(A)); once both are spent
+	// this refuses rather than allocating without limit. The contract for a
+	// caller that gets nullptr is to DROP: it cannot answer 503, because building
+	// the 503 would need a message out of the same empty pool. SIP over UDP
+	// retransmits, so a dropped packet costs latency, not the call.
+	// Issue #81: `message` is a view, never copied here — SipMessage::reset()
+	// below reads through it once, synchronously, to parse the pooled slot.
+	// Issue #105: taking it by view (not by value) also means a caller holding
+	// the original wire-received bytes (SipMessageFactory::createMessage, on
+	// behalf of SipServer::onNewMessage) keeps them intact after this returns.
+	std::shared_ptr<SipMessage> getMessageFromPool(std::string_view message, sockaddr_in src);
+
+	// Clones an already-parsed message into a free pool slot via a direct field
+	// copy (SipMessage's copy assignment is a plain owned-string/vector copy —
+	// no shared buffer to fix up). Used by every response-building call site that
+	// used to go through getMessageFromPool(source->toString(), source->getSource()),
+	// which paid a full serialize + reparse just to duplicate a message we had
+	// already parsed once (issue #76).
+	std::shared_ptr<SipMessage> getMessageFromPool(const SipMessage& source);
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,9 @@ add_executable(sip_parser_tests
     # driver. Host-compilable — the driver is a std::thread off-device and the
     # tests step the clock with tickOnce() instead of starting it.
     ../src/SIP/ConferenceRoom.cpp
+    # Issue #53/#101(A)/#101(E): the static SipMessage pool, extracted out of
+    # RequestsHandler into its own translation unit.
+    ../src/SIP/SipMessagePool.cpp
     ../src/SIP/RequestsHandler.cpp
     ../src/SIP/TransactionLayer.cpp
     ../src/SIP/Registrar.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -170,6 +170,9 @@ add_executable(sip_parser_tests
     # The five DND/forward/ring-group/page-zone/dial-plan PBX feature tables,
     # extracted out of RequestsHandler into their own translation unit.
     ../src/SIP/PbxFeatureConfig.cpp
+    # The CDR ring buffer, extracted out of RequestsHandler into its own
+    # translation unit.
+    ../src/SIP/CdrRing.cpp
     ../src/SIP/RequestsHandler.cpp
     ../src/SIP/TransactionLayer.cpp
     ../src/SIP/Registrar.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,9 @@ add_executable(sip_parser_tests
     # Issue #53/#101(A)/#101(E): the static SipMessage pool, extracted out of
     # RequestsHandler into its own translation unit.
     ../src/SIP/SipMessagePool.cpp
+    # The five DND/forward/ring-group/page-zone/dial-plan PBX feature tables,
+    # extracted out of RequestsHandler into their own translation unit.
+    ../src/SIP/PbxFeatureConfig.cpp
     ../src/SIP/RequestsHandler.cpp
     ../src/SIP/TransactionLayer.cpp
     ../src/SIP/Registrar.cpp


### PR DESCRIPTION
## Summary

First of two stacked PRs decomposing `RequestsHandler` (originally 5302+863 lines) into cohesive machine classes, each behind `PbxEnv` with a `Machine _x{*this}` member — the same pattern already used for `TransactionLayer`/`Registrar`/`ParkOrbit`/`BlfSubscriptions`/`RegisterBeeper`/`ConferenceRoom`. Pure mechanical moves: bodies unchanged except scope renames (`this->` drops, engine-member access → `_env.x()`) and comment references that would otherwise dangle.

- `src/SIP/SipMessagePool.{hpp,cpp}` — the static, leaf-locked SIP message pool
- `src/SIP/PbxFeatureConfig.{hpp,cpp}` — DND/forwards/ring-groups/page-zones/dial-plan storage, with an `OnChanged` callback wired back to `RequestsHandler::refreshPbxConfigSnapshot` so the existing immediate-dashboard-refresh contract (issue #77) survives the split
- `src/SIP/CdrRing.{hpp,cpp}` — the CDR ring buffer, including the *69 last-caller scan

None of these three touch `onInvite` or the packet path. Zero new `PbxEnv` virtuals.

## Test plan
- [x] Host tests: 309/309 (1 pre-existing flaky test excluded: `ConferenceRoom.ThreeLegsEachHearTheOthersMinusThemselves`, unrelated to this refactor)
- [x] Firmware compiles: `idf.py -D SIP_TRANSPORT=eth build`
- [x] `tests/tools/check_parser_callgraph.py` stack-recursion guard clean
- [x] Adversarial multi-lens review on each commit (lock discipline, call-site updates, byte-identical moved bodies, bounds/validation) — all clean after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ3ToKh5jPcQKEFpGABAWH