### PR TITLE
fix(provisioning): probe the Ethernet netif for ARP, not just Wi-Fi (#103)

### DIFF
--- a/src/Helpers/ArpLookup.cpp
+++ b/src/Helpers/ArpLookup.cpp
@@ -87,9 +87,23 @@ namespace ArpLookup
 
 		Mac mac{};
 		// AP first (the common case: phones associate to the device's SoftAP), then
-		// STA (the device is itself a client on an upstream LAN). First hit wins.
+		// STA (the device is itself a client on an upstream LAN), then Ethernet.
+		// First hit wins.
+		//
+		// ETH_DEF is not optional (issue #103). On an Ethernet build -- the whole
+		// SIP_TRANSPORT=eth family, e.g. the LilyGO T-ETH-Elite -- there is no Wi-Fi
+		// netif at all, so both Wi-Fi probes get a nullptr handle and this function
+		// returned nullopt for EVERY caller, forever. That is a permanent ARP miss,
+		// and admitLearn() treats a miss as "accept but defer the MAC-lock to the
+		// next REGISTER" -- a next REGISTER that could never resolve either. The
+		// device registry therefore stayed empty on every Ethernet board, so no
+		// device was ever adopted and GET /config/<mac>.cfg answered 404 for all of
+		// them. Silently: the miss path is a deliberate non-error.
+		// The key string is ESP-IDF's own (esp_netif_defaults.h,
+		// ESP_NETIF_INHERENT_DEFAULT_ETH sets .if_key = "ETH_DEF").
 		if (probeIfkey("WIFI_AP_DEF", ip, mac) ||
-			probeIfkey("WIFI_STA_DEF", ip, mac))
+			probeIfkey("WIFI_STA_DEF", ip, mac) ||
+			probeIfkey("ETH_DEF", ip, mac))
 		{
 			return mac;
 		}


### PR DESCRIPTION
Closes #103.

## The hypothesis was wrong; the impact was right

#103 predicted *"zero-touch provisioning silently returns 404 for every adopted device — the feature simply never works, with no error anywhere."* That is exactly what happens. But not for the reason it guessed.

The suspected cause was a MAC **format** mismatch (colon-separated or uppercase registry key vs. the 12-lowercase-hex URL). A prior comment argued from code that both sides go through `ArpLookup::toHex12()` and therefore agree. **That argument was correct** — and the feature was still 100% broken, because the registry was always *empty*, so there was never a key to compare.

## Root cause

`ArpLookup::pdLookupMac()` probed exactly two interfaces:

```cpp
if (probeIfkey("WIFI_AP_DEF", ip, mac) ||
    probeIfkey("WIFI_STA_DEF", ip, mac))
```

On an Ethernet build there is **no Wi-Fi netif at all**, so `esp_netif_get_handle_from_ifkey()` returns `nullptr` for both and the function returns `nullopt` for every caller, forever.

`admitLearn()` reads `nullopt` as a first-packet cache miss and takes its deliberate soft path — accept the REGISTER, defer the MAC-lock to *"the NEXT REGISTER"*. That next REGISTER could never resolve either. So on the entire `SIP_TRANSPORT=eth` family the device registry stayed permanently empty: nothing was ever adopted, and `GET /config/<mac>.cfg` 404'd for every phone — silently, because the miss path is a non-error by design.

## Fix

Add `ETH_DEF` to the probe chain. The key string is ESP-IDF's own (`esp_netif_defaults.h`, `ESP_NETIF_INHERENT_DEFAULT_ETH` sets `.if_key = "ETH_DEF"`).

## Hardware verification

This is the from-scratch device run the earlier comment asked for. A **LilyGO T-ETH-Elite S3** (W5500, ETH MAC `e0:72:a1:cc:1c:07`), fully flash-erased, REGISTERs driven from a host whose MAC is `e4:5f:01:65:45:16`:

| | serial output |
|---|---|
| **before** (v1.3.0 release + `main`) | `Learn REGISTER ext 1001: ARP miss, deferring MAC-lock` — **4 of 4** attempts, after warming the board's neighbour table with pings and across repeated REGISTERs. Registry `devices: []`, `GET /config/e45f01654516.cfg` → **404**. |
| **after** (this fix) | `Learn: adopted device e45f01654516 as ext 1001` — and **zero** ARP-miss lines. |

The adopted key is `e45f01654516`: exactly `toHex12(e4:5f:01:65:45:16)`, the 12-lowercase-hex no-separator form `HttpServer::isProvisioningConfigPath()` parses out of the URL. The two sides agree, as the code-reading said — they just never had anything to compare.

## Honest limits of this verification

- **`GET /config/<mac>.cfg` was not itself re-fetched with a 200 after the fix.** Once provisioned the board is dark-by-default, and the `*4887` DTMF star-code that reopened the admin HTTP plane on the v1.3.0 firmware would not fire again on this build from my synthetic SIP client. The DTMF and admin-gate code is **byte-identical** between `v1.3.0` and `main` (`git log v1.3.0..origin/main` over `DtmfFeatureCodes.*`, `AdminAuth.cpp`, `HttpServer.cpp`, `main/` is empty), so this is a limitation of my test client, not a regression — but I could not close that last hop, and I am not claiming it.
- The adoption line plus the confirmed key format is the substantive proof: `findProvisioningInfo()` compares `d.mac == mac`, `d.mac` is now `e45f01654516`, and the URL parser yields that same string.
- To reach Learn mode without the HTTP plane I temporarily seeded `Registrar::Mode::Learn` at compile time. That hack was **reverted before this commit** — the diff here is the `ArpLookup.cpp` change and nothing else. (For the record, `RequestsHandler.hpp` documents a supported way to do this properly: the NVS `reg_mode` value, settable at flash time via the cfgseed record, per `docs/LEARN_MODE.md`.)

## No host test

`ArpLookup`'s non-ESP build is a stub that returns `nullopt` unconditionally, so the interface-probe order has no off-device observable. The hardware run above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd9eFx53kc4sTkVYf9XbK
