### PR TITLE
fix(tests): stop the RtpSender pacer before draining a leg by hand (#135)

### DIFF
--- a/src/SIP/ConferenceRoom.cpp
+++ b/src/SIP/ConferenceRoom.cpp
@@ -148,6 +148,13 @@ MediaBridge* ConferenceRoom::bridgeForCall(const std::string& callID)
 	return (idx < 0) ? nullptr : &_legs[static_cast<size_t>(idx)].bridge;
 }
 
+RtpSender* ConferenceRoom::senderForCall(const std::string& callID)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	const int idx = indexOfLocked(callID);
+	return (idx < 0) ? nullptr : &_legs[static_cast<size_t>(idx)].tx;
+}
+
 // ── The single mix-tick driver ───────────────────────────────────────────────
 // One periodic clock for the whole room. Deliberately NOT hung off a leg's
 // RtpSender cadence: there are N senders and only one bus, so that would be N

--- a/src/SIP/ConferenceRoom.hpp
+++ b/src/SIP/ConferenceRoom.hpp
@@ -109,6 +109,18 @@ public:
 	MixBus& bus() { return _bus; }
 	MediaBridge* bridgeForCall(const std::string& callID);
 
+	// Test access to a leg's RtpSender. On a Linux host RtpSender::start() is NOT the
+	// inert stub the host build is often assumed to get: RtpSender.cpp's
+	// "#elif defined(__linux__)" branch (issue #82) spawns a real 20 ms pacer thread
+	// whose frame provider is MediaBridge::fillHandsetTx -- i.e. a DESTRUCTIVE
+	// MixBus::outputFrame() pop of this port's out ring (PlayoutBuffer::read advances
+	// the read pointer and decrements _count). A test that steps the bus with
+	// tickOnce() and then drains a leg by hand is therefore a SECOND consumer of that
+	// ring, and must stop the pacer first or it can lose the very frame it is about to
+	// assert on (issue #135). Production never needs this: the pacer is the only caller
+	// of fillHandsetTx.
+	RtpSender* senderForCall(const std::string& callID);
+
 private:
 	struct Leg
 	{

--- a/tests/ConferenceRoom_test.cpp
+++ b/tests/ConferenceRoom_test.cpp
@@ -87,6 +87,24 @@ namespace
 		return RtpReceiver::mulawDecode(RtpSender::linearToUlaw(saturate(mix)));
 	}
 
+	// Halt every named leg's RtpSender pacer thread so the test is the ONLY consumer
+	// of each port's out ring before it starts draining legs by hand (issue #135).
+	// On this host RtpSender::start() spawns a real 20 ms thread whose provider is
+	// MediaBridge::fillHandsetTx -- the same destructive PlayoutBuffer::read() that
+	// drainLeg() below performs -- so without this the pacer can pop the very frame
+	// the test is about to assert on. stop() joins synchronously; the bridge and its
+	// bus port stay live, so tickOnce()/drainLeg() remain valid afterwards. Same shape
+	// as the tx.stop("call-x") in AnchorModeIsUnchangedByTheBusRewiring.
+	void quiesceSenders(ConferenceRoom& room, const std::vector<std::string>& callIds)
+	{
+		for (const auto& id : callIds)
+		{
+			RtpSender* tx = room.senderForCall(id);
+			ASSERT_NE(tx, nullptr) << "no leg for " << id;
+			ASSERT_TRUE(tx->stop(id)) << "pacer for " << id << " was not running";
+		}
+	}
+
 	// Pull one 20 ms frame out of a leg and decode it back to PCM16.
 	std::vector<int16_t> drainLeg(MediaBridge& bridge)
 	{
@@ -188,6 +206,7 @@ TEST(ConferenceRoom, ThreeLegsEachHearTheOthersMinusThemselves)
 	ASSERT_GE(room.join("call-b", "102", "127.0.0.1", 10002), 0);
 	ASSERT_GE(room.join("call-c", "103", "127.0.0.1", 10003), 0);
 	EXPECT_EQ(room.legCount(), 3);
+	quiesceSenders(room, {"call-a", "call-b", "call-c"});
 
 	MediaBridge* a = room.bridgeForCall("call-a");
 	MediaBridge* b = room.bridgeForCall("call-b");
@@ -239,6 +258,7 @@ TEST(ConferenceRoom, LoudLegsDoNotOverSaturateThroughTheBridge)
 		ASSERT_GE(room.join(ids.back(), "10" + std::to_string(i), "127.0.0.1",
 			static_cast<uint16_t>(11000 + i)), 0);
 	}
