### PR TITLE
fix(sip): relay BYE across park-retrieve bridge on either leg's teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased (fix/issue-127-park-retrieve-bye-relay) - 2026-09-04
+
+### Fixed — Park retrieve: BYE from either leg was never relayed to the other (#127)
+
+- `ParkOrbit::onInvite` created both the parked leg's session (at park time) and
+  the retriever's session (at retrieve time) without ever calling
+  `Session::setDialogHeaders()` — so `RequestsHandler::onBye`'s peerCallID
+  cross-dialog relay branch (the same one Issue #68 call pickup uses) always
+  found an empty `getDialogFrom()`/`getDialogTo()` and silently skipped
+  building the peer-addressed BYE. `peerCallID` itself was set correctly on
+  both legs; only the dialog-header half of the contract was missing, which is
+  why the retriever's own BYE was still answered 200 OK (its own dialog ended
+  fine) while the formerly-parked party's phone was left hanging on a dead
+  call.
+
+  Fixed by capturing each leg's own dialog `From`/`To` (with the server's own
+  to-tag) at the point each session is created, mirroring the convention
+  `CallPickup::complete()` already established. The ring-back-timeout leg
+  (`Session::isParkUac()`) has the same gap but is a server-UAC-role dialog
+  needing swapped header capture — out of scope here; the `onBye` comment
+  where the relay lives now says so explicitly.
+
+  New coverage in `tests/ParkOrbit_test.cpp` pins that both legs' dialog
+  headers and `peerCallID` are set after a retrieve — the host-testable
+  regression, since `.smoke/office_smoke.py`'s "Call park + retrieve" scenario
+  (which originally caught this) isn't wired into CI.
+
 ## Unreleased (on main, in no published release) - 2026-09-03
 
 ### Security — SoftAP WPA2, CSRF tokens, and a centralised admin gate

--- a/src/SIP/ParkOrbit.cpp
+++ b/src/SIP/ParkOrbit.cpp
@@ -69,6 +69,13 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 			session->setDest(virt);
 			session->setLocalTag(toTag);
 			session->setInviteMessage(data);
+			// Captured now, used later: once this parked leg is retrieved (see
+			// the RETRIEVE branch below) or rung back on timeout, onBye's
+			// peerCallID branch needs this dialog's own From/To (with our
+			// to-tag) to build a correctly-addressed BYE toward this party —
+			// same convention as CallPickup::complete()'s setDialogHeaders().
+			session->setDialogHeaders(std::string(data->getFrom()),
+				std::string(data->getTo()) + ";tag=" + toTag);
 			_env.insertSession(std::string(data->getCallID()), session);
 			session->setState(Session::State::Connected);
 		}
