### PR TITLE
fix(sip): attended transfer via REFER + Replaces (RFC 3891)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## Unreleased (feat/issue-131-attended-transfer) - 2026-09-04
+
+### Added — Attended transfer via REFER + Replaces (#131)
+
+- Ported drawbridge's `e594914` ("Phase C-2 — attended transfer via REFER +
+  Replaces") to pocket-dial. A transferor (A) with two active P2P calls — A-B
+  and a consult call A-C — sends REFER on the A-B dialog with a `Replaces`
+  URI parameter naming the A-C dialog (RFC 3891). `RequestsHandler::onRefer`
+  now recognizes this and splices B and C together directly: cross
+  re-INVITEs carry each leg's SDP to the other, A is BYE'd out of both
+  dialogs, and the two sessions are linked as a transfer bridge
+  (`Session::isTransferBridge`/`getPeerCallID`) so a later BYE from either B
+  or C relays to the other instead of reaching the now-departed A
+  (`RequestsHandler::onBye`'s new transfer-bridge branch, which must run
+  before the pre-existing Issue #68/#127 generic peerCallID branch). The
+  splice's own re-INVITE 200 OKs are intercepted and ACKed directly
+  (`RequestsHandler::handleTransferOk`, called from `onOk` before the
+  generic session lookup) so they never reach the generic relay, which would
+  otherwise forward them toward A.
+
+  Most of the supporting `Session` scaffolding this needed
+  (`_remoteSdp`/`getRemoteSdp`/`setRemoteSdp`, `_isTransferBridge`) was
+  already present as unused fields from an earlier partial port — this PR
+  wires it up rather than adding it from scratch. `onOk`'s SDP/dialog-header
+  capture for it turned out to already be in place too.
+
+  A can be either side (caller or callee) of either dialog — the
+  "receptionist" case (B calls A, A consults C) is just as valid as A
+  originating both calls. The splice derives which side A is on
+  independently per dialog and picks the other party's client, SDP (via
+  `getInviteMessage()->getBody()` when A is the callee, since
+  `getRemoteSdp()` is always "the callee's SDP" and would otherwise return
+  A's own answer), and dialog-header From/To orientation accordingly, rather
+  than assuming A is always the caller. `Session` gained
+  `wasTransferorSrc()`/`setWasTransferorSrc()` (mirroring the existing
+  `isParkUac()` pattern) so `onBye`'s transfer-bridge relay can find the
+  correct surviving peer and header orientation for a session whose original
+  A-orientation is otherwise unrecoverable by the time a later BYE arrives.
+
+  `siphdr::urlDecode` (new, `SipHeaderUtil.hpp`) percent-decodes the
+  `Replaces=` URI parameter before parsing its `;`-separated pieces, so a
+  `%3B`-encoded separator inside the SIP-URI-embedded value doesn't get cut
+  at the wrong point. A `Replaces` value that decodes to something
+  containing a control character (e.g. a `%0D%0A`-smuggled CRLF) is treated
+  as malformed and declined (603) rather than silently falling through to a
+  blind transfer.
+
+  New coverage in `tests/AttendedTransfer_test.cpp`: the splice's accepted
+  response and crossed re-INVITEs, the re-INVITE-OK-intercepted-not-relayed
+  behavior, post-splice BYE relay, an unresolvable `Replaces` declining
+  cleanly, and two orientation regressions found by adversarial review
+  before this PR — B-calls-A-then-A-consults-C, and both legs A-as-callee —
+  which the initial port got backwards (it unconditionally assumed A was the
+  caller of both dialogs). `.smoke/office_smoke.py`'s "Attended transfer"
+  scenario (A-as-caller only) also passes, 11/11 overall.
+
+  Known gaps, not fixed here: #133 (`onRefer` has no source-authorization
+  check, same as blind transfer); the splice's SDP/dialog-header presence
+  check can't detect a leg that's on HOLD at consult time (documented
+  in-code, not exercised by any test); RFC 3891 §3's `from-tag`/`to-tag`
+  MUST-match against the `Replaces` target dialog is not enforced (the bare
+  Call-ID is matched, tags are parsed by office_smoke's own construction but
+  not validated) — neither drawbridge's source nor this port do this
+  matching; worth its own follow-up if it matters in practice.
+
+### Fixed — ConferenceRoom test: RtpSender's real Linux pacer thread raced synchronous playout-buffer assertions (#135)
+
+- Found while adding the above: `ConferenceRoom.AnchorModeIsUnchangedByTheBusRewiring`
+  intermittently failed depending on the test binary's link layout, unrelated to
+  its own test bodies ever running. Root cause: `RtpSender.cpp`'s Linux-desktop
+  branch (`#elif defined(__linux__)`, Issue #82) is not the inert host stub the
+  test file's own header comment claimed — on this build (WSL defines
+  `__linux__`) it spawns a real `std::thread` the instant `startBridge()`
+  succeeds, racing the test's own direct calls into the same buffer. Fixed by
+  stopping that thread right after `startBridge()` succeeds, before driving the
+  buffer by hand. See `tests/ConferenceRoom_test.cpp` and issue #135 for the full
+  mechanism.
+
 ## Unreleased (fix/issue-128-blind-transfer-teardown) - 2026-09-04
 
 ### Fixed — Blind transfer: the dropped party never received a BYE (#128)

--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1483,6 +1483,52 @@ void RequestsHandler::onBye(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
+	// Attended-transfer bridge teardown (issue #131). MUST run before the generic
+	// peerCallID branch below: after onRefer()'s splice, both the B and C sessions
+	// still have src/dest exactly as they were in their ORIGINAL (pre-splice)
+	// dialog with A — the generic branch below BYEs peer->getSrc(), which is
+	// only ever right by coincidence here (A could be either side), so this gets
+	// its own branch rather than a special case bolted onto the generic one.
+	if (session.has_value() && session.value()->isTransferBridge() &&
+		!session.value()->getPeerCallID().empty())
+	{
+		auto response = getMessageFromPool(*data);
+		if (response)
+		{
+			response->setHeader(SipMessageTypes::OK);
+			response->setVia(std::string(data->getVia()) + ";received=" + _localIp);
+			response->clearBody();
+			_outbox.emplace_back(data->getSource(), std::move(response));
+		}
+
+		const std::string peerId = session.value()->getPeerCallID();
+		if (auto peer = getSession(peerId); peer.has_value())
+		{
+			auto peerSess = peer.value();
+			// wasTransferorSrc() records which side A was in the PEER's original
+			// dialog (captured at splice time, since A's identity is otherwise
+			// gone from both sessions by now) -- the surviving party is whichever
+			// side A wasn't.
+			bool peerAIsSrc = peerSess->wasTransferorSrc();
+			auto survivor = peerAIsSrc ? peerSess->getDest() : peerSess->getSrc();
+			// Same #72 malformed-BYE guard as the generic branch below.
+			if (survivor && !peerSess->getDialogFrom().empty() && !peerSess->getDialogTo().empty())
+			{
+				// Impersonate the dropped transferor (A) in the peer dialog — A's
+				// own From/To tags are exactly what that phone's dialog expects.
+				const std::string& peerAHdr     = peerAIsSrc ? peerSess->getDialogFrom() : peerSess->getDialogTo();
+				const std::string& peerOtherHdr = peerAIsSrc ? peerSess->getDialogTo()   : peerSess->getDialogFrom();
+				auto bye = buildServerBye(survivor->getNumber(), survivor->getAddress(),
+					peerId, peerAHdr, peerOtherHdr);
+				if (bye) _outbox.emplace_back(survivor->getAddress(), std::move(bye));
+			}
+			endCall(peerId, survivor ? survivor->getNumber() : std::string(),
+				std::string(data->getFromNumber()), "transfer bridge peer BYE");
+		}
+		endCall(data->getCallID(), data->getFromNumber(), destNumber, "transfer bridge BYE");
+		return;
+	}
+
 	// Cross-dialog bridge teardown (Issue #68 call pickup and, since #127,
 	// ParkOrbit's park+retrieve legs — both set peerCallID AND capture dialog
 	// headers). A BYE here ends ONE of two independently-dialogued legs that
@@ -1552,6 +1598,14 @@ void RequestsHandler::onOk(std::shared_ptr<SipMessage> data)
 	// snapshot mirror is driven by _park.consumeParkChanged() in handle(), so a
 	// state-neutral ACK confirmation no longer pays a rebuild.
 	if (_park.handleOk(data))
+	{
+		return;
+	}
+
+	// Attended-transfer splice re-INVITE ACKs (issue #131), same intercept-before-
+	// session-lookup pattern -- must never reach the generic relay below, which
+	// would forward this 200 OK toward A, the transferor the splice already drops.
+	if (handleTransferOk(data))
 	{
 		return;
 	}
@@ -1822,12 +1876,14 @@ void RequestsHandler::onAck(std::shared_ptr<SipMessage> data)
 
 void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 {
-	// Blind (unattended) transfer, RFC 3515. The transferor (the party that holds
-	// the call and pressed "transfer") sends REFER with a Refer-To header naming the
-	// new target. We ack 202 Accepted, then drive a fresh INVITE from the transferor
-	// to the target, and report progress with a NOTIFY (Event: refer + sipfrag body).
-	// Attended transfer (Refer-To carrying a Replaces= dialog) is OUT OF SCOPE — see
-	// the summary; such a REFER is treated as a blind transfer to the named target.
+	// RFC 3515 REFER handler -- blind transfer and attended transfer (RFC 3891
+	// Replaces). The transferor sends REFER with a Refer-To header naming the
+	// target. When the Refer-To carries a ?Replaces=callid URI parameter, the
+	// REFER is attended: two existing sessions (A-B and A-C, where A is this
+	// transferor) are spliced via cross re-INVITEs so B and C talk directly once A
+	// drops out (see the attended-transfer block below, issue #131). Otherwise the
+	// REFER is a blind transfer: 202 Accepted, then a fresh INVITE from the
+	// transferor to the target, reported back via NOTIFY (Event: refer + sipfrag).
 	auto transferorOpt = findClient(data->getFromNumber());
 	if (!transferorOpt.has_value())
 	{
@@ -1843,8 +1899,16 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 	}
 	auto transferor = transferorOpt.value();
 
-	// Pull the Refer-To header value out of the raw message and extract the target.
+	// Pull the Refer-To header value out of the raw message, extract the target,
+	// and (issue #131) any ?Replaces= URI parameter naming the consult dialog.
 	std::string target;
+	std::string replacesCallIdBare; // bare call-id from ?Replaces=, URL-decoded
+	// True when a Replaces= param was present but decoded to something
+	// containing a control character (e.g. a %0D%0A-smuggled CRLF that would
+	// otherwise be embedded verbatim into an outgoing Call-ID header below).
+	// A malformed Replaces is NOT the same as an absent one -- it forces a
+	// 603 Decline rather than silently downgrading to a blind transfer.
+	bool replacesMalformed = false;
 	{
 		const std::string& raw = data->toString();
 		// Case-insensitive scan for a "Refer-To:" header line (no compact form in 3515).
@@ -1863,6 +1927,36 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 					size_t valEnd = (lineEnd == std::string::npos) ? raw.size() : lineEnd;
 					std::string value = raw.substr(pos + 9, valEnd - (pos + 9));
 					target = pbx::parseReferToTarget(value);
+
+					// parseReferToTarget() stops at '?', so the URI params (including
+					// Replaces=) are still intact in `value`.
+					if (size_t qmark = value.find('?'); qmark != std::string::npos)
+					{
+						std::string uriParams = value.substr(qmark + 1);
+						if (size_t rp = uriParams.find("Replaces="); rp != std::string::npos)
+						{
+							std::string repVal = uriParams.substr(rp + 9);
+							size_t semi = repVal.find_first_of(";&>\r");
+							replacesCallIdBare = siphdr::urlDecode(
+								(semi == std::string::npos) ? repVal : repVal.substr(0, semi));
+							// URL-decode FIRST, then strip: a %3B-encoded ;from-tag=/
+							// ;to-tag= param must not bleed into the bare call-id used
+							// for the session lookup below.
+							if (size_t semiDecoded = replacesCallIdBare.find(';');
+								semiDecoded != std::string::npos)
+							{
+								replacesCallIdBare.resize(semiDecoded);
+							}
+							for (unsigned char c : replacesCallIdBare)
+							{
+								if (c < 0x20 || c == 0x7F)
+								{
+									replacesMalformed = true;
+									break;
+								}
+							}
+						}
+					}
 					break;
 				}
 			}
@@ -1886,6 +1980,214 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 		return;
 	}
 
