### PR TITLE
fix(eth): correct the Waveshare W5500 pin map (#155)

### DIFF
--- a/main/esp_main_eth.cpp
+++ b/main/esp_main_eth.cpp
@@ -65,15 +65,24 @@ static const char* TAG = "SipServerETH";
 //     waveshare → Waveshare ESP32-S3-ETH (W5500, PoE)
 //   Defaults to the Elite when neither macro is defined, so a stray build of
 //   this file targets the board that's actually on the bench.
-//   Verify against your board's schematic / silkscreen before trusting it.
+//   Both maps below are hardware-verified: the Elite continuously, the Waveshare
+//   as of #155. A wrong pin here is not a soft failure -- esp_eth_driver_install()
+//   returns ESP_ERR_TIMEOUT and the ESP_ERROR_CHECK at eth_init_w5500() aborts
+//   the boot, so the board reset-loops with no network to diagnose it over.
 #if defined(PD_ETH_BOARD_WAVESHARE)
 #  define W5500_BOARD_NAME "Waveshare ESP32-S3-ETH"
-#  define W5500_SCLK_GPIO  12
-#  define W5500_MISO_GPIO  13
+// Verified on hardware 2026-09-07 (issue #155). The previous map here had SCLK
+// and MISO transposed, CS and INT transposed, and no reset line; it did not just
+// fail to link, it timed out inside esp_eth_driver_install() and the
+// ESP_ERROR_CHECK aborted the boot, so the board sat in a reset loop
+// (108 consecutive rst:0xc in one capture). These values are the ones the
+// ESP32_AdBlocker_Reborn firmware has been running on this exact board.
+#  define W5500_SCLK_GPIO  13
+#  define W5500_MISO_GPIO  12
 #  define W5500_MOSI_GPIO  11
-#  define W5500_CS_GPIO    10
-#  define W5500_INT_GPIO   14
-#  define W5500_RST_GPIO   -1
+#  define W5500_CS_GPIO    14
+#  define W5500_INT_GPIO   10
+#  define W5500_RST_GPIO   9    // Waveshare wires a real reset line; the Elite does not
 #else  // PD_ETH_BOARD_ELITE (default)
 #  define W5500_BOARD_NAME "LilyGO T-ETH-ELITE S3"
 #  define W5500_SCLK_GPIO  48


### PR DESCRIPTION
Closes #155.

`PD_ETH_BOARD=waveshare` had three of six pins wrong — SCLK/MISO transposed, CS/INT transposed, and `RST` left at `-1` (copy-pasted from the Elite, which genuinely has no GPIO reset).

| | SCLK | MISO | MOSI | CS | INT | RST |
|---|---|---|---|---|---|---|
| before | 12 | 13 | 11 | 10 | 14 | −1 |
| after | **13** | **12** | 11 | **14** | **10** | **9** |

**It aborted the boot rather than failing soft.** `esp_eth_driver_install()` → `ESP_ERR_TIMEOUT` → `ESP_ERROR_CHECK` at `eth_init_w5500()`: the board reset-loops with no network and no HTTP plane to diagnose over. 108 consecutive aborts in one capture, all `rst:0xc`, zero link-up.

The corrected values aren't a datasheet reading — they're the pins **ESP32_AdBlocker_Reborn runs on this exact board** as its production DNS sinkhole.

## Verified on hardware, same board, same procedure

| | before | after |
|---|---|---|
| Boot | 108× `ESP_ERR_TIMEOUT` abort, `rst:0xc` loop | boots clean |
| Ethernet | never linked, no DHCP | `Starting SipServer on 192.168.12.195:5060` |
| cfgseed → Learn (#151 path) | unreachable | `Learn: adopted device e45f01654516 as ext 1001` |
| `reg_mode` namespace | — | `pbxcfg` ✓ |

So this also confirms v1.4.1's #151 fix on a second, independent board.

**No release needed** — the release matrix ships `elite` only and that map is fine. This is pre-existing, not a v1.4.x regression; found while verifying v1.4.1 on a second board.

## Deliberately not included

A CI leg for `waveshare`, and a plain-language "W5500 did not respond — check PD_ETH_BOARD matches your hardware" log before the abort. Both are worth doing (the first stops the option bit-rotting; the second gives an operator without a serial cable something to go on) but neither is this fix, and a CI leg would not have caught this — only hardware can. Noted on #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Sd9eFx53kc4sTkVYf9XbK