### PR TITLE
fix(sip): send the dropped party a BYE on blind transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased (fix/issue-128-blind-transfer-teardown) - 2026-09-04
+
+### Fixed — Blind transfer: the dropped party never received a BYE (#128)
+
+- `RequestsHandler::onRefer`'s blind-transfer path already tore down the
+  transferor's original session via `endCall()` before driving the fresh
+  INVITE to the transfer target (drawbridge's earlier fix for the reverse
+  ordering bug, already present here) — but `endCall()` is pure local
+  bookkeeping (session/pool/CDR release); it never puts a packet on the wire.
+  The OTHER party on that dialog (the one the transfer drops, not the
+  transferor) was never told the call ended, so its phone sat on a call the
+  server itself already considered over.
+
+  Fixed by sending that party an explicit BYE before `endCall()` erases the
+  session. REFER is itself an in-dialog request on the SAME dialog it's
+  transferring out of, so `data->getFrom()`/`getTo()` already carry that
+  dialog's tags exactly — no dependency on `Session::getDialogFrom()`/
+  `getDialogTo()`, which `armSessionTimer()` only populates when RFC 4028
+  Session-Expires was negotiated. Works regardless of which side of the
+  original call sent the REFER (the transferor can be either the original
+  caller or callee) by comparing both `Session::getSrc()`/`getDest()` against
+  the transferor's own number and BYE-ing whichever one isn't it.
+
+  New coverage in `tests/BlindTransfer_test.cpp` drives a full call through
+  connect and blind transfer, and asserts the dropped party receives a BYE
+  for the correct Call-ID (not just that the transfer target gets an
+  INVITE) — the host-testable regression, since
+  `.smoke/office_smoke.py`'s "Blind transfer" scenario (which originally
+  caught this) isn't wired into CI.
+
 ## Unreleased (fix/issue-127-park-retrieve-bye-relay) - 2026-09-04
 
 ### Fixed — Park retrieve: BYE from either leg was never relayed to the other (#127)

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1908,6 +1908,27 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 	std::string callID(data->getCallID());
 	auto targetClient = findClient(target);
 
+	// Issue #128: endCall() below is pure local bookkeeping (session/pool/CDR) — it
+	// never puts a packet on the wire, so the OTHER party on this dialog (the one
+	// NOT the transferor, dropped by the transfer) was never told the call ended and
+	// sat on a dead call forever. REFER is itself an in-dialog request on the SAME
+	// A-B dialog it's transferring out of, so data->getFrom()/getTo() already carry
+	// exactly this dialog's tags (transferor's own + the other party's) — no need to
+	// read session->getDialogFrom()/getDialogTo(), which armSessionTimer() only
+	// populates when RFC 4028 Session-Expires was negotiated.
+	if (auto original = getSession(callID); original.has_value())
+	{
+		auto src = original.value()->getSrc();
+		auto dest = original.value()->getDest();
+		auto other = (dest && dest->getNumber() != transferor->getNumber()) ? dest : src;
+		if (other && other->getNumber() != transferor->getNumber())
+		{
+			auto bye = buildServerBye(other->getNumber(), other->getAddress(), callID,
+				std::string(data->getFrom()), std::string(data->getTo()));
+			if (bye) _outbox.emplace_back(other->getAddress(), std::move(bye));
+		}
+	}
+
 	endCall(callID, transferor->getNumber(), std::string(data->getToNumber()), "blind transfer");
 
 	bool ok = targetClient.has_value() && _forker.redirectInvite(data, transferor, target);

