### PR TITLE
sec(sip): gate REFER on the dialog's own source IPs (#133)

### DIFF
--- a/src/SIP/RequestsHandler.cpp
+++ b/src/SIP/RequestsHandler.cpp
@@ -1982,6 +1982,43 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 
 	std::string callID(data->getCallID());
 
+	// Issue #133: reject an off-path forged transfer, the REFER analogue of #46's
+	// BYE guard. findClient() above only proves the From header names a REGISTERed
+	// extension — From is attacker-chosen, so on its own it lets any registered
+	// phone name someone else's Call-ID and tear that session down (blind path:
+	// endCall() + a BYE to the victim's peer) or splice it into another dialog
+	// (attended path). Same rule as onBye: an in-dialog REFER must arrive from one
+	// of the dialog's own leg IPs. isDialogSourceAuthorized() fails open on an
+	// unknown or half-set-up session, so a genuinely out-of-dialog REFER still
+	// falls through to the blind-transfer path exactly as before.
+	if (auto referred = getSession(callID); referred.has_value() &&
+		!isDialogSourceAuthorized(referred.value(), data->getSource()))
+	{
+		queueLog("REFER for Call-ID " + callID +
+			" rejected: source not a dialog leg (spoofed transfer)", true);
+		_registrar.sendForbidden(data, "Forbidden");
+		return;
+	}
+
+	// The consult dialog gets the same treatment. The attended block below only
+	// checks that the transferor's NUMBER is common to both dialogs — also a
+	// From-header claim — so without this a party legitimately on the A-B dialog
+	// could still name any unrelated call A happens to be in as ?Replaces= and
+	// splice A out of it. A real transferor is a leg of both dialogs and passes
+	// both checks; anyone else fails one.
+	if (!replacesCallIdBare.empty())
+	{
+		if (auto consult = getSession("Call-ID: " + replacesCallIdBare);
+			consult.has_value() &&
+			!isDialogSourceAuthorized(consult.value(), data->getSource()))
+		{
+			queueLog("REFER Replaces=" + replacesCallIdBare +
+				" rejected: source not a leg of the consult dialog (spoofed transfer)", true);
+			_registrar.sendForbidden(data, "Forbidden");
+			return;
+		}
+	}
+
 	// ── Attended transfer (RFC 3891 Replaces), issue #131 ─────────────────────────
 	// A (transferor) has two active calls: A-B (this REFER's own dialog, callID)
 	// and A-C (the consult session, replacesCallIdBare). Splice B<->C via cross
@@ -2019,9 +2056,10 @@ void RequestsHandler::onRefer(std::shared_ptr<SipMessage> data)
 				bool aIsDestAB = ab->getDest() && ab->getDest()->getNumber() == aNum;
 				aIsSrcAC = ac->getSrc() && ac->getSrc()->getNumber() == aNum;
 				bool aIsDestAC = ac->getDest() && ac->getDest()->getNumber() == aNum;