@@ -115,6 +122,12 @@ void ParkOrbit::onInvite(const std::shared_ptr<SipMessage>& data,
 	rsession->setPeerCallID(slot.callID);
 	rsession->setLocalTag(toTag);
 	rsession->setInviteMessage(data);
+	// Issue #127: onBye's peerCallID branch (RequestsHandler.cpp) only relays a
+	// BYE across the bridge when BOTH legs' dialog headers are captured — this
+	// was the missing half (the parked leg gets its own setDialogHeaders() call
+	// at park time, above). Same convention as CallPickup::complete().
+	rsession->setDialogHeaders(std::string(data->getFrom()),
+		std::string(data->getTo()) + ";tag=" + toTag);
 	_env.insertSession(std::string(data->getCallID()), rsession);
 	rsession->setState(Session::State::Connected);
 

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1483,15 +1483,15 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
-	// Cross-dialog bridge teardown (Issue #68 call pickup — and, as a
-	// byproduct, ParkOrbit's retrieve/ring-back legs, which set peerCallID
-	// too but had no relay wired up for it before this). A BYE here ends ONE
-	// of two independently-dialogued legs that only the server's own
-	// bookkeeping links together; relaying the raw BYE as-is (its own
-	// Call-ID) would be rejected 481 by the peer's phone (wrong dialog), so a
-	// peer-addressed BYE has to be built fresh from the PEER session's own
-	// dialog identifiers — exactly what sweepSessionTimers() already does for
-	// a single session's own two legs, generalized here across two sessions.
+	// Cross-dialog bridge teardown (Issue #68 call pickup and, since #127,
+	// ParkOrbit's park+retrieve legs — both set peerCallID AND capture dialog
+	// headers). A BYE here ends ONE of two independently-dialogued legs that
+	// only the server's own bookkeeping links together; relaying the raw BYE
+	// as-is (its own Call-ID) would be rejected 481 by the peer's phone
+	// (wrong dialog), so a peer-addressed BYE has to be built fresh from the
+	// PEER session's own dialog identifiers — exactly what sweepSessionTimers()
+	// already does for a single session's own two legs, generalized here
+	// across two sessions.
 	if (session.has_value() && !session.value()->getPeerCallID().empty())
 	{
 		std::string peerCallId = session.value()->getPeerCallID();
@@ -1499,11 +1499,14 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		{
 			auto peer = peerSession.value();
 			// Issue #72's guard, reused: a BYE with an empty From or To is
-			// malformed and phones drop it. CallPickup::complete() always captures
-			// both via setDialogHeaders(), but ParkOrbit's retrieve/ring-back legs
-			// (the other peerCallID-setting path) don't yet — so a park leg
-			// still gets the endCall() cleanup below, just not a peer-phone
-			// BYE, rather than emitting a "From: \r\nTo: \r\n" packet.
+			// malformed and phones drop it. CallPickup::complete() and
+			// ParkOrbit's park+retrieve paths always capture both via
+			// setDialogHeaders() (see ParkOrbit::onInvite). ParkOrbit's
+			// ring-back-timeout leg (isParkUac()) is the one path that still
+			// doesn't — it's a server-initiated (UAC-role) dialog, so its
+			// From/To would need swapped capture, not just the same call —
+			// left as-is: a ring-back leg still gets the endCall() cleanup
+			// below, just not a peer-phone BYE, rather than a malformed one.
 			if (auto notify = peer->getSrc();
 				notify && !peer->getDialogFrom().empty() && !peer->getDialogTo().empty())
 			{

--- a/tests/ParkOrbit_test.cpp
+++ b/tests/ParkOrbit_test.cpp
@@ -139,6 +139,45 @@ TEST(ParkOrbit, ParkChangedFlagTracksSlotStateNotTraffic)
 	EXPECT_TRUE(park.snapshotRows(std::chrono::steady_clock::now(), /*onlyParked=*/false).empty());
 }
 
+// Issue #127: a BYE from either leg of a retrieved park must relay to the
+// other (RequestsHandler::onBye's peerCallID branch), but that relay only
+// fires when both legs' own dialog headers were captured via
+// setDialogHeaders() — the same convention CallPickup::complete() uses.
+// ParkOrbit is the producer of that state; this pins it directly rather than
+// relying on the harder-to-wire end-to-end office_smoke.py scenario that
+// originally caught the regression.
+TEST(ParkOrbit, RetrieveCapturesDialogHeadersOnBothLegsForByeRelay)
+{
+	FakePbxEnv env;
+	ParkOrbit park(env);
+
+	const sockaddr_in parkedAddr    = FakePbxEnv::addr("192.168.1.50", 5060);
+	const sockaddr_in retrieverAddr = FakePbxEnv::addr("192.168.1.51", 5060);
+
+	park.onInvite(inviteTo("700", "101", "parked-call-5@192.168.1.50", parkedAddr, "192.168.1.50"),
+		std::make_shared<SipClient>("101", parkedAddr), 0);
+	park.onInvite(inviteTo("700", "102", "retrieve-call-5@192.168.1.51", retrieverAddr, "192.168.1.51"),
+		std::make_shared<SipClient>("102", retrieverAddr), 0);
+
+	// findSession/insertSession key on the FULL "Call-ID: x@host" line (see
+	// ParkOrbit::sendReinvite's comment on getCallID()), not the bare value.
+	auto parked = env.findSession("Call-ID: parked-call-5@192.168.1.50");
+	ASSERT_TRUE(parked);
+	EXPECT_FALSE(parked->getDialogFrom().empty());
+	EXPECT_FALSE(parked->getDialogTo().empty());
+	EXPECT_NE(parked->getDialogFrom().find("101@"), std::string::npos) << parked->getDialogFrom();
+	EXPECT_NE(parked->getDialogTo().find(";tag="), std::string::npos) << parked->getDialogTo();
+	EXPECT_EQ(parked->getPeerCallID(), "Call-ID: retrieve-call-5@192.168.1.51");
+
+	auto retriever = env.findSession("Call-ID: retrieve-call-5@192.168.1.51");
+	ASSERT_TRUE(retriever);
+	EXPECT_FALSE(retriever->getDialogFrom().empty());
+	EXPECT_FALSE(retriever->getDialogTo().empty());
+	EXPECT_NE(retriever->getDialogFrom().find("102@"), std::string::npos) << retriever->getDialogFrom();
+	EXPECT_NE(retriever->getDialogTo().find(";tag="), std::string::npos) << retriever->getDialogTo();
+	EXPECT_EQ(retriever->getPeerCallID(), "Call-ID: parked-call-5@192.168.1.50");
+}
+
 // A retrieve that cannot get a session must 503 the retriever and leave the
 // orbit occupied rather than half-tearing-down the parked leg (#71).
 TEST(ParkOrbit, RetrieveWithExhaustedSessionPoolLeavesSlotParked)


### PR DESCRIPTION
## Summary

Fixes #127. Stacked on #130 (third in the stack: #129 → #130 → this). Will show only its own diff once #130 merges; CI won't run on this PR until then either (same base-branch gap already noted on #130).

`ParkOrbit::onInvite` created both the parked leg's session (at park time) and the retriever's session (at retrieve time) without ever calling `Session::setDialogHeaders()` — so `RequestsHandler::onBye`'s peerCallID cross-dialog relay branch (the same one Issue #68 call pickup uses) always found an empty `getDialogFrom()`/`getDialogTo()` and silently skipped building the peer-addressed BYE. `peerCallID` itself was set correctly on both legs already; only the dialog-header half of the contract was missing — which is why the retriever's own BYE was still answered 200 OK (its own dialog ended fine) while the formerly-parked party's phone was left hanging on a dead call.

Fixed by capturing each leg's own dialog From/To (with the server's own to-tag) at the point each session is created, mirroring the convention `CallPickup::complete()` already established for the same relay mechanism.

**Not in scope**: the ring-back-timeout leg (`Session::isParkUac()`) has the identical missing-dialog-headers gap, but it's a server-UAC-role dialog needing swapped header capture, not just the same call. Left alone; the `onBye` comment where the relay lives now says so explicitly instead of implying full coverage.

**Also found while baselining this fix**: `.smoke/office_smoke.py`'s "Attended transfer" scenario also fails, but that looks like a possibly-unimplemented feature rather than a regression — filed separately as #131, not touched here.

## Test plan
- [x] Host tests: 310/310 (309 baseline + 1 new regression test in `tests/ParkOrbit_test.cpp`, 1 pre-existing flaky test excluded)
- [x] Firmware compiles: `idf.py -D SIP_TRANSPORT=eth build`
- [x] `tests/tools/check_parser_callgraph.py` stack-recursion guard clean
- [x] `.smoke/office_smoke.py` "Call park + retrieve" flips from FAIL (`BYE-relay-to-A=False`) to PASS (`BYE-relay-to-A=True`) against a live host build — this scenario isn't wired into CI, so the new gtest is what actually gates regressions here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ3ToKh5jPcQKEFpGABAWH