+	std::string callID(data->getCallID());
+
+	// ── Attended transfer (RFC 3891 Replaces), issue #131 ─────────────────────────
+	// A (transferor) has two active calls: A-B (this REFER's own dialog, callID)
+	// and A-C (the consult session, replacesCallIdBare). Splice B<->C via cross
+	// re-INVITEs carrying swapped SDP, then drop A from both dialogs. Falls through
+	// to the blind-transfer path below when Replaces is absent (or unusable).
+	if (!replacesCallIdBare.empty() || replacesMalformed)
+	{
+		const std::string replacesCallIdKey = "Call-ID: " + replacesCallIdBare;
+		bool canSplice = false;
+		std::shared_ptr<Session> ab, ac;
+		std::shared_ptr<SipClient> bClient, cClient;
+		std::string bSdp, cSdp, dFromAB, dToAB, dFromAC, dToAC;
+		bool aIsSrcAB = false, aIsSrcAC = false;
+
+		if (replacesMalformed)
+		{
+			// A control character survived decode (e.g. a %0D%0A-smuggled CRLF) --
+			// refuse outright rather than looking anything up with it. Decline,
+			// don't silently fall through to blind transfer: the caller asked for
+			// an attended transfer and it should fail as one, not quietly change
+			// what it did.
+			queueLog("REFER: attended transfer Replaces contains a control character after decode, declining", true);
+		}
+		else
+		{
+			auto sessionAB = getSession(callID);
+			auto sessionAC = getSession(replacesCallIdKey);
+			canSplice = sessionAB.has_value() && sessionAC.has_value();
+			if (canSplice)
+			{
+				ab = sessionAB.value();
+				ac = sessionAC.value();
+				const std::string aNum = transferor->getNumber();
+				aIsSrcAB = ab->getSrc() && ab->getSrc()->getNumber() == aNum;
+				bool aIsDestAB = ab->getDest() && ab->getDest()->getNumber() == aNum;
+				aIsSrcAC = ac->getSrc() && ac->getSrc()->getNumber() == aNum;
+				bool aIsDestAC = ac->getDest() && ac->getDest()->getNumber() == aNum;
+				// Narrower than #133's general onRefer auth gap: A must be common to
+				// BOTH dialogs, or there is nothing coherent to splice. Stays regardless
+				// of how #133 is eventually resolved.
+				if (!(aIsSrcAB || aIsDestAB) || !(aIsSrcAC || aIsDestAC))
+				{
+					queueLog("REFER: attended transfer invariant violated (A not common to both dialogs)", true);
+					canSplice = false;
+				}
+			}
+			if (canSplice)
+			{
+				// pocket-dial has no SIP-trunk/anchor concept on Session (unlike
+				// drawbridge's isAnchor()/isAnchorInbound() guard) -- every session here
+				// is already a P2P leg, so that check has no equivalent to port.
+				//
+				// A can be EITHER side of either dialog (the receptionist case: B
+				// calls A, A consults C, A transfers -- A is AB's callee, not its
+				// caller), so "the other party" and their SDP must be derived from
+				// which side A actually is, never assumed. getRemoteSdp() is always
+				// "the callee's SDP" -- when A is the callee, that SDP is A's OWN
+				// answer, not B's/C's, so the caller's original offer is read back
+				// from the stored INVITE message body instead (kept for the call's
+				// life -- see getInviteMessage()'s other callers). Same hold-SDP
+				// staleness caveat as the getRemoteSdp() path: this can't detect a
+				// later re-INVITE either, for the same reason noted below.
+				bClient = aIsSrcAB ? ab->getDest() : ab->getSrc();
+				cClient = aIsSrcAC ? ac->getDest() : ac->getSrc();
+				bSdp = aIsSrcAB ? ab->getRemoteSdp()
+					: (ab->getInviteMessage() ? std::string(ab->getInviteMessage()->getBody()) : std::string());
+				cSdp = aIsSrcAC ? ac->getRemoteSdp()
+					: (ac->getInviteMessage() ? std::string(ac->getInviteMessage()->getBody()) : std::string());
+				dFromAB = ab->getDialogFrom(); // AB dialog's caller (src) tag -- not necessarily A's
+				dToAB   = ab->getDialogTo();   // AB dialog's callee (dest) tag -- not necessarily B's
+				dFromAC = ac->getDialogFrom(); // AC dialog's caller (src) tag -- not necessarily A's
+				dToAC   = ac->getDialogTo();   // AC dialog's callee (dest) tag -- not necessarily C's
+				if (!bClient || !cClient || bSdp.empty() || cSdp.empty() ||
+					dFromAB.empty() || dToAB.empty() || dFromAC.empty() || dToAC.empty())
+				{
+					// SDP or dialog headers missing (call too new, or a leg never
+					// reached Connected) -- nothing coherent to splice. NOTE: a phone
+					// that put B on hold before consulting C has bSdp/cSdp holding B's
+					// HOLD answer (a=recvonly/inactive), not a resumed one -- this
+					// check doesn't (and can't, from here) catch that; it only catches
+					// SDP/headers never having been captured at all.
+					canSplice = false;
+				}
+			}
+		}
+
+		if (!canSplice)
+		{
+			auto declined = getMessageFromPool(*data);
+			if (!declined) return;   // pool exhausted: drop, peer retransmits (#101A)
+			declined->setHeader("SIP/2.0 603 Decline");
+			declined->clearBody();
+			declined->setVia(std::string(data->getVia()) + ";received=" + _localIp);
+			_outbox.emplace_back(data->getSource(), std::move(declined));
+			return;
+		}
+
+		// ── Draw every wire-critical message BEFORE mutating any session state or
+		// sending anything (#101A, same acquire-everything-then-mutate discipline as
+		// CallPickup::complete()). A splice touches two sessions' worth of wire state
+		// (two BYEs, two re-INVITEs, one 202); a refusal partway through would leave
+		// A half-dropped with B/C never re-INVITEd — worse than declining outright,
+		// so on ANY refusal below nothing is sent and nothing mutates.
+		const std::string srcIpPort = _localIp + ":" + std::to_string(_serverPort);
+
+		// A's own tag/header in each dialog, and the other party's -- these flip
+		// with orientation. A message the server sends impersonating A carries
+		// A's own tag as From and the peer's as To; a message impersonating the
+		// OTHER party (toward A, e.g. the BYE below) is the reverse. Same
+		// role-inversion reasoning as setParkUac()'s own comment.
+		const std::string& aHdrAB     = aIsSrcAB ? dFromAB : dToAB;
+		const std::string& otherHdrAB = aIsSrcAB ? dToAB   : dFromAB;
+		const std::string& aHdrAC     = aIsSrcAC ? dFromAC : dToAC;
+		const std::string& otherHdrAC = aIsSrcAC ? dToAC   : dFromAC;
+
+		auto byeAfromAB = buildServerBye(transferor->getNumber(), transferor->getAddress(),
+			callID, otherHdrAB, aHdrAB);
+		auto byeAfromAC = buildServerBye(transferor->getNumber(), transferor->getAddress(),
+			replacesCallIdKey, otherHdrAC, aHdrAC);
+
+		std::shared_ptr<SipMessage> invToB;
+		{
+			std::ostringstream ss;
+			ss << "INVITE sip:" << bClient->getNumber() << "@" << sipwire::addrToIpPort(bClient->getAddress()) << " SIP/2.0\r\n"
+			   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=z9hG4bK" << IDGen::GenerateID(12) << "\r\n"
+			   << "From: " << stripHeaderName(aHdrAB) << "\r\n"
+			   << "To: " << stripHeaderName(otherHdrAB) << "\r\n"
+			   << "Call-ID: " << stripHeaderName(callID) << "\r\n"
+			   << "CSeq: 100 INVITE\r\n"
+			   << "Max-Forwards: 70\r\n"
+			   << "Contact: <sip:" << bClient->getNumber() << "@" << srcIpPort << ">\r\n"
+			   << "User-Agent: pocket-dial\r\n"
+			   << "Content-Type: application/sdp\r\n"
+			   << "Content-Length: " << cSdp.size() << "\r\n\r\n"
+			   << cSdp;
+			invToB = getMessageFromPool(ss.str(), bClient->getAddress());
+		}
+		std::shared_ptr<SipMessage> invToC;
+		{
+			std::ostringstream ss;
+			ss << "INVITE sip:" << cClient->getNumber() << "@" << sipwire::addrToIpPort(cClient->getAddress()) << " SIP/2.0\r\n"
+			   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=z9hG4bK" << IDGen::GenerateID(12) << "\r\n"
+			   << "From: " << stripHeaderName(aHdrAC) << "\r\n"
+			   << "To: " << stripHeaderName(otherHdrAC) << "\r\n"
+			   << "Call-ID: " << replacesCallIdBare << "\r\n"
+			   << "CSeq: 100 INVITE\r\n"
+			   << "Max-Forwards: 70\r\n"
+			   << "Contact: <sip:" << cClient->getNumber() << "@" << srcIpPort << ">\r\n"
+			   << "User-Agent: pocket-dial\r\n"
+			   << "Content-Type: application/sdp\r\n"
+			   << "Content-Length: " << bSdp.size() << "\r\n\r\n"
+			   << bSdp;
+			invToC = getMessageFromPool(ss.str(), cClient->getAddress());
+		}
+		auto accepted = getMessageFromPool(*data);
+
+		if (!byeAfromAB || !byeAfromAC || !invToB || !invToC || !accepted)
+		{
+			// Pool exhausted partway through the draw: nothing has been sent or
+			// mutated yet (#101A) — drop, the transferor's phone retransmits the
+			// REFER and the whole splice is retried cleanly from scratch.
+			return;
+		}
+
+		(void)invToB->filterAudioCodecs(/*allowWideband=*/true);   // phone SDP relayed P2P
+		invToB->syncContentLength();
+		(void)invToC->filterAudioCodecs(/*allowWideband=*/true);   // phone SDP relayed P2P
+		invToC->syncContentLength();
+
+		accepted->setHeader(SipMessageTypes::ACCEPTED);
+		accepted->clearBody();
+		accepted->setVia(std::string(data->getVia()) + ";received=" + _localIp);
+		accepted->setTo(std::string(data->getTo()) + ";tag=" + IDGen::GenerateID(9));
+		_outbox.emplace_back(data->getSource(), std::move(accepted));
+
+		_outbox.emplace_back(transferor->getAddress(), std::move(byeAfromAB));
+		_outbox.emplace_back(transferor->getAddress(), std::move(byeAfromAC));
+		_outbox.emplace_back(bClient->getAddress(), std::move(invToB));
+		_outbox.emplace_back(cClient->getAddress(), std::move(invToC));
+		_transferPendingAcks.push_back(callID);
+		_transferPendingAcks.push_back(replacesCallIdKey);
+
+		// Link the two sessions as a transfer bridge: a BYE from either B or C
+		// (onBye's isTransferBridge() branch) relays to the other, using
+		// wasTransferorSrc() to find the surviving party -- A can be either
+		// src or dest of either original dialog, so unlike the generic
+		// peerCallID branch below it, this can't hardcode getDest().
+		ab->setPeerCallID(replacesCallIdKey);
+		ab->setTransferBridge(true);
+		ab->setWasTransferorSrc(aIsSrcAB);
+		ac->setPeerCallID(callID);
+		ac->setTransferBridge(true);
+		ac->setWasTransferorSrc(aIsSrcAC);
+
+		// NOTIFY A with the success sipfrag — best-effort: the splice itself is
+		// already fully committed and on the wire by this point, so a pool refusal
+		// here just means A's phone doesn't get the courtesy status update.
+		auto notify = buildReferNotify(data, transferor, "SIP/2.0 200 OK", /*terminated=*/true);
+		if (notify) _outbox.emplace_back(transferor->getAddress(), std::move(notify));
+
+		queueLog("REFER: attended transfer " + transferor->getNumber() + " -> " +
+			bClient->getNumber() + " <-> " + cClient->getNumber());
+		return;
+	}
+
+	// ── Blind transfer ─────────────────────────────────────────────────────────────
 	// 202 Accepted to the transferor (RFC 3515 §2.4.4).
 	{
 		auto accepted = getMessageFromPool(*data);
@@ -1905,7 +2207,6 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 	// matched no session and the transfer silently never completed. onBusy()/tick()
 	// (CFB/CFNA) end-then-redirect for exactly this reason. CDR is recorded as the
 	// original leg tears down; redirectInvite() then allocates a clean session.
-	std::string callID(data->getCallID());
 	auto targetClient = findClient(target);
 
 	// Issue #128: endCall() below is pure local bookkeeping (session/pool/CDR) — it
@@ -2004,6 +2305,38 @@ std::shared_ptr<SipMessage> RequestsHandler::buildReferNotify(const std::shared_
 	return getMessageFromPool(ss.str(), transferor->getAddress());
 }
 
+bool RequestsHandler::handleTransferOk(const std::shared_ptr<SipMessage>& data)
+{
+	// Only the splice re-INVITEs use CSeq 100 (chosen high enough to never collide
+	// with the dialog's own in-flight CSeq at splice time) — same recognise-by-
+	// Call-ID-in-a-tracking-vector pattern as ParkOrbit::handleOk's pendingAcks scan.
+	if (data->getCSeq().find(SipMessageTypes::INVITE) == std::string::npos) return false;
+	const std::string callID(data->getCallID());
+	auto it = std::find(_transferPendingAcks.begin(), _transferPendingAcks.end(), callID);
+	if (it == _transferPendingAcks.end()) return false;
+
+	std::string activeIp = _localIp;
+	std::string srcIpPort = activeIp + ":" + std::to_string(_serverPort);
+	std::string destIpPort = sipwire::addrToIpPort(data->getSource());
+
+	std::ostringstream ss;
+	ss << "ACK sip:" << data->getToNumber() << "@" << destIpPort << " SIP/2.0\r\n"
+	   << "Via: SIP/2.0/UDP " << srcIpPort << ";branch=z9hG4bK" << IDGen::GenerateID(12) << "\r\n"
+	   << "From: " << stripHeaderName(data->getFrom()) << "\r\n"
+	   << "To: " << stripHeaderName(data->getTo()) << "\r\n"
+	   << "Call-ID: " << stripHeaderName(callID) << "\r\n"
+	   << "CSeq: 100 ACK\r\n"
+	   << "Max-Forwards: 70\r\n"
+	   << "Content-Length: 0\r\n\r\n";
+	auto ack = getMessageFromPool(ss.str(), data->getSource());
+	if (!ack) return true;   // pool exhausted: drop, peer retransmits the 200 OK (#101A) —
+	                          // entry stays so the retransmit still lands here, not the
+	                          // generic relay below (which would forward it toward A).
+	_outbox.emplace_back(data->getSource(), std::move(ack));
+	_transferPendingAcks.erase(it);
+	return true;
+}
+
 bool RequestsHandler::setCallState(std::string_view callID, Session::State state)
 {
 	auto session = getSession(callID);
@@ -2026,6 +2359,12 @@ void RequestsHandler::endCall(std::string_view callID, std::string_view srcNumbe
 	_txLayer.freeForCallId(callID);
 	// Free any park orbit slot holding this call's parked leg.
 	_park.freeForCallId(callID);
+	// Issue #131: a leg that dies mid-splice (before its 200 OK arrives) must not
+	// leak its entry in _transferPendingAcks forever -- same bounded-state
+	// reasoning as the park orbit line above.
+	_transferPendingAcks.erase(
+		std::remove(_transferPendingAcks.begin(), _transferPendingAcks.end(), std::string(callID)),
+		_transferPendingAcks.end());
 	// Drop this call's conference leg, if it had one. Idempotent for every other
 	// call, so this is the ONE place a 888 leg is released — BYE, CANCEL, a session
 	// timer expiring and the orphan sweep all funnel through endCall(), and none of

--- a/src/SIP/RequestsHandler.hpp
+++ b/src/SIP/RequestsHandler.hpp
@@ -505,6 +505,16 @@ private:
 		const std::string& sipfrag,
 		bool terminated);
 
+	// Attended transfer (RFC 3891 Replaces), issue #131: onRefer() splices two live
+	// P2P sessions (A-B and A-C) into one B-C call via cross re-INVITEs carrying
+	// swapped SDP, then drops A. handleTransferOk() (called from onOk() before the
+	// normal session lookup, same pattern as _beeper.handleOk()/_park.handleOk())
+	// intercepts the 200 OK to each splice re-INVITE (CSeq 100, tracked by Call-ID
+	// in _transferPendingAcks) and ACKs it directly — it must never reach the
+	// generic relay below, which would forward it toward A, who is already gone.
+	// Caller holds _mutex.
+	bool handleTransferOk(const std::shared_ptr<SipMessage>& data);
+
 	// ── Media beachhead: virtual extension 440 (server-sourced RTP tone) ─────────
 	// onInvite() routes a dial of 440 here. The server answers 200 OK advertising its
 	// OWN media (server IP:port, m=audio <svrport> RTP/AVP 0, PCMU) and starts the
@@ -598,6 +608,13 @@ private:
 	// RequestsHandler.hpp: Issues #24 and #28 resolved.
 	std::unordered_map<std::string, std::function<void(std::shared_ptr<SipMessage> request)>> _handlers;
 	std::unordered_map<std::string, std::shared_ptr<Session>>   _sessions;
+
+	// Call-IDs of attended-transfer splice re-INVITEs (issue #131) pending their
+	// 200 OK -> ACK, so handleTransferOk() can find them (same bounded-vector
+	// pattern as ParkOrbit's own _pendingAcks). At most two entries live per
+	// transfer (the B leg and the C leg); endCall() erases any entry for the
+	// Call-ID it tears down, so a leg that dies mid-splice can't leak one forever.
+	std::vector<std::string> _transferPendingAcks;
 
 	std::mutex _mutex;
 	OnHandledEvent _onHandled;

--- a/src/SIP/Session.hpp
+++ b/src/SIP/Session.hpp
@@ -128,6 +128,16 @@ public:
 	bool isTransferBridge() const { return _isTransferBridge; }
 	void setTransferBridge(bool v) { _isTransferBridge = v; }
 
+	// Whether the transferor (A) was THIS dialog's caller (src) or callee
+	// (dest) at splice time. The splice deliberately leaves src/dest
+	// unchanged (swapping them would corrupt CDR caller/callee and
+	// getRemoteSdp()'s "callee's SDP" meaning), so the surviving non-A party
+	// can be getSrc() OR getDest() depending on which side A originally was
+	// -- meaningful only when isTransferBridge() is true. Same
+	// role-inversion reasoning as isParkUac() above.
+	bool wasTransferorSrc() const { return _wasTransferorSrc; }
+	void setWasTransferorSrc(bool v) { _wasTransferorSrc = v; }
+
 	void release();
 
 private:
@@ -170,6 +180,7 @@ private:
 
 	std::string _remoteSdp;        // callee's most recent SDP (for transfer SDP swap)
 	bool _isTransferBridge = false; // true for attended-transfer bridge halves
+	bool _wasTransferorSrc = true; // meaningful only when _isTransferBridge
 };
 
 #endif

--- a/src/SIP/SipHeaderUtil.hpp
+++ b/src/SIP/SipHeaderUtil.hpp
@@ -55,6 +55,46 @@ namespace siphdr
 		while (e > v && (h[e - 1] == '\r' || h[e - 1] == '\n')) --e;
 		return std::string(h.substr(v, e - v));
 	}
