### PR TITLE
docs(scaling): record the multi-host firmware concurrency measurement (#79)

### DIFF
--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -181,6 +181,36 @@ headroom and bump the tier before exhaustion becomes routine.
 > #115. This was a single-host, host-build measurement (loopback-range source
 > IPs, not real distinct hosts), not a real multi-host run against firmware.
 
+> **Measured on firmware, multi-host (Issue #79, 2026-09-06):** the run above has
+> now been repeated against a real board — a LilyGO T-ETH-Elite S3 (W5500,
+> `SIP_TRANSPORT=eth`, default 32/8 tier) — driven concurrently from **two
+> genuinely distinct physical hosts** on the same LAN, so the Issue #38 per-IP
+> token bucket is bypassed by having separate buckets rather than by loopback
+> aliases:
+>
+> | source host | attempts | `200` | `503` | p50 latency |
+> |---|--:|--:|--:|--:|
+> | `192.168.12.110` | 25 | **25** | 0 | 7.3 ms |
+> | `192.168.12.161` | 25 | **7** | 18 | 11.8 ms |
+> | **total** | 50 | **32** | 18 | — |
+>
+> The client-pool ceiling lands at **exactly 32** across the two hosts, matching
+> `POCKETDIAL_MAX_CLIENTS` — confirming the pool is global, not per-source. Every
+> rejection was a clean `503 Service Unavailable`; `packetsDropped` stayed 0, and
+> the serial console showed no watchdog, panic, abort or reboot. The board kept
+> answering REGISTERs afterwards. A separate single-host run (45 attempts, paced
+> under the per-IP limit) reproduced the same 32/13 split with p50 4.6 ms.
+>
+> Two caveats worth recording. First, the **session** ceiling (8) was *not*
+> cleanly demonstrated on firmware: 14 concurrent `777` echo calls returned 11 ×
+> `200` and 3 × *no response at all* rather than `503` — the Issue #115 behaviour,
+> now confirmed on hardware. Second, sustained registration load makes the
+> register-beep INVITE flood the static message pool
+> (`[tx] pool exhausted — INVITE sent without retransmit tracking`), which is
+> Issue #148; a starved pool silently drops unrelated signalling, so the latency
+> figures above should be read as "healthy tier, known beep bug", not as a clean
+> bill of health.
+
 ---
 
 ## 5. Why the defaults are 32 / 8 — and what breaks if you 10× them


### PR DESCRIPTION
Closes #79.

`SCALING.md` already carried an Issue #79 measurement, but it was explicit about what it *wasn't*: a single-host **host-build** run using loopback-range source IPs, *"not a real multi-host run against firmware."* That's the run this PR records.

## Setup

A **LilyGO T-ETH-Elite S3** (W5500, `SIP_TRANSPORT=eth`, default 32/8 tier) driven **concurrently from two genuinely distinct physical hosts** on the same LAN — so the Issue #38 per-IP token bucket is bypassed by having separate buckets, not by loopback aliases on one machine.

| source host | attempts | `200` | `503` | p50 |
|---|--:|--:|--:|--:|
| `192.168.12.110` (Pi) | 25 | **25** | 0 | 7.3 ms |
| `192.168.12.161` (desktop) | 25 | **7** | 18 | 11.8 ms |
| **total** | 50 | **32** | 18 | — |

## Result

The client-pool ceiling lands at **exactly 32** across the two hosts — matching `POCKETDIAL_MAX_CLIENTS`, and confirming the pool is **global, not per-source**. Every rejection was a clean `503 Service Unavailable`. `packetsDropped` stayed **0**, and the serial console showed **no watchdog, panic, abort or reboot**; the board kept answering REGISTERs afterwards. A separate single-host run (45 attempts paced under the per-IP limit) reproduced the same 32/13 split at p50 4.6 ms.

That satisfies the issue's acceptance: a documented ceiling, and the 503 path confirmed clean at pool exhaustion.

## Two caveats, recorded rather than glossed

- **The session ceiling (8) was *not* cleanly demonstrated on firmware.** 14 concurrent `777` echo calls returned 11 × `200` and **3 × no response at all** rather than `503` — that's Issue #115's behaviour, now confirmed on hardware rather than inferred.
- **Sustained registration load starves the message pool.** The register-beep INVITE floods it (`[tx] pool exhausted — INVITE sent without retransmit tracking`), filed as #148. A starved pool silently drops unrelated signalling, so the latency figures should be read as *"healthy tier, known beep bug"* — not a clean bill of health.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd9eFx53kc4sTkVYf9XbK