--- a/tests/BlindTransfer_test.cpp
+++ b/tests/BlindTransfer_test.cpp
@@ -1,0 +1,299 @@
+// BlindTransfer_test.cpp — Issue #128 regression coverage.
+//
+// RequestsHandler::onRefer() already tears down the transferor's ORIGINAL
+// session (endCall()) before driving the fresh INVITE to the transfer target
+// — but endCall() is pure local bookkeeping (session/pool/CDR); it never puts
+// a packet on the wire. The OTHER party on that original dialog (the one
+// being dropped by the transfer, not the transferor) was never sent a BYE, so
+// its phone sat on a call the server considered long over.
+//
+// This drives a real RequestsHandler through handle() end-to-end (mirroring
+// BroadcastHoldResume_test.cpp's pattern): register three extensions, place a
+// direct call, answer it, then blind-transfer it and assert the dropped
+// party actually receives a BYE for the SAME dialog it was on — not just
+// that the transfer target gets a fresh INVITE.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "RequestsHandler.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <WinSock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	sockaddr_in addrFor(const std::string& ip, uint16_t port = 5060)
+	{
+		sockaddr_in a{};
+		a.sin_family = AF_INET;
+		a.sin_addr.s_addr = inet_addr(ip.c_str());
+		a.sin_port = htons(port);
+		return a;
+	}
+
+	std::shared_ptr<SipMessage> makeRegister(const std::string& ext, const std::string& ip,
+	                                          const std::string& callId)
+	{
+		std::string raw =
+			"REGISTER sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + ip + ":5060;branch=z9hG4bKr" + callId + "\r\n"
+			"From: <sip:" + ext + "@server>;tag=rt" + callId + "\r\n"
+			"To: <sip:" + ext + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 REGISTER\r\n"
+			"Contact: <sip:" + ext + "@" + ip + ":5060>;expires=3600\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, addrFor(ip));
+	}
+
+	std::string sdpBody()
+	{
+		return
+			"v=0\r\n"
+			"o=- 0 0 IN IP4 10.0.0.1\r\n"
+			"s=-\r\n"
+			"c=IN IP4 10.0.0.1\r\n"
+			"t=0 0\r\n"
+			"m=audio 10000 RTP/AVP 0\r\n"
+			"a=rtpmap:0 PCMU/8000\r\n";
+	}
+
+	std::string findSentTo(const std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                       const sockaddr_in& addr, const std::string& needle)
+	{
+		for (auto it = sent.rbegin(); it != sent.rend(); ++it)
+		{
+			if (it->first.sin_addr.s_addr != addr.sin_addr.s_addr) continue;
+			if (it->first.sin_port != addr.sin_port) continue;
+			if (!it->second) continue;
+			std::string raw = it->second->toString();
+			if (raw.find(needle) != std::string::npos) return raw;
+		}
+		return {};
+	}
+
+	std::string extractHeaderLine(const std::string& raw, const std::string& name)
+	{
+		size_t pos = 0;
+		while (pos < raw.size())
+		{
+			size_t eol = raw.find("\r\n", pos);
+			if (eol == std::string::npos) eol = raw.size();
+			std::string line = raw.substr(pos, eol - pos);
+			if (line.size() > name.size() &&
+				line.compare(0, name.size(), name) == 0)
+			{
+				return line;
+			}
+			pos = eol + 2;
+		}
+		return {};
+	}
+}
+
+TEST(BlindTransfer, DroppedPartyReceivesByeAndTargetReceivesFreshInvite)
+{
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+	RequestsHandler handler("192.168.30.1", 5060,
+		[&sent](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			sent.emplace_back(addr, std::move(msg));
+		});
+
+	const sockaddr_in transferorAddr = addrFor("192.168.30.10"); // A: 100
+	const sockaddr_in droppedAddr    = addrFor("192.168.30.20"); // B: 106
+	const sockaddr_in targetAddr     = addrFor("192.168.30.30"); // C: 107
+
+	handler.handle(makeRegister("100", "192.168.30.10", "reg-100"));
+	handler.handle(makeRegister("106", "192.168.30.20", "reg-106"));
+	handler.handle(makeRegister("107", "192.168.30.30", "reg-107"));
+
+	// ── A calls B directly ──────────────────────────────────────────────────
+	const std::string callId = "blindxfer-128";
+	{
+		std::string body = sdpBody();
+		std::string raw =
+			"INVITE sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.30.10:5060;branch=z9hG4bKinv\r\n"
+			"From: <sip:100@server>;tag=atag\r\n"
+			"To: <sip:106@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Contact: <sip:100@192.168.30.10:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, transferorAddr));
+	}
+	std::string forkToB = findSentTo(sent, droppedAddr, "INVITE sip:106@");
+	ASSERT_FALSE(forkToB.empty()) << "direct call must reach B";
+
+	// ── B answers ────────────────────────────────────────────────────────────
+	{
+		std::string fromLine = extractHeaderLine(forkToB, "From:");
+		std::string via = extractHeaderLine(forkToB, "Via:");
+		ASSERT_FALSE(fromLine.empty());
+		std::string body = sdpBody();
+		std::string raw =
+			"SIP/2.0 200 OK\r\n" +
+			via + "\r\n" +
+			fromLine + "\r\n"
+			"To: <sip:106@server>;tag=btag\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Contact: <sip:106@192.168.30.20:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, droppedAddr));
+	}
+	ASSERT_FALSE(findSentTo(sent, transferorAddr, "SIP/2.0 200 OK").empty())
+		<< "A must see B's answer relayed";
+
+	auto sessionOpt = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(sessionOpt.has_value());
+	EXPECT_EQ(sessionOpt.value()->getState(), Session::State::Connected);
+
+	// ── A blind-transfers the call to C (107) — REFER in-dialog on the A-B
+	// dialog established above, so its From/To carry A's and B's own tags. ──
+	{
+		std::string raw =
+			"REFER sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.30.10:5060;branch=z9hG4bKref\r\n"
+			"From: <sip:100@server>;tag=atag\r\n"
+			"To: <sip:106@server>;tag=btag\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server>\r\n"
+			"Contact: <sip:100@192.168.30.10:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		handler.handle(RequestsHandler::getMessageFromPool(raw, transferorAddr));
+	}
+
+	// A gets the 202 Accepted.
+	EXPECT_FALSE(findSentTo(sent, transferorAddr, "SIP/2.0 202 Accepted").empty())
+		<< "REFER must be accepted";
+
+	// B — the party being dropped, NOT the transferor — must get an explicit
+	// BYE for the SAME dialog (Call-ID) it was on. This is the #128 regression:
+	// endCall() alone never sends this.
+	std::string byeToB = findSentTo(sent, droppedAddr, "BYE sip:");
+	ASSERT_FALSE(byeToB.empty()) << "B must receive a BYE ending its dialog with A";
+	EXPECT_NE(byeToB.find("Call-ID: " + callId), std::string::npos) << byeToB;
+	// The whole point: B's UA must actually ACCEPT this as its own dialog, which
+	// means the tags aren't just present but in the right slots — From carries
+	// the transferor's (A's) tag, To carries B's own tag, exactly as REFER's own
+	// From/To did. Swapping the two buildServerBye() args would still produce a
+	// message starting with "BYE sip:" and containing the right Call-ID, so the
+	// Call-ID check above can't catch that mistake — only this can.
+	EXPECT_NE(extractHeaderLine(byeToB, "From:").find("tag=atag"), std::string::npos) << byeToB;
+	EXPECT_NE(extractHeaderLine(byeToB, "To:").find("tag=btag"), std::string::npos) << byeToB;
+
+	// C — the transfer target — must get a fresh INVITE. redirectInvite()
+	// reuses the SAME Call-ID for the new A-C leg (that reuse is exactly why
+	// endCall() must run before it, per the ordering comment in onRefer()),
+	// so the session under this Call-ID legitimately still exists afterward —
+	// it now represents A's continuation with C, not the torn-down A-B leg.
+	EXPECT_FALSE(findSentTo(sent, targetAddr, "INVITE sip:107@").empty())
+		<< "transfer target must receive a fresh INVITE";
+}
+
+// The transferor can be either side of the original call — issue #128's own
+// repro has the CALLEE transfer ("A calls B; B answers; B sends REFER"), the
+// more common real-world shape (a receptionist transferring an inbound call).
+// onRefer()'s other/src/dest selection must BYE the ORIGINAL CALLER in that
+// orientation, not always the callee — this exercises the ternary's second
+// branch, which the caller-as-transferor test above never reaches.
+TEST(BlindTransfer, CalleeAsTransferorByesTheOriginalCaller)
+{
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+	RequestsHandler handler("192.168.31.1", 5060,
+		[&sent](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			sent.emplace_back(addr, std::move(msg));
+		});
+
+	const sockaddr_in callerAddr     = addrFor("192.168.31.10"); // A: 100 (original caller, dropped)
+	const sockaddr_in transferorAddr = addrFor("192.168.31.20"); // B: 106 (callee, does the REFER)
+	const sockaddr_in targetAddr     = addrFor("192.168.31.30"); // C: 107
+
+	handler.handle(makeRegister("100", "192.168.31.10", "reg-100b"));
+	handler.handle(makeRegister("106", "192.168.31.20", "reg-106b"));
+	handler.handle(makeRegister("107", "192.168.31.30", "reg-107b"));
+
+	// ── A calls B ────────────────────────────────────────────────────────────
+	const std::string callId = "blindxfer-128b";
+	{
+		std::string body = sdpBody();
+		std::string raw =
+			"INVITE sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.31.10:5060;branch=z9hG4bKinvb\r\n"
+			"From: <sip:100@server>;tag=atagb\r\n"
+			"To: <sip:106@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Contact: <sip:100@192.168.31.10:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, callerAddr));
+	}
+	std::string forkToB = findSentTo(sent, transferorAddr, "INVITE sip:106@");
+	ASSERT_FALSE(forkToB.empty()) << "direct call must reach B";
+
+	// ── B answers ────────────────────────────────────────────────────────────
+	{
+		std::string fromLine = extractHeaderLine(forkToB, "From:");
+		std::string via = extractHeaderLine(forkToB, "Via:");
+		ASSERT_FALSE(fromLine.empty());
+		std::string body = sdpBody();
+		std::string raw =
+			"SIP/2.0 200 OK\r\n" +
+			via + "\r\n" +
+			fromLine + "\r\n"
+			"To: <sip:106@server>;tag=btagb\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 INVITE\r\n"
+			"Contact: <sip:106@192.168.31.20:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		handler.handle(RequestsHandler::getMessageFromPool(raw, transferorAddr));
+	}
+	ASSERT_FALSE(findSentTo(sent, callerAddr, "SIP/2.0 200 OK").empty())
+		<< "A must see B's answer relayed";
+
+	// ── B (the callee) blind-transfers to C. REFER's From carries B's own tag,
+	// To carries A's — B is the transferor here, A is the party to drop. ──────
+	{
+		std::string raw =
+			"REFER sip:100@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.31.20:5060;branch=z9hG4bKrefb\r\n"
+			"From: <sip:106@server>;tag=btagb\r\n"
+			"To: <sip:100@server>;tag=atagb\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server>\r\n"
+			"Contact: <sip:106@192.168.31.20:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		handler.handle(RequestsHandler::getMessageFromPool(raw, transferorAddr));
+	}
+
+	EXPECT_FALSE(findSentTo(sent, transferorAddr, "SIP/2.0 202 Accepted").empty())
+		<< "REFER must be accepted";
+
+	// A — the original caller, NOT the transferor this time — must get the BYE,
+	// correctly tagged (From=B's tag, To=A's tag, matching the REFER's own).
+	std::string byeToA = findSentTo(sent, callerAddr, "BYE sip:");
+	ASSERT_FALSE(byeToA.empty()) << "A must receive a BYE ending its dialog with B";
+	EXPECT_NE(byeToA.find("Call-ID: " + callId), std::string::npos) << byeToA;
+	EXPECT_NE(extractHeaderLine(byeToA, "From:").find("tag=btagb"), std::string::npos) << byeToA;
+	EXPECT_NE(extractHeaderLine(byeToA, "To:").find("tag=atagb"), std::string::npos) << byeToA;
+
+	EXPECT_FALSE(findSentTo(sent, targetAddr, "INVITE sip:107@").empty())
+		<< "transfer target must receive a fresh INVITE";
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,13 @@ add_executable(sip_parser_tests
     # 200 OK was silently dropped instead of reaching the held leg. Drives a full
     # 999 broadcast call through connect -> hold -> resume via handle().
     BroadcastHoldResume_test.cpp
+    # Issue #128: blind transfer's onRefer() tore down the transferor's ORIGINAL
+    # session (endCall(), pure local bookkeeping) without ever sending the
+    # dropped party a BYE on the wire. Drives a direct call through connect,
+    # then a blind transfer, and asserts the dropped party's phone actually
+    # gets a BYE for the dialog it was on (not just that the target gets an
+    # INVITE).
+    BlindTransfer_test.cpp
     # Issue #69: the bounded pattern -> action dial plan that generalizes the
     # ring-group mechanism. Pure grammar/precedence/cap coverage against
     # DialPlan.hpp, end-to-end routing (dispatch + fallthrough) driven through


### PR DESCRIPTION
## Summary

Fixes #128. Stacked on #132 (fourth in the stack: #129 → #130 → #132 → this). Will show only its own diff once #132 merges; CI won't run on this PR until then either (same base-branch gap already noted on #130/#132).

`onRefer()`'s blind-transfer path already tore down the transferor's original session via `endCall()` before driving the fresh INVITE to the transfer target (drawbridge's earlier fix for the reverse ordering bug, already present in this repo) — but `endCall()` is pure local bookkeeping (session/pool/CDR release); it never puts a packet on the wire. The OTHER party on that dialog (the one the transfer drops, not the transferor) was never told the call ended, so its phone sat on a call the server itself already considered over.

Fixed by sending that party an explicit BYE before `endCall()` erases the session, built from the REFER's own in-dialog From/To (no dependency on `Session::getDialogFrom()`/`getDialogTo()`, which is only populated when RFC 4028 Session-Expires was negotiated). Works regardless of which side of the original call sent the REFER — both orientations (caller-as-transferor and callee-as-transferor, the latter being issue #128's own repro and the more common real-world shape) are covered by separate tests.

**Also found while investigating, filed separately, not touched here**:
- #131 (attended transfer, REFER+`Replaces`): I originally guessed this might be an unimplemented feature. Corrected — it's a confirmed port from drawbridge (`onRefer`/`onBye` logic + `Session` fields pocket-dial already has but doesn't use yet). Planned as the next PR in this stack.
- #133: `onRefer` has no `isDialogSourceAuthorized` check, unlike `onBye`'s #46 guard — pre-existing auth gap, now has a wire-visible side effect (a mismatched-tag BYE to the victim's peer) as of this fix. Filed, not fixed here.

## Test plan
- [x] Host tests: 312/312 (310 baseline + 2 new tests in `tests/BlindTransfer_test.cpp`, covering both transferor orientations and asserting the BYE's From/To tags land in the correct slots — not just that a BYE with the right Call-ID was sent, which a swapped-arguments bug would still pass; 1 pre-existing flaky test excluded)
- [x] Firmware compiles: `idf.py -D SIP_TRANSPORT=eth build`
- [x] `tests/tools/check_parser_callgraph.py` stack-recursion guard clean
- [x] `.smoke/office_smoke.py` "Blind transfer" flips from FAIL (`B torn down=False`) to PASS (`B torn down=True`) against a live host build — this scenario isn't wired into CI, so the new gtests are what actually gate regressions here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ3ToKh5jPcQKEFpGABAWH