+
+	// Percent-decode a URI parameter value (RFC 3986 %XX escapes only — unlike
+	// HTTP form encoding, a SIP URI parameter does NOT treat '+' as space, so an
+	// intentional '+' in a Call-ID or tag survives unchanged). Used to decode the
+	// ?Replaces=callid;from-tag=X;to-tag=Y URI parameter on an attended-transfer
+	// Refer-To (RFC 3891) before the embedded ';' separators are parsed.
+	inline std::string urlDecode(std::string_view src)
+	{
+		// Hand-rolled instead of sscanf("%x", ...): sscanf greedily matches a
+		// variable-length run of hex digits, so a malformed escape like "%4Z"
+		// (second char not hex) would parse just "4", report success, and the
+		// caller's fixed pos += 2 would still skip both chars -- silently
+		// dropping the literal 'Z' instead of emitting it. Require BOTH chars
+		// to be hex before consuming either.
+		auto hexVal = [](char c) -> int
+		{
+			if (c >= '0' && c <= '9') return c - '0';
+			if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+			if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+			return -1;
+		};
+		std::string ret;
+		ret.reserve(src.size());
+		for (size_t pos = 0; pos < src.size(); ++pos)
+		{
+			if (src[pos] == '%' && pos + 2 < src.size())
+			{
+				int hi = hexVal(src[pos + 1]);
+				int lo = hexVal(src[pos + 2]);
+				if (hi >= 0 && lo >= 0)
+				{
+					ret += static_cast<char>((hi << 4) | lo);
+					pos += 2;
+					continue;
+				}
+			}
+			ret += src[pos];
+		}
+		return ret;
+	}
 }
 
 #endif