+	quiesceSenders(room, ids);
 
 	const int16_t level = 30000;
 	for (const auto& id : ids)
@@ -264,6 +284,7 @@ TEST(ConferenceRoom, LegLeavingDoesNotDisturbTheRest)
 	ASSERT_GE(room.join("call-a", "101", "127.0.0.1", 12001), 0);
 	ASSERT_GE(room.join("call-b", "102", "127.0.0.1", 12002), 0);
 	ASSERT_GE(room.join("call-c", "103", "127.0.0.1", 12003), 0);
+	quiesceSenders(room, {"call-a", "call-b", "call-c"});
 
 	MediaBridge* a = room.bridgeForCall("call-a");
 	MediaBridge* b = room.bridgeForCall("call-b");

--- a/tests/MediaBridge_test.cpp
+++ b/tests/MediaBridge_test.cpp
@@ -1,6 +1,10 @@
 // MediaBridge_test.cpp — unit coverage for MediaBridge, the RTP<->AnchorClient
-// glue. On host, RtpReceiver/RtpSender::start() are no-op stubs (no real socket
-// or pacing task), so these tests exercise the parts that are real on host: the
+// glue. On host RtpReceiver::start() is a no-op stub, but RtpSender is NOT: its
+// "#elif defined(__linux__)" branch (issue #82) spawns a real 20 ms pacer thread
+// whose provider is MediaBridge::fillHandsetTx, which pops the very playout buffer
+// these tests assert on (PlayoutBuffer::read is destructive). Any test that reads
+// getPlayoutBuffer() must stop that sender right after startBridge() first -- see
+// issue #135. Otherwise these tests exercise the parts that are real on host: the
 // lifecycle/identity bookkeeping and the feedRx -> PlayoutBuffer path, including
 // an end-to-end run through a real LoopbackAnchorClient wired the way
 // RequestsHandler would wire any AnchorClient's single rx callback.
