### PR TITLE
fix(tests): match the 403 status line, not a bare "403" (#136)

### DIFF
--- a/tests/InviteAdmission_test.cpp
+++ b/tests/InviteAdmission_test.cpp
@@ -199,7 +199,17 @@ TEST(InviteAdmission, SecureModeChallengesInviteThenAdmitsCredentialedRetry)
 	h.sent.clear();
 	h.handler.handle(makeInvite("sec", 2, kPcmuOffer, authz));
 	EXPECT_FALSE(anySentContains(h.sent, "401 Unauthorized")) << "valid credentials must not be re-challenged";
-	EXPECT_FALSE(anySentContains(h.sent, "403"));
+	// Match the status LINE, not a bare "403" (issue #136). anySentContains() is a
+	// plain substring search over the whole message, and the INVITE forked to 600
+	// echoes this request's Authorization header verbatim -- 64 characters of digest
+	// nonce and MD5 response hex. Those 62 three-character windows hit "403" roughly
+	// 1.5% of the time (measured 3/400 fresh processes), which is exactly the
+	// order-dependent-looking intermittent failure #136 recorded: the credentials
+	// were accepted and the fork went out, but a random hex triple spelled the code
+	// this line was watching for. The sibling assertion at the bottom of this test
+	// already uses the full "SIP/2.0 403 Bad Credentials" form.
+	EXPECT_FALSE(anySentContains(h.sent, "SIP/2.0 403"))
+		<< "valid credentials must not be rejected";
 	EXPECT_TRUE(anySentContains(h.sent, "INVITE sip:600@")) << "admitted INVITE is forked to the callee";
 
 	// 3. Wrong password -> 403, not a loop of challenges.


### PR DESCRIPTION
Closes #136.

## It isn't a race — it's a three-character needle

#136 recorded a single intermittent failure of `InviteAdmission.SecureModeChallengesInviteThenAdmitsCredentialedRetry` and reasonably guessed at a second order-dependent flake, by analogy with #135's real `RtpSender` pacer-thread race. It's neither order-dependent nor a race.

`tests/InviteAdmission_test.cpp:202` asserted:

```cpp
EXPECT_FALSE(anySentContains(h.sent, "403"));
```

`anySentContains()` is a plain `toString().find()` over the **whole message**. Step 2 of the test sends an INVITE with valid digest credentials; the handler admits it and `CallForker` forks it to 600 with the inbound `Authorization` header echoed verbatim — **64 characters of nonce and MD5 response hex**, drawn from a per-process random secret.

62 overlapping three-character windows over uniform hex hit `"403"` with probability ≈ `62/4096` = **1.5%**. So the test failed at random, on runs where the credentials were accepted and the fork went out correctly.

The structural proof it was never a real 403: every 403 emitter reachable from the INVITE path returns *before* forking (`RequestsHandler.cpp:654`, `:691-695` → `Registrar::sendForbidden`). Line 203 — `EXPECT_TRUE(anySentContains(h.sent, "INVITE sip:600@"))` — passed in **every** failing run. A genuine rejection would have failed line 203 too.

## Measurement

`--gtest_repeat` under-samples this badly: the nonce is drawn **once per process**, so repeats inside one process re-test nearly the same string. My first attempt (20 processes × 60 repeats = 1200 iterations) found **zero** failures and looked like a non-repro. Sampling by independent *process* instead:

| | result |
|---|---|
| before | **3 / 400** processes failed — all at `InviteAdmission_test.cpp:202`, `Actual: true` |
| after | **0 / 1200** processes failed |

0.75% observed vs 1.5% predicted, on a 400-sample; the fix run is ~9 expected failures suppressed to zero (p ≈ 1e-4 under the null).

## The fix

Match `"SIP/2.0 403"` — the same full-status-line form the sibling assertion at the end of this same test (`"SIP/2.0 403 Bad Credentials"`) already uses.

## Scope

This is the only assertion in `tests/` that asserts the **absence** of a bare three-digit needle, so it's the only one that can flake this way. The two `find("200")` checks in `PcapCapture_test.cpp:513,566` and `HttpTraceCommand_test.cpp:190` assert *presence* — a spurious match silently weakens them rather than failing them. Noted, deliberately not changed here.

322/322 host tests green under WSL/g++ Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd9eFx53kc4sTkVYf9XbK