--- a/tests/AttendedTransfer_test.cpp
+++ b/tests/AttendedTransfer_test.cpp
@@ -1,0 +1,686 @@
+// AttendedTransfer_test.cpp — Issue #131 regression coverage.
+//
+// RequestsHandler::onRefer() splices two live P2P sessions (A-B, the REFER's
+// own dialog, and A-C, the consult session named by a ?Replaces= URI param on
+// the Refer-To) into one B-C call: cross re-INVITEs carry each leg's SDP to
+// the other, A is BYE'd out of both dialogs, and the two sessions are linked
+// as a transfer bridge so a later BYE from either B or C relays to the other
+// (RequestsHandler::onBye's isTransferBridge() branch) instead of reaching A.
+//
+// This is a port of drawbridge's e594914 ("Phase C-2 — attended transfer via
+// REFER + Replaces"), adapted for pocket-dial's #101A pool-refusal discipline
+// (every pool draw here is null-checked, and the whole splice draws all of its
+// wire-critical messages before mutating any session state or sending
+// anything) and the fact pocket-dial has no SIP-trunk/anchor concept on
+// Session to guard against.
+//
+// Drives a real RequestsHandler through handle() end-to-end (mirroring
+// BlindTransfer_test.cpp's pattern): register three extensions, A calls B and
+// answers, A calls C (consult) and answers, then A sends REFER with Replaces
+// naming the A-C dialog.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "RequestsHandler.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <WinSock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	sockaddr_in addrFor(const std::string& ip, uint16_t port = 5060)
+	{
+		sockaddr_in a{};
+		a.sin_family = AF_INET;
+		a.sin_addr.s_addr = inet_addr(ip.c_str());
+		a.sin_port = htons(port);
+		return a;
+	}
+
+	std::shared_ptr<SipMessage> makeRegister(const std::string& ext, const std::string& ip,
+	                                          const std::string& callId)
+	{
+		std::string raw =
+			"REGISTER sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + ip + ":5060;branch=z9hG4bKr" + callId + "\r\n"
+			"From: <sip:" + ext + "@server>;tag=rt" + callId + "\r\n"
+			"To: <sip:" + ext + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 REGISTER\r\n"
+			"Contact: <sip:" + ext + "@" + ip + ":5060>;expires=3600\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, addrFor(ip));
+	}
+
+	std::string sdpBody(const std::string& mediaIp, int port)
+	{
+		return
+			"v=0\r\n"
+			"o=- 0 0 IN IP4 " + mediaIp + "\r\n"
+			"s=-\r\n"
+			"c=IN IP4 " + mediaIp + "\r\n"
+			"t=0 0\r\n"
+			"m=audio " + std::to_string(port) + " RTP/AVP 0\r\n"
+			"a=rtpmap:0 PCMU/8000\r\n";
+	}
+
+	std::string findSentTo(const std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                       const sockaddr_in& addr, const std::string& needle)
+	{
+		for (auto it = sent.rbegin(); it != sent.rend(); ++it)
+		{
+			if (it->first.sin_addr.s_addr != addr.sin_addr.s_addr) continue;
+			if (it->first.sin_port != addr.sin_port) continue;
+			if (!it->second) continue;
+			std::string raw = it->second->toString();
+			if (raw.find(needle) != std::string::npos) return raw;
+		}
+		return {};
+	}
+
+	size_t countContaining(const std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                       const sockaddr_in& addr, const std::string& needle)
+	{
+		size_t n = 0;
+		for (const auto& [a, msg] : sent)
+		{
+			if (a.sin_addr.s_addr != addr.sin_addr.s_addr || a.sin_port != addr.sin_port) continue;
+			if (msg && msg->toString().find(needle) != std::string::npos) ++n;
+		}
+		return n;
+	}
+
+	// Like findSentTo, but requires BOTH needles -- needed once the transferor's
+	// two splice BYEs (one per leg) share the same request-line target (A's own
+	// number) and are distinguishable only by which leg's Call-ID they carry.
+	std::string findSentToBoth(const std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                           const sockaddr_in& addr, const std::string& needle1, const std::string& needle2)
+	{
+		for (auto it = sent.rbegin(); it != sent.rend(); ++it)
+		{
+			if (it->first.sin_addr.s_addr != addr.sin_addr.s_addr) continue;
+			if (it->first.sin_port != addr.sin_port) continue;
+			if (!it->second) continue;
+			std::string raw = it->second->toString();
+			if (raw.find(needle1) != std::string::npos && raw.find(needle2) != std::string::npos) return raw;
+		}
+		return {};
+	}
+
+	std::string extractHeaderLine(const std::string& raw, const std::string& name)
+	{
+		size_t pos = 0;
+		while (pos < raw.size())
+		{
+			size_t eol = raw.find("\r\n", pos);
+			if (eol == std::string::npos) eol = raw.size();
+			std::string line = raw.substr(pos, eol - pos);
+			if (line.size() > name.size() &&
+				line.compare(0, name.size(), name) == 0)
+			{
+				return line;
+			}
+			pos = eol + 2;
+		}
+		return {};
+	}
+
+	// Test fixture: registers A/B/C, places A-B and A-C direct calls, answers
+	// both, and returns everything a scenario needs to send the REFER.
+	struct Rig
+	{
+		std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+		std::unique_ptr<RequestsHandler> handler;
+		sockaddr_in aAddr, bAddr, cAddr;
+		std::string abCallId, acCallId;
+	};
+
+	// Takes `rig` by reference and fills it in place, rather than constructing a
+	// local Rig and returning it by value: the handler's send-callback lambda
+	// captures &rig, so rig must never move/relocate after construction — a
+	// by-value return would risk exactly that (NRVO is compiler best-effort in
+	// this shape, not guaranteed the way a prvalue return is).
+	void setUpSplicedCalls(Rig& rig)
+	{
+		rig.aAddr = addrFor("192.168.40.10");
+		rig.bAddr = addrFor("192.168.40.20");
+		rig.cAddr = addrFor("192.168.40.30");
+		rig.abCallId = "attxfer-ab";
+		rig.acCallId = "attxfer-ac";
+
+		rig.handler = std::make_unique<RequestsHandler>("192.168.40.1", 5060,
+			[&rig](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+				rig.sent.emplace_back(addr, std::move(msg));
+			});
+		auto& handler = *rig.handler;
+		auto& sent = rig.sent;
+
+		handler.handle(makeRegister("100", "192.168.40.10", "reg-100c"));
+		handler.handle(makeRegister("106", "192.168.40.20", "reg-106c"));
+		handler.handle(makeRegister("107", "192.168.40.30", "reg-107c"));
+
+		// A calls B, B answers.
+		{
+			std::string body = sdpBody("192.168.40.10", 10000);
+			std::string raw =
+				"INVITE sip:106@server SIP/2.0\r\n"
+				"Via: SIP/2.0/UDP 192.168.40.10:5060;branch=z9hG4bKab\r\n"
+				"From: <sip:100@server>;tag=abtag\r\n"
+				"To: <sip:106@server>\r\n"
+				"Call-ID: " + rig.abCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Max-Forwards: 70\r\n"
+				"Contact: <sip:100@192.168.40.10:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+		}
+		std::string forkToB = findSentTo(sent, rig.bAddr, "INVITE sip:106@");
+		{
+			std::string fromLine = extractHeaderLine(forkToB, "From:");
+			std::string via = extractHeaderLine(forkToB, "Via:");
+			std::string body = sdpBody("192.168.40.20", 20000);
+			std::string raw =
+				"SIP/2.0 200 OK\r\n" + via + "\r\n" + fromLine + "\r\n"
+				"To: <sip:106@server>;tag=btag\r\n"
+				"Call-ID: " + rig.abCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Contact: <sip:106@192.168.40.20:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.bAddr));
+		}
+
+		// A calls C (consult), C answers. Same From tag reused is fine — different
+		// Call-ID makes it a distinct dialog.
+		{
+			std::string body = sdpBody("192.168.40.10", 10002);
+			std::string raw =
+				"INVITE sip:107@server SIP/2.0\r\n"
+				"Via: SIP/2.0/UDP 192.168.40.10:5060;branch=z9hG4bKac\r\n"
+				"From: <sip:100@server>;tag=actag\r\n"
+				"To: <sip:107@server>\r\n"
+				"Call-ID: " + rig.acCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Max-Forwards: 70\r\n"
+				"Contact: <sip:100@192.168.40.10:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+		}
+		std::string forkToC = findSentTo(sent, rig.cAddr, "INVITE sip:107@");
+		{
+			std::string fromLine = extractHeaderLine(forkToC, "From:");
+			std::string via = extractHeaderLine(forkToC, "Via:");
+			std::string body = sdpBody("192.168.40.30", 30000);
+			std::string raw =
+				"SIP/2.0 200 OK\r\n" + via + "\r\n" + fromLine + "\r\n"
+				"To: <sip:107@server>;tag=ctag\r\n"
+				"Call-ID: " + rig.acCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Contact: <sip:107@192.168.40.30:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.cAddr));
+		}
+
+		sent.clear(); // scenarios only care about traffic from the REFER onward
+	}
+
+	// Sends A's REFER on the A-B dialog with Refer-To: 107, Replaces=<A-C
+	// call-id>;from-tag=actag;to-tag=ctag — percent-encoded exactly like
+	// office_smoke.py's construction (Replaces=%3Bfrom-tag%3D...%3Bto-tag%3D...).
+	void sendAttendedRefer(Rig& rig)
+	{
+		std::string raw =
+			"REFER sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.40.10:5060;branch=z9hG4bKref\r\n"
+			"From: <sip:100@server>;tag=abtag\r\n"
+			"To: <sip:106@server>;tag=btag\r\n"
+			"Call-ID: " + rig.abCallId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server?Replaces=" + rig.acCallId +
+				"%3Bfrom-tag%3Dactag%3Bto-tag%3Dctag>\r\n"
+			"Contact: <sip:100@192.168.40.10:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		rig.handler->handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+	}
+
+	// Adversarial-review regression (issue #131 follow-up): "the receptionist
+	// case" -- B calls A first (A is the AB dialog's CALLEE, not its caller),
+	// then A calls C to consult. Before the orientation fix, onRefer() assumed
+	// A was always the caller of both dialogs, so bClient/bSdp resolved to A's
+	// OWN identity/SDP instead of B's whenever A was actually the callee.
+	void setUpSplicedCallsReceptionist(Rig& rig)
+	{
+		rig.aAddr = addrFor("192.168.40.10");
+		rig.bAddr = addrFor("192.168.40.20");
+		rig.cAddr = addrFor("192.168.40.30");
+		rig.abCallId = "attxfer-ab-recept";
+		rig.acCallId = "attxfer-ac-recept";
+
+		rig.handler = std::make_unique<RequestsHandler>("192.168.40.1", 5060,
+			[&rig](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+				rig.sent.emplace_back(addr, std::move(msg));
+			});
+		auto& handler = *rig.handler;
+		auto& sent = rig.sent;
+
+		handler.handle(makeRegister("100", "192.168.40.10", "reg-100r"));
+		handler.handle(makeRegister("106", "192.168.40.20", "reg-106r"));
+		handler.handle(makeRegister("107", "192.168.40.30", "reg-107r"));
+
+		// B calls A: src=B, dest=A in the AB dialog (opposite of the base rig).
+		{
+			std::string body = sdpBody("192.168.40.20", 21000);
+			std::string raw =
+				"INVITE sip:100@server SIP/2.0\r\n"
+				"Via: SIP/2.0/UDP 192.168.40.20:5060;branch=z9hG4bKrab\r\n"
+				"From: <sip:106@server>;tag=rbatag\r\n"
+				"To: <sip:100@server>\r\n"
+				"Call-ID: " + rig.abCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Max-Forwards: 70\r\n"
+				"Contact: <sip:106@192.168.40.20:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.bAddr));
+		}
+		std::string forkToA = findSentTo(sent, rig.aAddr, "INVITE sip:100@");
+		{
+			std::string fromLine = extractHeaderLine(forkToA, "From:");
+			std::string via = extractHeaderLine(forkToA, "Via:");
+			std::string body = sdpBody("192.168.40.10", 11000);
+			std::string raw =
+				"SIP/2.0 200 OK\r\n" + via + "\r\n" + fromLine + "\r\n"
+				"To: <sip:100@server>;tag=raatag\r\n"
+				"Call-ID: " + rig.abCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Contact: <sip:100@192.168.40.10:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+		}
+
+		// A calls C to consult -- same orientation as the base rig for this leg.
+		{
+			std::string body = sdpBody("192.168.40.10", 11002);
+			std::string raw =
+				"INVITE sip:107@server SIP/2.0\r\n"
+				"Via: SIP/2.0/UDP 192.168.40.10:5060;branch=z9hG4bKrac\r\n"
+				"From: <sip:100@server>;tag=ractag\r\n"
+				"To: <sip:107@server>\r\n"
+				"Call-ID: " + rig.acCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Max-Forwards: 70\r\n"
+				"Contact: <sip:100@192.168.40.10:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+		}
+		std::string forkToC = findSentTo(sent, rig.cAddr, "INVITE sip:107@");
+		{
+			std::string fromLine = extractHeaderLine(forkToC, "From:");
+			std::string via = extractHeaderLine(forkToC, "Via:");
+			std::string body = sdpBody("192.168.40.30", 31000);
+			std::string raw =
+				"SIP/2.0 200 OK\r\n" + via + "\r\n" + fromLine + "\r\n"
+				"To: <sip:107@server>;tag=rctag\r\n"
+				"Call-ID: " + rig.acCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Contact: <sip:107@192.168.40.30:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.cAddr));
+		}
+
+		sent.clear();
+	}
+
+	// A originates the REFER within the AB dialog where A is the CALLEE: A's own
+	// tag is the To-tag from the original INVITE (raatag), B's is the From-tag
+	// (rbatag) -- the REFER's own From/To must swap to match, since a request's
+	// From is always the SENDER's own tag, not "whoever was the original caller."
+	void sendAttendedReferReceptionist(Rig& rig)
+	{
+		std::string raw =
+			"REFER sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.40.10:5060;branch=z9hG4bKrrefer\r\n"
+			"From: <sip:100@server>;tag=raatag\r\n"
+			"To: <sip:106@server>;tag=rbatag\r\n"
+			"Call-ID: " + rig.abCallId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server?Replaces=" + rig.acCallId +
+				"%3Bfrom-tag%3Dractag%3Bto-tag%3Drctag>\r\n"
+			"Contact: <sip:100@192.168.40.10:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		rig.handler->handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+	}
+
+	// Both legs inverted: B calls A AND C calls A. Exercises the
+	// getInviteMessage()->getBody() SDP fallback on BOTH sides of the splice at
+	// once (getRemoteSdp() would silently return A's own answer on either leg
+	// if the orientation fix didn't cover both dialogs independently).
+	void setUpSplicedCallsBothLegsCallee(Rig& rig)
+	{
+		rig.aAddr = addrFor("192.168.40.10");
+		rig.bAddr = addrFor("192.168.40.20");
+		rig.cAddr = addrFor("192.168.40.30");
+		rig.abCallId = "attxfer-ab-bothcallee";
+		rig.acCallId = "attxfer-ac-bothcallee";
+
+		rig.handler = std::make_unique<RequestsHandler>("192.168.40.1", 5060,
+			[&rig](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+				rig.sent.emplace_back(addr, std::move(msg));
+			});
+		auto& handler = *rig.handler;
+		auto& sent = rig.sent;
+
+		handler.handle(makeRegister("100", "192.168.40.10", "reg-100bc"));
+		handler.handle(makeRegister("106", "192.168.40.20", "reg-106bc"));
+		handler.handle(makeRegister("107", "192.168.40.30", "reg-107bc"));
+
+		// B calls A.
+		{
+			std::string body = sdpBody("192.168.40.20", 22000);
+			std::string raw =
+				"INVITE sip:100@server SIP/2.0\r\n"
+				"Via: SIP/2.0/UDP 192.168.40.20:5060;branch=z9hG4bKbcab\r\n"
+				"From: <sip:106@server>;tag=bcbatag\r\n"
+				"To: <sip:100@server>\r\n"
+				"Call-ID: " + rig.abCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Max-Forwards: 70\r\n"
+				"Contact: <sip:106@192.168.40.20:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.bAddr));
+		}
+		std::string forkToA1 = findSentTo(sent, rig.aAddr, "INVITE sip:100@");
+		{
+			std::string fromLine = extractHeaderLine(forkToA1, "From:");
+			std::string via = extractHeaderLine(forkToA1, "Via:");
+			std::string body = sdpBody("192.168.40.10", 12000);
+			std::string raw =
+				"SIP/2.0 200 OK\r\n" + via + "\r\n" + fromLine + "\r\n"
+				"To: <sip:100@server>;tag=bcaatag\r\n"
+				"Call-ID: " + rig.abCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Contact: <sip:100@192.168.40.10:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+		}
+
+		// C calls A (a second inbound call, arriving while A is already on with
+		// B -- serves as the "consult" leg for this test even though a real
+		// phone would normally hold B and originate the consult itself).
+		{
+			std::string body = sdpBody("192.168.40.30", 33000);
+			std::string raw =
+				"INVITE sip:100@server SIP/2.0\r\n"
+				"Via: SIP/2.0/UDP 192.168.40.30:5060;branch=z9hG4bKbcac\r\n"
+				"From: <sip:107@server>;tag=bccatag\r\n"
+				"To: <sip:100@server>\r\n"
+				"Call-ID: " + rig.acCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Max-Forwards: 70\r\n"
+				"Contact: <sip:107@192.168.40.30:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.cAddr));
+		}
+		std::string forkToA2 = findSentToBoth(sent, rig.aAddr, "INVITE sip:100@", "Call-ID: " + rig.acCallId);
+		{
+			std::string fromLine = extractHeaderLine(forkToA2, "From:");
+			std::string via = extractHeaderLine(forkToA2, "Via:");
+			std::string body = sdpBody("192.168.40.10", 12002);
+			std::string raw =
+				"SIP/2.0 200 OK\r\n" + via + "\r\n" + fromLine + "\r\n"
+				"To: <sip:100@server>;tag=bcaatag2\r\n"
+				"Call-ID: " + rig.acCallId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Contact: <sip:100@192.168.40.10:5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+		}
+
+		sent.clear();
+	}
+
+	// A originates the REFER within the AB dialog (A is callee: From carries
+	// A's own tag bcaatag, To carries B's tag bcbatag) naming the AC dialog
+	// (also A-as-callee) via Replaces.
+	void sendAttendedReferBothLegsCallee(Rig& rig)
+	{
+		std::string raw =
+			"REFER sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.40.10:5060;branch=z9hG4bKbcrefer\r\n"
+			"From: <sip:100@server>;tag=bcaatag\r\n"
+			"To: <sip:106@server>;tag=bcbatag\r\n"
+			"Call-ID: " + rig.abCallId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server?Replaces=" + rig.acCallId +
+				"%3Bfrom-tag%3Dbccatag%3Bto-tag%3Dbcaatag2>\r\n"
+			"Contact: <sip:100@192.168.40.10:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		rig.handler->handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+	}
+}
+
+// (a) 202 to A, plus a cross re-INVITE to each leg carrying the OTHER leg's SDP.
+TEST(AttendedTransfer, SpliceSendsAcceptedAndCrossedReinvites)
+{
+	Rig rig;
+	setUpSplicedCalls(rig);
+	sendAttendedRefer(rig);
+
+	EXPECT_FALSE(findSentTo(rig.sent, rig.aAddr, "SIP/2.0 202 Accepted").empty())
+		<< "REFER must be accepted";
+
+	std::string invToB = findSentTo(rig.sent, rig.bAddr, "CSeq: 100 INVITE");
+	ASSERT_FALSE(invToB.empty()) << "B must get the splice re-INVITE";
+	EXPECT_NE(invToB.find("Call-ID: " + rig.abCallId), std::string::npos) << invToB;
+	EXPECT_NE(invToB.find("c=IN IP4 192.168.40.30"), std::string::npos)
+		<< "B's re-INVITE must carry C's SDP:\n" << invToB;
+
+	std::string invToC = findSentTo(rig.sent, rig.cAddr, "CSeq: 100 INVITE");
+	ASSERT_FALSE(invToC.empty()) << "C must get the splice re-INVITE";
+	EXPECT_NE(invToC.find("Call-ID: " + rig.acCallId), std::string::npos) << invToC;
+	EXPECT_NE(invToC.find("c=IN IP4 192.168.40.20"), std::string::npos)
+		<< "C's re-INVITE must carry B's SDP:\n" << invToC;
+}
+
+// (b) B's 200 OK to the splice re-INVITE gets ACKed and does NOT reach A —
+// handleTransferOk() must intercept it before the generic onOk() relay.
+TEST(AttendedTransfer, SpliceReinviteOkIsAckedNotRelayedToA)
+{
+	Rig rig;
+	setUpSplicedCalls(rig);
+	sendAttendedRefer(rig);
+
+	std::string invToB = findSentTo(rig.sent, rig.bAddr, "CSeq: 100 INVITE");
+	ASSERT_FALSE(invToB.empty());
+	std::string fromLine = extractHeaderLine(invToB, "From:");
+	std::string toLine = extractHeaderLine(invToB, "To:");
+	std::string via = extractHeaderLine(invToB, "Via:");
+
+	rig.sent.clear();
+	{
+		std::string body = sdpBody("192.168.40.20", 20001);
+		std::string raw =
+			"SIP/2.0 200 OK\r\n" + via + "\r\n" + fromLine + "\r\n" + toLine + "\r\n"
+			"Call-ID: " + rig.abCallId + "\r\n"
+			"CSeq: 100 INVITE\r\n"
+			"Contact: <sip:106@192.168.40.20:5060>\r\n"
+			"Content-Type: application/sdp\r\n"
+			"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+		rig.handler->handle(RequestsHandler::getMessageFromPool(raw, rig.bAddr));
+	}
+
+	EXPECT_FALSE(findSentTo(rig.sent, rig.bAddr, "ACK sip:").empty())
+		<< "B's splice-reinvite 200 OK must be ACKed";
+	EXPECT_EQ(countContaining(rig.sent, rig.aAddr, ""), 0u)
+		<< "nothing should be sent to A once the splice has completed";
+}
+
+// (c) B hangs up -> C gets a correctly-tagged BYE; A gets nothing (A is gone).
+TEST(AttendedTransfer, PostSpliceByeFromOneLegRelaysToTheOtherNotToA)
+{
+	Rig rig;
+	setUpSplicedCalls(rig);
+	sendAttendedRefer(rig);
+	rig.sent.clear();
+
+	{
+		std::string raw =
+			"BYE sip:100@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.40.20:5060;branch=z9hG4bKbye\r\n"
+			"From: <sip:106@server>;tag=btag\r\n"
+			"To: <sip:100@server>;tag=abtag\r\n"
+			"Call-ID: " + rig.abCallId + "\r\n"
+			"CSeq: 2 BYE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Content-Length: 0\r\n\r\n";
+		rig.handler->handle(RequestsHandler::getMessageFromPool(raw, rig.bAddr));
+	}
+
+	EXPECT_FALSE(findSentTo(rig.sent, rig.bAddr, "SIP/2.0 200 OK").empty())
+		<< "B's own BYE must be 200 OK'd";
+
+	std::string byeToC = findSentTo(rig.sent, rig.cAddr, "BYE sip:");
+	ASSERT_FALSE(byeToC.empty()) << "C must receive a relayed BYE";
+	EXPECT_NE(byeToC.find("Call-ID: " + rig.acCallId), std::string::npos) << byeToC;
+	// Impersonates A: From carries A's tag in the AC dialog, To carries C's tag.
+	EXPECT_NE(extractHeaderLine(byeToC, "From:").find("tag=actag"), std::string::npos) << byeToC;
+	EXPECT_NE(extractHeaderLine(byeToC, "To:").find("tag=ctag"), std::string::npos) << byeToC;
+
+	EXPECT_EQ(countContaining(rig.sent, rig.aAddr, ""), 0u)
+		<< "A is already dropped and must receive nothing for this teardown";
+}
+
+// (d) Replaces naming a Call-ID that doesn't exist -> 603, both original calls
+// untouched (no BYE to anyone, no re-INVITEs).
+TEST(AttendedTransfer, UnknownReplacesCallIdDeclines603LeavingBothCallsUp)
+{
+	Rig rig;
+	setUpSplicedCalls(rig);
+
+	std::string raw =
+		"REFER sip:106@server SIP/2.0\r\n"
+		"Via: SIP/2.0/UDP 192.168.40.10:5060;branch=z9hG4bKrefbad\r\n"
+		"From: <sip:100@server>;tag=abtag\r\n"
+		"To: <sip:106@server>;tag=btag\r\n"
+		"Call-ID: " + rig.abCallId + "\r\n"
+		"CSeq: 2 REFER\r\n"
+		"Max-Forwards: 70\r\n"
+		"Refer-To: <sip:107@server?Replaces=no-such-call-id%40nowhere>\r\n"
+		"Contact: <sip:100@192.168.40.10:5060>\r\n"
+		"Content-Length: 0\r\n\r\n";
+	rig.handler->handle(RequestsHandler::getMessageFromPool(raw, rig.aAddr));
+
+	EXPECT_FALSE(findSentTo(rig.sent, rig.aAddr, "SIP/2.0 603 Decline").empty())
+		<< "an unresolvable Replaces target must decline, not silently do nothing";
+	EXPECT_TRUE(findSentTo(rig.sent, rig.bAddr, "BYE sip:").empty())
+		<< "B must not be torn down for a splice that never happened";
+	EXPECT_TRUE(findSentTo(rig.sent, rig.cAddr, "BYE sip:").empty())
+		<< "C must not be torn down for a splice that never happened";
+
+	auto ab = rig.handler->getSession("Call-ID: " + rig.abCallId);
+	auto ac = rig.handler->getSession("Call-ID: " + rig.acCallId);
+	ASSERT_TRUE(ab.has_value());
+	ASSERT_TRUE(ac.has_value());
+	EXPECT_EQ(ab.value()->getState(), Session::State::Connected);
+	EXPECT_EQ(ac.value()->getState(), Session::State::Connected);
+}
+
+// (e) The receptionist case, found by adversarial review of this feature: B
+// called A first (A is the AB dialog's CALLEE, not its caller), then A called
+// C to consult. Before the orientation fix, onRefer() unconditionally treated
+// A as the caller of both dialogs -- bClient/bSdp would resolve to A's OWN
+// identity/SDP instead of B's, corrupting the splice instead of declining it.
+TEST(AttendedTransfer, SpliceHandlesReceptionistOrientationBCalledAThenAConsultedC)
+{
+	Rig rig;
+	setUpSplicedCallsReceptionist(rig);
+	sendAttendedReferReceptionist(rig);
+
+	EXPECT_FALSE(findSentTo(rig.sent, rig.aAddr, "SIP/2.0 202 Accepted").empty())
+		<< "REFER must be accepted";
+
+	std::string invToB = findSentTo(rig.sent, rig.bAddr, "CSeq: 100 INVITE");
+	ASSERT_FALSE(invToB.empty()) << "B must get the splice re-INVITE, addressed to B not A";
+	EXPECT_NE(invToB.find("INVITE sip:106@"), std::string::npos)
+		<< "must be addressed to B's own extension, not A's:\n" << invToB;
+	EXPECT_NE(invToB.find("c=IN IP4 192.168.40.30"), std::string::npos)
+		<< "B's re-INVITE must carry C's real SDP, not A's own answer:\n" << invToB;
+	EXPECT_NE(extractHeaderLine(invToB, "To:").find("tag=rbatag"), std::string::npos)
+		<< "must carry B's own dialog tag as To, not A's:\n" << invToB;
+
+	std::string invToC = findSentTo(rig.sent, rig.cAddr, "CSeq: 100 INVITE");
+	ASSERT_FALSE(invToC.empty()) << "C must get the splice re-INVITE";
+	EXPECT_NE(invToC.find("c=IN IP4 192.168.40.20"), std::string::npos)
+		<< "C's re-INVITE must carry B's real SDP, not A's own answer:\n" << invToC;
+
+	// BYE-to-A on the AB leg must impersonate B: From carries B's tag, To
+	// carries A's tag -- the swapped orientation vs. the base A-as-caller case.
+	std::string byeToAOnAB = findSentToBoth(rig.sent, rig.aAddr, "BYE sip:", "Call-ID: " + rig.abCallId);
+	ASSERT_FALSE(byeToAOnAB.empty()) << "A must be dropped from the AB dialog";
+	EXPECT_NE(extractHeaderLine(byeToAOnAB, "From:").find("tag=rbatag"), std::string::npos) << byeToAOnAB;
+	EXPECT_NE(extractHeaderLine(byeToAOnAB, "To:").find("tag=raatag"), std::string::npos) << byeToAOnAB;
+
+	// And a post-splice BYE from B must relay to C, not to the already-dropped A.
+	rig.sent.clear();
+	{
+		std::string raw =
+			"BYE sip:100@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.40.20:5060;branch=z9hG4bKrbye\r\n"
+			"From: <sip:106@server>;tag=rbatag\r\n"
+			"To: <sip:100@server>;tag=raatag\r\n"
+			"Call-ID: " + rig.abCallId + "\r\n"
+			"CSeq: 2 BYE\r\n"
+			"Max-Forwards: 70\r\n"
+			"Content-Length: 0\r\n\r\n";
+		rig.handler->handle(RequestsHandler::getMessageFromPool(raw, rig.bAddr));
+	}
+	std::string byeToC = findSentTo(rig.sent, rig.cAddr, "BYE sip:");
+	ASSERT_FALSE(byeToC.empty()) << "C must receive a relayed BYE, not A";
+	EXPECT_EQ(countContaining(rig.sent, rig.aAddr, ""), 0u)
+		<< "A is already dropped and must receive nothing for this teardown";
+}
+
+// (f) Both legs A-as-callee: B called A AND C called A. Exercises the SDP
+// fallback (getInviteMessage()->getBody() instead of getRemoteSdp()) on BOTH
+// sides of the splice independently -- a bug that only got one leg right
+// would still pass test (e) above (which inverts only the AB leg) but fail
+// here.
+TEST(AttendedTransfer, SpliceHandlesBothLegsAAsCallee)
+{
+	Rig rig;
+	setUpSplicedCallsBothLegsCallee(rig);
+	sendAttendedReferBothLegsCallee(rig);
+
+	EXPECT_FALSE(findSentTo(rig.sent, rig.aAddr, "SIP/2.0 202 Accepted").empty())
+		<< "REFER must be accepted";
+
+	std::string invToB = findSentTo(rig.sent, rig.bAddr, "CSeq: 100 INVITE");
+	ASSERT_FALSE(invToB.empty()) << "B must get the splice re-INVITE";
+	EXPECT_NE(invToB.find("c=IN IP4 192.168.40.30"), std::string::npos)
+		<< "B's re-INVITE must carry C's real (offered) SDP, not A's own answer:\n" << invToB;
+
+	std::string invToC = findSentTo(rig.sent, rig.cAddr, "CSeq: 100 INVITE");
+	ASSERT_FALSE(invToC.empty()) << "C must get the splice re-INVITE";
+	EXPECT_NE(invToC.find("c=IN IP4 192.168.40.20"), std::string::npos)
+		<< "C's re-INVITE must carry B's real (offered) SDP, not A's own answer:\n" << invToC;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,14 @@ add_executable(sip_parser_tests
     # gets a BYE for the dialog it was on (not just that the target gets an
     # INVITE).
     BlindTransfer_test.cpp
+    # Issue #131: attended transfer (REFER + Replaces, RFC 3891), ported from
+    # drawbridge. Splices two live P2P sessions via cross re-INVITEs carrying
+    # swapped SDP, then drops the transferor. Drives two direct calls through
+    # connect, then the splice, and asserts the crossed SDP, the splice
+    # re-INVITE's OK never reaching the dropped transferor, the post-splice
+    # BYE relay between the two remaining legs, and the 603-decline path for
+    # an unresolvable Replaces target.
+    AttendedTransfer_test.cpp
     # Issue #69: the bounded pattern -> action dial plan that generalizes the
     # ring-group mechanism. Pure grammar/precedence/cap coverage against
     # DialPlan.hpp, end-to-end routing (dispatch + fallthrough) driven through

--- a/tests/ConferenceRoom_test.cpp
+++ b/tests/ConferenceRoom_test.cpp
@@ -18,10 +18,15 @@
 //      answered 200 OK with a sendrecv SDP and land on one room; a BYE from one leaves
 //      the others mixing.
 //
-// On host RtpReceiver/RtpSender::start() are no-op stubs that store the callback and
-// never invoke it, so the media callbacks are driven directly through the named
-// MediaBridge::onHandsetRtp / fillHandsetTx members they are wired to — the same code
-// the sockets run on device.
+// On host RtpReceiver::start() is a no-op stub, so RX is always driven directly through
+// MediaBridge::onHandsetRtp. RtpSender is NOT inert on a Linux host: RtpSender.cpp's
+// "Linux desktop" branch (Issue #82) spawns a real std::thread the moment startBridge()
+// succeeds, and that thread calls the same fillHandsetTx provider on its own 20 ms pacer
+// — racing any test that also calls fillHandsetTx (or reads getPlayoutBuffer()) directly
+// after startBridge(). A test that wants deterministic, synchronous control over TX must
+// stop the RtpSender it passed to init() right after startBridge() returns (the bridge
+// itself, and the bus port, stay live — only the background pacer thread is halted) before
+// driving fillHandsetTx by hand. See AnchorModeIsUnchangedByTheBusRewiring below.
 
 #include <gtest/gtest.h>
 
@@ -425,6 +430,11 @@ TEST(ConferenceRoom, AnchorModeIsUnchangedByTheBusRewiring)
 	bridge.init(&rx, &tx, &anchor);   // no bus argument at all
 	ASSERT_TRUE(bridge.startBridge("127.0.0.1", 16003, "call-x", "part-1"));
 	EXPECT_EQ(bridge.busPort(), -1);
+
+	// Halt RtpSender's own background pacer thread (Linux host only — see the file
+	// header comment) before driving the playout buffer by hand below, so its
+	// unrelated 20 ms fillHandsetTx tick can't race and drain what this test writes.
+	ASSERT_TRUE(tx.stop("call-x"));
 
 	const int16_t in[] = {111, 222, 333};
 	EXPECT_TRUE(bridge.feedRx("part-1", in, 3));


### PR DESCRIPTION
## Summary

Ports drawbridge's `e594914` ("Phase C-2 — attended transfer via REFER + Replaces") to
pocket-dial. A transferor (A) with two active P2P calls — A-B and a consult call A-C — sends
REFER on the A-B dialog with a `Replaces` URI parameter naming the A-C dialog (RFC 3891).
`onRefer()` now splices B and C together directly: cross re-INVITEs carry each leg's SDP to
the other, A is BYE'd out of both dialogs, and the two sessions are linked as a transfer
bridge so a later BYE from either B or C relays to the other instead of reaching the departed
A. The splice's own re-INVITE 200 OKs are intercepted and ACKed directly
(`handleTransferOk()`, called from `onOk()` before the generic session lookup) so they never
reach the generic relay, which would otherwise forward them toward A.

Most of the supporting `Session` scaffolding (`_remoteSdp`/`getRemoteSdp`, `_isTransferBridge`)
was already present as unused fields from an earlier partial port — this wires it up rather
than adding it from scratch.

**Also included**: a fix for a pre-existing `ConferenceRoom` test race, found while adding
this feature's own test file (see below) — tracked separately at #135, its own commit
(`fa5f041`) on this branch.

## A bug adversarial review caught before this landed

The initial port validated that A could be either src or dest of each dialog, but the
extraction that followed unconditionally assumed A was the caller — so a "receptionist"
transfer (B calls A, A consults C) would corrupt the splice (target A's own identity/SDP
instead of B's) rather than being declined. Fixed by deriving the other party's client, SDP,
and dialog-header From/To orientation independently per leg from which side A actually is;
`getRemoteSdp()` is always "the callee's SDP", so when A is the callee the caller's SDP is
read from the stored INVITE message body instead. `Session` gained `wasTransferorSrc()`
(mirroring the existing `isParkUac()` pattern) so `onBye()`'s transfer-bridge relay can find
the right peer and header orientation once A's identity is otherwise unrecoverable.

Also caught: `siphdr::urlDecode` silently dropped a character on a malformed `%XY` escape
(sscanf's greedy hex match consumed a non-hex second char as if part of the escape); a
`Replaces` value that decodes to something containing a control character is now declined
(603) rather than silently falling through to a blind transfer.

## Test plan

- [x] `tests/AttendedTransfer_test.cpp` (new, 6 tests): splice sends 202 + crossed re-INVITEs,
      re-INVITE-OK intercepted not relayed to A, post-splice BYE relays correctly, unknown
      `Replaces` declines 603 leaving both calls up, and **two orientation regressions** found
      by adversarial review — B-calls-A-then-A-consults-C, and both legs A-as-callee — that the
      initial port got backwards.
- [x] Full host suite: 318/318, 3 consecutive runs, only the pre-existing
      `ConferenceRoom.ThreeLegsEachHearTheOthersMinusThemselves` excluded (tracked at #135,
      unrelated root cause).
- [x] `.smoke/office_smoke.py`: 11/11 scenarios, including its own attended-transfer scenario
      (A-as-caller only — the orientation bug above wasn't visible to it).
- [x] `tests/tools/check_parser_callgraph.py`: clean, no cycles, no dynamic frames.
- [x] Firmware compile (`idf.py -B <scratch> -D SIP_TRANSPORT=eth build`): succeeds. Not
      bench-tested — no hardware access in this session.
- [x] Adversarial verify across 4 lenses (pool-refusal-contract, bridged-dialog-contract,
      bounds-and-validation, port-fidelity vs. drawbridge `e594914`), plus a targeted re-verify
      of bridged-dialog-contract after the orientation fix. All clean.

## Known gaps, not fixed here

- #133: `onRefer` has no source-authorization check (same as blind transfer, #128).
- RFC 3891 §3's `from-tag`/`to-tag` MUST-match against the `Replaces` target dialog is not
  enforced (neither is it in drawbridge's own source) — the bare Call-ID is matched.
- A leg on HOLD at consult time isn't detected by the SDP/dialog-header presence check
  (documented in-code; the check can only tell "never captured" from "captured but stale").

## Base branch CI caveat

Same as #132/#134: this PR's base (`fix/issue-128-blind-transfer-teardown`) is not `main`, so
`ci.yml`'s `pull_request` trigger won't run automatically on it — CI will show green once the
stack (#129 → #130 → #132 → #134 → this) is merged in order, or can be run manually against
this branch in the meantime.

Fixes #131. Refs #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ3ToKh5jPcQKEFpGABAWH