@@ -106,7 +110,10 @@ TEST(MediaBridge, FeedRxRejectedForWrongParticipant) {
 
 TEST(MediaBridge, FeedRxWritesIntoPlayoutBuffer) {
 	Fixture f;
-	f.bridge.startBridge("127.0.0.1", 5004, "call-1", "part-1");
+	ASSERT_TRUE(f.bridge.startBridge("127.0.0.1", 5004, "call-1", "part-1"));
+	// Halt the Linux pacer thread before asserting on the playout buffer it also
+	// drains via fillHandsetTx -> PlayoutBuffer::read() (issue #135).
+	ASSERT_TRUE(f.sender.stop("call-1"));
 
 	const int16_t in[] = {111, 222, 333};
 	EXPECT_TRUE(f.bridge.feedRx("part-1", in, 3));
@@ -127,7 +134,9 @@ TEST(MediaBridge, FeedRxWritesIntoPlayoutBuffer) {
 
 TEST(MediaBridge, AnchorAudioReachesPlayoutBufferThroughRxFanout) {
 	Fixture f;
-	f.bridge.startBridge("127.0.0.1", 5004, "call-1", "part-1");
+	ASSERT_TRUE(f.bridge.startBridge("127.0.0.1", 5004, "call-1", "part-1"));
+	// Same pacer-thread hazard as above (issue #135).
+	ASSERT_TRUE(f.sender.stop("call-1"));
 
 	f.anchor.registerAudioRxCallback([&f](const std::string& participantId,
 	                                       const int16_t* samples, size_t count) {


### PR DESCRIPTION
Closes #135.

## First, a correction to the issue's premise

#135 says `ThreeLegsEachHearTheOthersMinusThemselves` is "already excluded from the gate as flaky." **It isn't, and never was.** `tests/CMakeLists.txt:230` registers the binary with a bare `add_test` (no filter), both CI workflows run a bare `ctest --test-dir build/tests --output-on-failure`, `--gtest_list_tests` shows the test with no `DISABLED_` prefix, and `git log --all -S"ThreeLegs"` over the CMakeLists and the workflows returns nothing. It has been live on `ubuntu-latest` — which defines `__linux__` and therefore compiles the real-threaded sender branch — the entire time.

## The race

`RtpSender::start()` is not the inert stub the host suite was written against. The `#elif defined(__linux__)` branch (issue #82) spawns a real 20 ms pacer thread, and `runLoop()` calls its frame provider on the **first iteration, before the first `sleep_until`** — no warm-up.

That provider is `MediaBridge::fillHandsetTx`, which reaches `MixBus::outputFrame` → `PlayoutBuffer::read()`. `read()` is **destructive**: it advances `_readPtr` and decrements `_count`. So a test that steps the bus with `tickOnce()` and then drains a leg by hand is a *second consumer of the same ring*, and the pacer can pop the very frame it is about to assert on.

#131 already fixed one instance (`tx.stop("call-x")` in `AnchorModeIsUnchangedByTheBusRewiring`). Three more had the identical shape and were missed, plus two in `MediaBridge_test.cpp` whose file header still asserted `RtpSender::start()` is a no-op stub on host.

## Measurement

This is why it read as rare and mysterious: the window is between the test's `tickOnce()` and its `drainLeg()`, so it only opens if a freshly spawned pacer thread is scheduled in that gap. **On an idle box it never opens** — 200 sequential processes were clean both before *and* after the fix, which is a non-result either way.

Oversubscribing the CPU forces the interleaving. 400 processes, 48 concurrent on 12 cores, identical command before and after:

| | result |
|---|---|
| before | **29 / 400** failed — 27× `ThreeLegsEachHearTheOthersMinusThemselves` at `ConferenceRoom_test.cpp:113` (*"leg C must hear A+B"*, reading back `-8` instead of `3004` — an emptied ring), plus `MediaBridge.FeedRxWritesIntoPlayoutBuffer` and `AnchorAudioReachesPlayoutBufferThroughRxFanout` |
| after | **0 / 400** failed |

## The fix

Add `ConferenceRoom::senderForCall()` beside the existing `bridgeForCall()` so a test can reach a leg's sender, then quiesce the pacers right after the joins in the three affected `ConferenceRoom` tests. `stop()` joins synchronously and leaves the bridge and its bus port live, so `tickOnce()`/`drainLeg()` still work. `RejoinAfterLeaveReusesTheReclaimedPort` never drains a leg, so it needs nothing. In `MediaBridge_test.cpp`, stop the fixture's own sender in the two tests that read `getPlayoutBuffer()`, and correct the stale header comment.

## On the issue's production concern

#135 also flagged that the same cold-start window might exist on a real Linux-desktop `SipServer`. Traced and **it does not**: `MediaBridge.cpp:82` is the only caller of `fillHandsetTx` anywhere in `src/`, `main/`, or `tools/`, so in production the pacer is the *sole* consumer of that ring. The tests create the second consumer by running driverless and draining by hand. Nothing to split out.

## Verification

- 6 sequential shuffled full-suite runs: 322/322 green each.
- `--gtest_filter='ConferenceRoom.*:MediaBridge.*' --gtest_repeat=30`: clean.
- Contended runs as tabled above.

One note on method: I also tried the *full* suite under the same oversubscription and got mass failures — all in `AdminHttpGate`/`WebHardening`/`DialPlanHttp`, which bind fixed ports (e.g. `canConnect(18082)` seeing a sibling process's listener). That's a limitation of running concurrent instances, not a defect, so that run carries no signal and I've drawn nothing from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd9eFx53kc4sTkVYf9XbK