-				// Narrower than #133's general onRefer auth gap: A must be common to
-				// BOTH dialogs, or there is nothing coherent to splice. Stays regardless
-				// of how #133 is eventually resolved.
+				// A coherence check, not an auth check (#133's source gate above is
+				// the auth one): A must be common to BOTH dialogs, or there is nothing
+				// to splice. Kept even though the source gate now subsumes the
+				// spoofing case — it still catches an honest client's mismatched pair.
 				if (!(aIsSrcAB || aIsDestAB) || !(aIsSrcAC || aIsDestAC))
 				{
 					queueLog("REFER: attended transfer invariant violated (A not common to both dialogs)", true);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,12 @@ add_executable(sip_parser_tests
     # BYE relay between the two remaining legs, and the 603-decline path for
     # an unresolvable Replaces target.
     AttendedTransfer_test.cpp
+    # Issue #133: onRefer() admitted any REGISTERed From, never checking that the
+    # REFER's source was actually a leg of the Call-ID it named — onBye's #46
+    # guard with no counterpart. Covers the forged blind teardown, the forged
+    # ?Replaces= splice of a consult dialog the source is not on, and that a
+    # genuine in-dialog transfer still completes.
+    ReferSourceAuth_test.cpp
     # Issue #69: the bounded pattern -> action dial plan that generalizes the
     # ring-group mechanism. Pure grammar/precedence/cap coverage against
     # DialPlan.hpp, end-to-end routing (dispatch + fallthrough) driven through

--- a/tests/ReferSourceAuth_test.cpp
+++ b/tests/ReferSourceAuth_test.cpp
@@ -1,0 +1,350 @@
+// ReferSourceAuth_test.cpp — Issue #133 regression coverage.
+//
+// RequestsHandler::onBye() has issue #46's guard: a BYE for an established
+// two-party dialog must arrive from one of that dialog's own leg IPs, or it is
+// a forged teardown and gets 403. onRefer() had no equivalent. Its only
+// admission check was findClient(data->getFromNumber()) — which proves the
+// From header names a REGISTERed extension, nothing more. From is chosen by
+// the sender, so any registered phone could put someone else's Call-ID on a
+// REFER and:
+//
+//   * blind path — endCall() the victim's session and (since #128) send the
+//     victim's peer a BYE built from the attacker's own tags; or
+//   * attended path — name the victim's call as ?Replaces= and splice it.
+//
+// The attended path's own "A must be common to both dialogs" check is not a
+// substitute: it compares NUMBERS taken from the same attacker-chosen From.
+//
+// These drive a real RequestsHandler through handle() end-to-end (same shape
+// as BlindTransfer_test.cpp) and assert the forged REFER is refused 403 with
+// the victim's session and peer both left untouched, while the legitimate
+// in-dialog REFER from a real leg still works.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "RequestsHandler.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+#include <WinSock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace
+{
+	sockaddr_in addrFor(const std::string& ip, uint16_t port = 5060)
+	{
+		sockaddr_in a{};
+		a.sin_family = AF_INET;
+		a.sin_addr.s_addr = inet_addr(ip.c_str());
+		a.sin_port = htons(port);
+		return a;
+	}
+
+	std::shared_ptr<SipMessage> makeRegister(const std::string& ext, const std::string& ip,
+	                                          const std::string& callId)
+	{
+		std::string raw =
+			"REGISTER sip:server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP " + ip + ":5060;branch=z9hG4bKr" + callId + "\r\n"
+			"From: <sip:" + ext + "@server>;tag=rt" + callId + "\r\n"
+			"To: <sip:" + ext + "@server>\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 1 REGISTER\r\n"
+			"Contact: <sip:" + ext + "@" + ip + ":5060>;expires=3600\r\n"
+			"Content-Length: 0\r\n\r\n";
+		return RequestsHandler::getMessageFromPool(raw, addrFor(ip));
+	}
+
+	std::string sdpBody(const std::string& ip)
+	{
+		return
+			"v=0\r\n"
+			"o=- 0 0 IN IP4 " + ip + "\r\n"
+			"s=-\r\n"
+			"c=IN IP4 " + ip + "\r\n"
+			"t=0 0\r\n"
+			"m=audio 10000 RTP/AVP 0\r\n"
+			"a=rtpmap:0 PCMU/8000\r\n";
+	}
+
+	// `since` skips everything the setup already emitted. It matters: RegisterBeeper
+	// sends every extension an "INVITE sip:<ext>@..." beep at REGISTER time, and the
+	// A-C call's own setup INVITE also reaches C — so an unscoped search for
+	// "INVITE sip:107@" finds a legitimate earlier message and can never prove that
+	// the forged REFER dialled nobody.
+	std::string findSentTo(const std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                       const sockaddr_in& addr, const std::string& needle,
+	                       size_t since = 0)
+	{
+		for (size_t i = sent.size(); i > since; --i)
+		{
+			const auto& e = sent[i - 1];
+			if (e.first.sin_addr.s_addr != addr.sin_addr.s_addr) continue;
+			if (e.first.sin_port != addr.sin_port) continue;
+			if (!e.second) continue;
+			std::string raw = e.second->toString();
+			if (raw.find(needle) != std::string::npos) return raw;
+		}
+		return {};
+	}
+
+	// Drives REGISTER -> INVITE -> 200 OK so `callId` names a Connected dialog
+	// between `callerExt`@`callerIp` and `calleeExt`@`calleeIp`.
+	void establishCall(RequestsHandler& handler,
+	                   std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>>& sent,
+	                   const std::string& callerExt, const std::string& callerIp,
+	                   const std::string& callerTag,
+	                   const std::string& calleeExt, const std::string& calleeIp,
+	                   const std::string& calleeTag,
+	                   const std::string& callId)
+	{
+		const sockaddr_in callerAddr = addrFor(callerIp);
+		const sockaddr_in calleeAddr = addrFor(calleeIp);
+		{
+			std::string body = sdpBody(callerIp);
+			std::string raw =
+				"INVITE sip:" + calleeExt + "@server SIP/2.0\r\n"
+				"Via: SIP/2.0/UDP " + callerIp + ":5060;branch=z9hG4bKi" + callId + "\r\n"
+				"From: <sip:" + callerExt + "@server>;tag=" + callerTag + "\r\n"
+				"To: <sip:" + calleeExt + "@server>\r\n"
+				"Call-ID: " + callId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Max-Forwards: 70\r\n"
+				"Contact: <sip:" + callerExt + "@" + callerIp + ":5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, callerAddr));
+		}
+		std::string fork = findSentTo(sent, calleeAddr, "INVITE sip:" + calleeExt + "@");
+		ASSERT_FALSE(fork.empty()) << "call must reach " << calleeExt;
+
+		// Echo back the forked INVITE's own Via/From so the 200 OK matches its
+		// transaction, exactly as a real callee's UA would.
+		std::string via, fromLine;
+		{
+			size_t pos = 0;
+			while (pos < fork.size())
+			{
+				size_t eol = fork.find("\r\n", pos);
+				if (eol == std::string::npos) eol = fork.size();
+				std::string line = fork.substr(pos, eol - pos);
+				if (line.rfind("Via:", 0) == 0) via = line;
+				if (line.rfind("From:", 0) == 0) fromLine = line;
+				pos = eol + 2;
+			}
+		}
+		ASSERT_FALSE(via.empty());
+		ASSERT_FALSE(fromLine.empty());
+		{
+			std::string body = sdpBody(calleeIp);
+			std::string raw =
+				"SIP/2.0 200 OK\r\n" +
+				via + "\r\n" +
+				fromLine + "\r\n"
+				"To: <sip:" + calleeExt + "@server>;tag=" + calleeTag + "\r\n"
+				"Call-ID: " + callId + "\r\n"
+				"CSeq: 1 INVITE\r\n"
+				"Contact: <sip:" + calleeExt + "@" + calleeIp + ":5060>\r\n"
+				"Content-Type: application/sdp\r\n"
+				"Content-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+			handler.handle(RequestsHandler::getMessageFromPool(raw, calleeAddr));
+		}
+	}
+}
+
+// The core hole: a third registered phone (D) sends a blind-transfer REFER
+// carrying the A-B dialog's Call-ID, with From spoofed to A's number and A's
+// tag, from D's own IP. Pre-#133 that passed findClient() and tore the call
+// down. It must now be refused 403 with nothing torn down and no BYE emitted.
+TEST(ReferSourceAuth, ForgedBlindTransferFromOffPathSourceIsRejected)
+{
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+	RequestsHandler handler("192.168.40.1", 5060,
+		[&sent](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			sent.emplace_back(addr, std::move(msg));
+		});
+
+	const sockaddr_in aAddr        = addrFor("192.168.40.10"); // A: 100
+	const sockaddr_in bAddr        = addrFor("192.168.40.20"); // B: 106
+	const sockaddr_in attackerAddr = addrFor("192.168.40.40"); // D: 108 — off-path
+
+	handler.handle(makeRegister("100", "192.168.40.10", "reg-a-133"));
+	handler.handle(makeRegister("106", "192.168.40.20", "reg-b-133"));
+	handler.handle(makeRegister("107", "192.168.40.30", "reg-c-133"));
+	handler.handle(makeRegister("108", "192.168.40.40", "reg-d-133"));
+
+	const std::string callId = "victim-dialog-133";
+	establishCall(handler, sent, "100", "192.168.40.10", "atag",
+	                             "106", "192.168.40.20", "btag", callId);
+
+	auto before = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(before.has_value());
+	ASSERT_EQ(before.value()->getState(), Session::State::Connected);
+
+	const size_t sentBefore = sent.size();
+
+	// D forges the REFER: A's number and A's tag in From, but D's own source
+	// address on the wire. Everything except the source IP is attacker-chosen.
+	{
+		std::string raw =
+			"REFER sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.40.40:5060;branch=z9hG4bKforged\r\n"
+			"From: <sip:100@server>;tag=atag\r\n"
+			"To: <sip:106@server>;tag=btag\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server>\r\n"
+			"Contact: <sip:100@192.168.40.40:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		handler.handle(RequestsHandler::getMessageFromPool(raw, attackerAddr));
+	}
+
+	// 403 goes back to the forger, and only to the forger.
+	EXPECT_FALSE(findSentTo(sent, attackerAddr, "SIP/2.0 403", sentBefore).empty())
+		<< "forged REFER must be refused 403";
+	EXPECT_TRUE(findSentTo(sent, attackerAddr, "SIP/2.0 202 Accepted", sentBefore).empty())
+		<< "forged REFER must never be accepted";
+
+	// Neither leg of the victim's call hears anything at all — this is the
+	// #128-era wire-visible symptom the guard has to prevent, not just the
+	// bookkeeping teardown.
+	EXPECT_TRUE(findSentTo(sent, bAddr, "BYE sip:", sentBefore).empty())
+		<< "B must not be BYE'd by a forged transfer";
+	EXPECT_TRUE(findSentTo(sent, aAddr, "BYE sip:", sentBefore).empty())
+		<< "A must not be BYE'd by a forged transfer";
+
+	// The transfer target must never be dialled.
+	EXPECT_TRUE(findSentTo(sent, addrFor("192.168.40.30"), "INVITE sip:107@", sentBefore).empty())
+		<< "forged transfer must not dial the target";
+
+	// And the session is still there, still Connected.
+	auto after = handler.getSession("Call-ID: " + callId);
+	ASSERT_TRUE(after.has_value()) << "victim session must survive a forged REFER";
+	EXPECT_EQ(after.value()->getState(), Session::State::Connected);
+
+	// Exactly one message (the 403) resulted.
+	EXPECT_EQ(sent.size(), sentBefore + 1);
+}
+
+// The guard must not break the legitimate case: the same REFER, from A's real
+// address, still transfers. Without this the test above would pass on a
+// handler that refused every REFER.
+TEST(ReferSourceAuth, InDialogTransferFromARealLegStillSucceeds)
+{
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+	RequestsHandler handler("192.168.41.1", 5060,
+		[&sent](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			sent.emplace_back(addr, std::move(msg));
+		});
+
+	const sockaddr_in aAddr      = addrFor("192.168.41.10"); // A: 100 — transferor
+	const sockaddr_in bAddr      = addrFor("192.168.41.20"); // B: 106 — dropped
+	const sockaddr_in targetAddr = addrFor("192.168.41.30"); // C: 107 — target
+
+	handler.handle(makeRegister("100", "192.168.41.10", "reg-a-133ok"));
+	handler.handle(makeRegister("106", "192.168.41.20", "reg-b-133ok"));
+	handler.handle(makeRegister("107", "192.168.41.30", "reg-c-133ok"));
+
+	const std::string callId = "legit-dialog-133";
+	establishCall(handler, sent, "100", "192.168.41.10", "atag",
+	                             "106", "192.168.41.20", "btag", callId);
+
+	const size_t sentBefore = sent.size();
+
+	{
+		std::string raw =
+			"REFER sip:106@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.41.10:5060;branch=z9hG4bKlegit\r\n"
+			"From: <sip:100@server>;tag=atag\r\n"
+			"To: <sip:106@server>;tag=btag\r\n"
+			"Call-ID: " + callId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server>\r\n"
+			"Contact: <sip:100@192.168.41.10:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		handler.handle(RequestsHandler::getMessageFromPool(raw, aAddr));
+	}
+
+	EXPECT_FALSE(findSentTo(sent, aAddr, "SIP/2.0 202 Accepted", sentBefore).empty())
+		<< "a real leg's REFER must still be accepted";
+	EXPECT_TRUE(findSentTo(sent, aAddr, "SIP/2.0 403", sentBefore).empty())
+		<< "a real leg's REFER must not be forbidden";
+	EXPECT_FALSE(findSentTo(sent, bAddr, "BYE sip:", sentBefore).empty())
+		<< "the dropped party must still get its #128 BYE";
+	EXPECT_FALSE(findSentTo(sent, targetAddr, "INVITE sip:107@", sentBefore).empty())
+		<< "the transfer target must still be dialled";
+}
+
+// A REFER whose source IS a leg of the A-B dialog (B, the far end) but which
+// names an unrelated call as ?Replaces=. B passes the A-B source check, and
+// spoofing A's number in From satisfies the attended path's own
+// "A common to both dialogs" coherence test — only the consult-dialog source
+// check stops B from splicing A out of A's other call.
+TEST(ReferSourceAuth, ReplacesNamingADialogTheSourceIsNotOnIsRejected)
+{
+	std::vector<std::pair<sockaddr_in, std::shared_ptr<SipMessage>>> sent;
+	RequestsHandler handler("192.168.42.1", 5060,
+		[&sent](const sockaddr_in& addr, std::shared_ptr<SipMessage> msg) {
+			sent.emplace_back(addr, std::move(msg));
+		});
+
+	const sockaddr_in aAddr = addrFor("192.168.42.10"); // A: 100
+	const sockaddr_in bAddr = addrFor("192.168.42.20"); // B: 106 — on A-B only
+	const sockaddr_in cAddr = addrFor("192.168.42.30"); // C: 107 — on A-C only
+
+	handler.handle(makeRegister("100", "192.168.42.10", "reg-a-133r"));
+	handler.handle(makeRegister("106", "192.168.42.20", "reg-b-133r"));
+	handler.handle(makeRegister("107", "192.168.42.30", "reg-c-133r"));
+
+	const std::string abCallId = "ab-dialog-133r";
+	const std::string acCallId = "ac-dialog-133r";
+	establishCall(handler, sent, "100", "192.168.42.10", "atag1",
+	                             "106", "192.168.42.20", "btag1", abCallId);
+	establishCall(handler, sent, "100", "192.168.42.10", "atag2",
+	                             "107", "192.168.42.30", "ctag2", acCallId);
+
+	ASSERT_TRUE(handler.getSession("Call-ID: " + acCallId).has_value());
+	const size_t sentBefore = sent.size();
+
+	// B sends the attended REFER on its own A-B dialog (so the first source
+	// check passes) with From spoofed as A, naming A's separate A-C call.
+	{
+		std::string raw =
+			"REFER sip:100@server SIP/2.0\r\n"
+			"Via: SIP/2.0/UDP 192.168.42.20:5060;branch=z9hG4bKrepl\r\n"
+			"From: <sip:100@server>;tag=atag1\r\n"
+			"To: <sip:106@server>;tag=btag1\r\n"
+			"Call-ID: " + abCallId + "\r\n"
+			"CSeq: 2 REFER\r\n"
+			"Max-Forwards: 70\r\n"
+			"Refer-To: <sip:107@server?Replaces=" + acCallId + ">\r\n"
+			"Contact: <sip:106@192.168.42.20:5060>\r\n"
+			"Content-Length: 0\r\n\r\n";
+		handler.handle(RequestsHandler::getMessageFromPool(raw, bAddr));
+	}
+
+	EXPECT_FALSE(findSentTo(sent, bAddr, "SIP/2.0 403", sentBefore).empty())
+		<< "a Replaces naming a dialog the source is not on must be refused 403";
+	EXPECT_TRUE(findSentTo(sent, bAddr, "SIP/2.0 202 Accepted", sentBefore).empty())
+		<< "the splice must never be accepted";
+
+	// No leg of either dialog is torn down or re-INVITEd.
+	EXPECT_TRUE(findSentTo(sent, aAddr, "BYE sip:", sentBefore).empty()) << "A must not be dropped";
+	EXPECT_TRUE(findSentTo(sent, cAddr, "INVITE sip:107@", sentBefore).empty())
+		<< "C must not be re-INVITEd by a forged splice";
+
+	auto ab = handler.getSession("Call-ID: " + abCallId);
+	auto ac = handler.getSession("Call-ID: " + acCallId);
+	ASSERT_TRUE(ab.has_value());
+	ASSERT_TRUE(ac.has_value());
+	EXPECT_FALSE(ab.value()->isTransferBridge()) << "no bridge may be established";
+	EXPECT_FALSE(ac.value()->isTransferBridge()) << "no bridge may be established";
+
+	EXPECT_EQ(sent.size(), sentBefore + 1);
+}


### PR DESCRIPTION
Closes #133.

## The hole

`onBye` carries issue #46's guard: a BYE for an established two-party dialog must arrive from one of that dialog's own leg IPs, or it's a forged teardown and gets 403. `onRefer` had no counterpart.

Its only admission check was `findClient(data->getFromNumber())` — that proves the REFER's From header names a **registered** extension, not that the sender is a party to the Call-ID it named. From is chosen by the sender, so any registered phone could name someone else's active dialog and:

- **blind path** — `endCall()` the victim's session and (since #128) send the victim's peer a BYE built from the attacker's own tags;
- **attended path** — name the victim's call as `?Replaces=` and splice it.

The attended path's existing "A must be common to both dialogs" invariant is *not* a substitute — it compares numbers pulled from that same attacker-chosen From.

## The fix

`isDialogSourceAuthorized()` — the same helper `onBye` uses, unchanged — applied at both dialogs `onRefer` can touch:

1. the REFER's own Call-ID, and
2. any `?Replaces=` consult dialog.

A genuine transferor is a leg of both and passes both checks; anyone else fails one and gets 403. The helper fails open on an unknown or half-set-up session, so a genuinely out-of-dialog REFER still falls through to the blind-transfer path exactly as before — no behaviour change for legitimate traffic.

The attended path's number-based coherence check is kept, with its comment corrected: it's no longer the auth check, but it still catches an honest client pairing two unrelated dialogs.

## Coverage

New `tests/ReferSourceAuth_test.cpp`, driving a real `RequestsHandler` through `handle()` end-to-end (same harness shape as `BlindTransfer_test.cpp`):

| Test | Asserts |
|---|---|
| `ForgedBlindTransferFromOffPathSourceIsRejected` | An off-path registered phone spoofing A's number *and* A's tag gets 403; no BYE to either leg, target never dialled, session still `Connected`, and exactly one message total resulted |
| `InDialogTransferFromARealLegStillSucceeds` | The identical REFER from A's real address still gets 202, still BYEs the dropped party (#128), still dials the target |
| `ReplacesNamingADialogTheSourceIsNotOnIsRejected` | B — genuinely a leg of A–B, so it passes the first check — is still refused when its `?Replaces=` names A's separate A–C call; no bridge established on either session |

One thing worth flagging: `findSentTo()` here takes a `since` index. Without it the assertions are vacuous — `RegisterBeeper` sends every extension an `INVITE sip:<ext>@…` beep at REGISTER time, so an unscoped search for the transfer target's INVITE matches a legitimate earlier message and can never prove the forged REFER dialled nobody. (That bit me: the first run of these tests failed for exactly that reason, not because the guard was wrong.)

## Verification

`322/322` host tests green under WSL/g++ (Release), including the pre-existing `BlindTransfer` and `AttendedTransfer` suites unchanged — which is what shows the guard doesn't break legitimate transfers.

Not hardware-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd9eFx53kc4sTkVYf9XbK
